### PR TITLE
Add accountability metrics with SHAPASH

### DIFF
--- a/xai/Accountability/XGBoost.ipynb
+++ b/xai/Accountability/XGBoost.ipynb
@@ -1,0 +1,3202 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Import binary data - Taken from binarized dataset\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xgboost as xgb\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.metrics import mean_squared_error\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.model_selection import train_test_split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The shape of the full dataset: (382, 22)\n",
+      "Features: ['session_time', '%tcp_protocol', '%udp_protocol', 'ul_data_volume', 'max_ul_volume', 'min_ul_volume', 'avg_ul_volume', 'std_ul_volume', '%ul_volume', 'dl_data_volume', 'max_dl_volume', 'min_dl_volume', 'avg_dl_volume', 'std_dl_volume', '%dl_volume', 'nb_uplink_packet', 'nb_downlink_packet', 'ul_packet', 'dl_packet', 'kB/s', 'nb_packet/s']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load the dataset from csv files\n",
+    "full_dataset = pd.read_csv(\"../../output_full_web_or_not.csv\", header=0, usecols=[*range(1,23)], sep=\";\") \n",
+    "full_dataset.dropna(axis = 0, inplace = True)\n",
+    "print(\"The shape of the full dataset: \" + str(full_dataset.shape))\n",
+    "\n",
+    "full_dataset.head()\n",
+    "\n",
+    "# Set of features in the dataset\n",
+    "features = list(full_dataset.columns)\n",
+    "print(\"Features: \" + str(features[:-1]))\n",
+    "\n",
+    "activity_df = full_dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "activity_df = activity_df.sample(frac=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shape of the training dataset: (267, 21), (267, 1)\n",
+      "Shape of the testing dataset: (115, 21), (115, 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "y_df = activity_df['output'].to_frame()\n",
+    "X_df = activity_df[activity_df.columns.difference(['output'])]\n",
+    "\n",
+    "X_train, X_test, y_train_orig, y_test_orig = train_test_split(X_df, y_df, stratify=y_df, train_size=0.7, random_state=9)\n",
+    "\n",
+    "print(\"Shape of the training dataset: \" + str(X_train.shape) + \", \" + str(y_train_orig.shape))\n",
+    "print(\"Shape of the testing dataset: \" + str(X_test.shape) + \", \" + str(y_test_orig.shape))\n",
+    "\n",
+    "# print(X_train.index.tolist())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y_train_orig['output'].mask(activity_df['output'] == 1, 0, inplace=True)\n",
+    "y_train_orig['output'].mask(activity_df['output'] == 2, 1, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "output\n",
+       "0         212\n",
+       "1          55\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y_train_orig.value_counts()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "XGBClassifier(base_score=None, booster=None, callbacks=None,\n",
+      "              colsample_bylevel=None, colsample_bynode=None,\n",
+      "              colsample_bytree=None, early_stopping_rounds=None,\n",
+      "              enable_categorical=False, eval_metric=None, feature_types=None,\n",
+      "              gamma=None, gpu_id=None, grow_policy=None, importance_type=None,\n",
+      "              interaction_constraints=None, learning_rate=None, max_bin=None,\n",
+      "              max_cat_threshold=None, max_cat_to_onehot=None,\n",
+      "              max_delta_step=None, max_depth=None, max_leaves=None,\n",
+      "              min_child_weight=None, missing=nan, monotone_constraints=None,\n",
+      "              n_estimators=100, n_jobs=None, num_parallel_tree=None,\n",
+      "              predictor=None, random_state=None, ...)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "XGBClassifier(base_score=None, booster=None, callbacks=None,\n",
+       "              colsample_bylevel=None, colsample_bynode=None,\n",
+       "              colsample_bytree=None, early_stopping_rounds=None,\n",
+       "              enable_categorical=False, eval_metric=None, feature_types=None,\n",
+       "              gamma=None, gpu_id=None, grow_policy=None, importance_type=None,\n",
+       "              interaction_constraints=None, learning_rate=None, max_bin=None,\n",
+       "              max_cat_threshold=None, max_cat_to_onehot=None,\n",
+       "              max_delta_step=None, max_depth=None, max_leaves=None,\n",
+       "              min_child_weight=None, missing=nan, monotone_constraints=None,\n",
+       "              n_estimators=100, n_jobs=None, num_parallel_tree=None,\n",
+       "              predictor=None, random_state=None, ...)"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from xgboost import XGBClassifier\n",
+    "\n",
+    "clf = XGBClassifier()\n",
+    "print(clf)\n",
+    "XGBClassifier(base_score=0.5, booster='gbtree', colsample_bylevel=1,\n",
+    "       colsample_bynode=1, colsample_bytree=1, gamma=0, learning_rate=0.1,\n",
+    "       max_delta_step=0, max_depth=3, min_child_weight=1, missing=None,\n",
+    "       n_estimators=100, n_jobs=1, nthread=None,\n",
+    "       objective='multi:softprob', random_state=0, reg_alpha=0,\n",
+    "       reg_lambda=1, scale_pos_weight=1, seed=None, silent=None,\n",
+    "       subsample=1, verbosity=1) \n",
+    "clf.fit(X_train, y_train_orig)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Shapash"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from shapash import SmartExplainer\n",
+    "# features = list(features)\n",
+    "features_dict = dict(zip(features, features))\n",
+    "xpl = SmartExplainer(\n",
+    "    model=clf,\n",
+    "    #preprocessing=encoder, # Optional: compile step can use inverse_transform method\n",
+    "    features_dict=features_dict # optional parameter, specifies label for features name \n",
+    ")\n",
+    "xpl.compile(x=X_test,\n",
+    "            y_target=y_test_orig # Optional: allows to display True Values vs Predicted Values\n",
+    "           )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "customdata": [
+          "%udp_protocol",
+          "%ul_volume",
+          "nb_packet/s",
+          "min_ul_volume",
+          "dl_data_volume",
+          "max_dl_volume",
+          "ul_data_volume",
+          "dl_packet",
+          "std_ul_volume",
+          "%dl_volume",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "session_time",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ],
+         "hovertemplate": "Feature: %{customdata}<br />Contribution: %{x:.4f}<extra></extra>",
+         "marker": {
+          "color": [
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)"
+          ],
+          "line": {
+           "color": "rgba(52, 55, 54, 0.8)",
+           "width": 0.5
+          }
+         },
+         "name": "Global",
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          0,
+          0,
+          0,
+          0,
+          0.002099999925121665,
+          0.002300000051036477,
+          0.004100000020116568,
+          0.00419999985024333,
+          0.005900000222027302,
+          0.008700000122189522,
+          0.009399999864399433,
+          0.009999999776482582,
+          0.01209999993443489,
+          0.01640000008046627,
+          0.035999998450279236,
+          0.05829999968409538,
+          0.10239999741315842,
+          0.11050000041723251,
+          0.1500999927520752,
+          0.4677000045776367
+         ],
+         "y": [
+          "%udp_protocol",
+          "%ul_volume",
+          "nb_packet/s",
+          "min_ul_volume",
+          "dl_data_volume",
+          "max_dl_volume",
+          "ul_data_volume",
+          "dl_packet",
+          "std_ul_volume",
+          "%dl_volume",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "session_time",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ]
+        }
+       ],
+       "layout": {
+        "autosize": false,
+        "barmode": "group",
+        "height": 500,
+        "hovermode": "closest",
+        "margin": {
+         "b": 50,
+         "l": 160,
+         "r": 0,
+         "t": 95
+        },
+        "template": {
+         "data": {
+          "scatter": [
+           {
+            "type": "scatter"
+           }
+          ]
+         }
+        },
+        "title": {
+         "font": {
+          "color": "rgb(50, 50, 50)",
+          "family": "Arial",
+          "size": 24
+         },
+         "text": "Features Importance<br><sup>Response: <b>1</b> - Total number of features: 21</sup>",
+         "x": 0.5,
+         "xanchor": "center",
+         "y": 0.9,
+         "yanchor": "middle"
+        },
+        "width": 900,
+        "xaxis": {
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Contribution"
+         }
+        },
+        "yaxis": {
+         "automargin": true,
+         "dtick": 1,
+         "tickmode": "array",
+         "ticktext": [
+          "%udp_protocol",
+          "%ul_volume",
+          "nb_packet/s",
+          "min_ul_volume",
+          "dl_data_volume",
+          "max_dl_volume",
+          "ul_data_volume",
+          "dl_packet",
+          "std_ul_volume",
+          "%dl_volume",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "session_time",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ],
+         "tickvals": [
+          "%udp_protocol",
+          "%ul_volume",
+          "nb_packet/s",
+          "min_ul_volume",
+          "dl_data_volume",
+          "max_dl_volume",
+          "ul_data_volume",
+          "dl_packet",
+          "std_ul_volume",
+          "%dl_volume",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "session_time",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ],
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          }
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "xpl.plot.features_importance()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "customdata": [
+          [
+           99.51632406287789,
+           242
+          ],
+          [
+           99.02912621359224,
+           313
+          ],
+          [
+           89.33333333333333,
+           131
+          ],
+          [
+           8.447937131630649,
+           355
+          ],
+          [
+           99.61315280464216,
+           231
+          ],
+          [
+           8.703535811423391,
+           350
+          ],
+          [
+           2.3529411764705883,
+           144
+          ],
+          [
+           100,
+           33
+          ],
+          [
+           99.78145488604432,
+           74
+          ],
+          [
+           98.76543209876544,
+           274
+          ],
+          [
+           99.80704293294744,
+           42
+          ],
+          [
+           83.6734693877551,
+           16
+          ],
+          [
+           3.716216216216216,
+           161
+          ],
+          [
+           0.081799591002045,
+           202
+          ],
+          [
+           100,
+           358
+          ],
+          [
+           2.6548672566371683,
+           140
+          ],
+          [
+           4.183266932270916,
+           152
+          ],
+          [
+           100,
+           195
+          ],
+          [
+           94.11764705882354,
+           383
+          ],
+          [
+           99.9213217938631,
+           68
+          ],
+          [
+           0,
+           212
+          ],
+          [
+           0,
+           343
+          ],
+          [
+           100,
+           130
+          ],
+          [
+           99.8570918185066,
+           43
+          ],
+          [
+           100,
+           107
+          ],
+          [
+           99.91773609740046,
+           290
+          ],
+          [
+           4.158004158004158,
+           142
+          ],
+          [
+           7.522123893805309,
+           179
+          ],
+          [
+           96.81274900398408,
+           26
+          ],
+          [
+           100,
+           21
+          ],
+          [
+           1.702127659574468,
+           147
+          ],
+          [
+           0,
+           364
+          ],
+          [
+           99.53051643192488,
+           379
+          ],
+          [
+           0.1661129568106312,
+           204
+          ],
+          [
+           100,
+           194
+          ],
+          [
+           91.48936170212764,
+           100
+          ],
+          [
+           0,
+           207
+          ],
+          [
+           2.380952380952381,
+           351
+          ],
+          [
+           100,
+           62
+          ],
+          [
+           94.91525423728814,
+           236
+          ],
+          [
+           0,
+           363
+          ],
+          [
+           100,
+           98
+          ],
+          [
+           91.83673469387756,
+           120
+          ],
+          [
+           0,
+           362
+          ],
+          [
+           99.65095986038396,
+           230
+          ],
+          [
+           99.74059662775616,
+           85
+          ],
+          [
+           100,
+           9
+          ],
+          [
+           100,
+           114
+          ],
+          [
+           89.28571428571429,
+           254
+          ],
+          [
+           99.85414235705952,
+           31
+          ],
+          [
+           99.85742291926572,
+           63
+          ],
+          [
+           2.25140712945591,
+           149
+          ],
+          [
+           50,
+           176
+          ],
+          [
+           100,
+           318
+          ],
+          [
+           99.92877492877491,
+           44
+          ],
+          [
+           99.6474217717056,
+           59
+          ],
+          [
+           98.64864864864865,
+           263
+          ],
+          [
+           91.83673469387756,
+           109
+          ],
+          [
+           96.03960396039604,
+           261
+          ],
+          [
+           97.4025974025974,
+           377
+          ],
+          [
+           99.8931623931624,
+           64
+          ],
+          [
+           88.73239436619718,
+           134
+          ],
+          [
+           100,
+           296
+          ],
+          [
+           3.7383177570093458,
+           342
+          ],
+          [
+           100,
+           105
+          ],
+          [
+           95.34883720930232,
+           235
+          ],
+          [
+           100,
+           90
+          ],
+          [
+           98.24561403508773,
+           371
+          ],
+          [
+           99.92816091954025,
+           297
+          ],
+          [
+           36.11111111111112,
+           180
+          ],
+          [
+           97.91666666666669,
+           382
+          ],
+          [
+           100,
+           101
+          ],
+          [
+           98,
+           265
+          ],
+          [
+           99.92344204562856,
+           10
+          ],
+          [
+           100,
+           117
+          ],
+          [
+           4.143126177024482,
+           143
+          ],
+          [
+           99.86033519553072,
+           22
+          ],
+          [
+           100,
+           34
+          ],
+          [
+           96.07843137254902,
+           264
+          ],
+          [
+           1.8867924528301887,
+           141
+          ],
+          [
+           99.88665344290168,
+           80
+          ],
+          [
+           94.87179487179488,
+           122
+          ],
+          [
+           100,
+           214
+          ],
+          [
+           88.73239436619718,
+           136
+          ],
+          [
+           99.50149551345962,
+           96
+          ],
+          [
+           100,
+           196
+          ],
+          [
+           6.25,
+           199
+          ],
+          [
+           100,
+           320
+          ],
+          [
+           100,
+           56
+          ],
+          [
+           1.6597510373443984,
+           157
+          ],
+          [
+           100,
+           28
+          ],
+          [
+           100,
+           278
+          ],
+          [
+           100,
+           76
+          ],
+          [
+           3.839732888146912,
+           166
+          ],
+          [
+           100,
+           67
+          ],
+          [
+           99.67637540453076,
+           284
+          ],
+          [
+           99.08256880733946,
+           241
+          ],
+          [
+           100,
+           93
+          ],
+          [
+           99.05660377358492,
+           238
+          ],
+          [
+           99.54389965792474,
+           243
+          ],
+          [
+           99.5475113122172,
+           244
+          ],
+          [
+           23.07692307692308,
+           175
+          ],
+          [
+           100,
+           323
+          ],
+          [
+           100,
+           388
+          ],
+          [
+           100,
+           172
+          ],
+          [
+           98.91304347826087,
+           252
+          ],
+          [
+           95.1219512195122,
+           338
+          ],
+          [
+           99.95455922447744,
+           58
+          ],
+          [
+           99.67105263157896,
+           227
+          ],
+          [
+           92.45283018867924,
+           118
+          ],
+          [
+           0,
+           215
+          ],
+          [
+           99.8928418345478,
+           77
+          ],
+          [
+           88.57142857142857,
+           133
+          ],
+          [
+           99.87351378699722,
+           70
+          ],
+          [
+           99.89163415691374,
+           300
+          ]
+         ],
+         "hovertemplate": "<b>%{hovertext}</b><br />%tcp_protocol: %{customdata[0]}<br />Contribution: %{y:.4f}<extra></extra>",
+         "hovertext": [
+          "Id: 242",
+          "Id: 313",
+          "Id: 131",
+          "Id: 355",
+          "Id: 231",
+          "Id: 350",
+          "Id: 144",
+          "Id: 33",
+          "Id: 74",
+          "Id: 274",
+          "Id: 42",
+          "Id: 16",
+          "Id: 161",
+          "Id: 202",
+          "Id: 358",
+          "Id: 140",
+          "Id: 152",
+          "Id: 195",
+          "Id: 383",
+          "Id: 68",
+          "Id: 212",
+          "Id: 343",
+          "Id: 130",
+          "Id: 43",
+          "Id: 107",
+          "Id: 290",
+          "Id: 142",
+          "Id: 179",
+          "Id: 26",
+          "Id: 21",
+          "Id: 147",
+          "Id: 364",
+          "Id: 379",
+          "Id: 204",
+          "Id: 194",
+          "Id: 100",
+          "Id: 207",
+          "Id: 351",
+          "Id: 62",
+          "Id: 236",
+          "Id: 363",
+          "Id: 98",
+          "Id: 120",
+          "Id: 362",
+          "Id: 230",
+          "Id: 85",
+          "Id: 9",
+          "Id: 114",
+          "Id: 254",
+          "Id: 31",
+          "Id: 63",
+          "Id: 149",
+          "Id: 176",
+          "Id: 318",
+          "Id: 44",
+          "Id: 59",
+          "Id: 263",
+          "Id: 109",
+          "Id: 261",
+          "Id: 377",
+          "Id: 64",
+          "Id: 134",
+          "Id: 296",
+          "Id: 342",
+          "Id: 105",
+          "Id: 235",
+          "Id: 90",
+          "Id: 371",
+          "Id: 297",
+          "Id: 180",
+          "Id: 382",
+          "Id: 101",
+          "Id: 265",
+          "Id: 10",
+          "Id: 117",
+          "Id: 143",
+          "Id: 22",
+          "Id: 34",
+          "Id: 264",
+          "Id: 141",
+          "Id: 80",
+          "Id: 122",
+          "Id: 214",
+          "Id: 136",
+          "Id: 96",
+          "Id: 196",
+          "Id: 199",
+          "Id: 320",
+          "Id: 56",
+          "Id: 157",
+          "Id: 28",
+          "Id: 278",
+          "Id: 76",
+          "Id: 166",
+          "Id: 67",
+          "Id: 284",
+          "Id: 241",
+          "Id: 93",
+          "Id: 238",
+          "Id: 243",
+          "Id: 244",
+          "Id: 175",
+          "Id: 323",
+          "Id: 388",
+          "Id: 172",
+          "Id: 252",
+          "Id: 338",
+          "Id: 58",
+          "Id: 227",
+          "Id: 118",
+          "Id: 215",
+          "Id: 77",
+          "Id: 133",
+          "Id: 70",
+          "Id: 300"
+         ],
+         "marker": {
+          "color": [
+           0.0021895263344049454,
+           0.0034651667810976505,
+           0.0016730647766962647,
+           0.9797163009643555,
+           0.002265399554744363,
+           0.026883680373430252,
+           0.9984196424484253,
+           0.0011842286912724376,
+           0.0010028749238699675,
+           0.0010564548429101706,
+           0.0019510578131303191,
+           0.05553162842988968,
+           0.9984196424484253,
+           0.9863905906677246,
+           0.010802431963384151,
+           0.9984196424484253,
+           0.9957106113433838,
+           0.0016415086574852467,
+           0.0016730647766962647,
+           0.0010028749238699675,
+           0.11587906628847122,
+           0.9962781071662903,
+           0.010802431963384151,
+           0.002126419683918357,
+           0.001390567165799439,
+           0.0010028749238699675,
+           0.9984196424484253,
+           0.05453267693519592,
+           0.0016730647766962647,
+           0.0009200843051075935,
+           0.9957106113433838,
+           0.07756003737449646,
+           0.0010564548429101706,
+           0.9904086589813232,
+           0.010802431963384151,
+           0.0014780127676203847,
+           0.7817392945289612,
+           0.09823524951934814,
+           0.0009692452731542289,
+           0.0016730647766962647,
+           0.9945626854896545,
+           0.0010564548429101706,
+           0.0016730647766962647,
+           0.995658278465271,
+           0.0032898257486522198,
+           0.0016726816538721323,
+           0.0010028749238699675,
+           0.0014780127676203847,
+           0.0010564548429101706,
+           0.0010028749238699675,
+           0.001303223893046379,
+           0.9984196424484253,
+           0.621636152267456,
+           0.0016730647766962647,
+           0.0010028749238699675,
+           0.0013599387602880597,
+           0.0016730647766962647,
+           0.0016730647766962647,
+           0.0016730647766962647,
+           0.0010564548429101706,
+           0.0010028749238699675,
+           0.0016730647766962647,
+           0.0010028749238699675,
+           0.997509241104126,
+           0.0014780127676203847,
+           0.0016730647766962647,
+           0.0010028749238699675,
+           0.0016730647766962647,
+           0.0010028749238699675,
+           0.045907098799943924,
+           0.0010564548429101706,
+           0.0016730647766962647,
+           0.0010564548429101706,
+           0.0010028749238699675,
+           0.0016730647766962647,
+           0.9984196424484253,
+           0.002126419683918357,
+           0.0010028749238699675,
+           0.0016730647766962647,
+           0.9984196424484253,
+           0.0010028749238699675,
+           0.010802431963384151,
+           0.9880971908569336,
+           0.0016730647766962647,
+           0.0010564548429101706,
+           0.0009692452731542289,
+           0.79497891664505,
+           0.0012758109951391816,
+           0.0010028749238699675,
+           0.9984196424484253,
+           0.0009200843051075935,
+           0.039338402450084686,
+           0.0010564548429101706,
+           0.056393928825855255,
+           0.0009200843051075935,
+           0.0010028749238699675,
+           0.0010564548429101706,
+           0.0010564548429101706,
+           0.0010564548429101706,
+           0.002880945336073637,
+           0.0030804937705397606,
+           0.9960013031959534,
+           0.0010564548429101706,
+           0.0010564548429101706,
+           0.9248340129852295,
+           0.0016730647766962647,
+           0.001390567165799439,
+           0.0010028749238699675,
+           0.002735086716711521,
+           0.0016730647766962647,
+           0.9960013031959534,
+           0.0010028749238699675,
+           0.0016730647766962647,
+           0.0010028749238699675,
+           0.0010028749238699675
+          ],
+          "coloraxis": "coloraxis",
+          "line": {
+           "color": "white",
+           "width": 0.8
+          },
+          "opacity": 0.8,
+          "size": 10
+         },
+         "mode": "markers",
+         "type": "scatter",
+         "x": [
+          99.51632406287789,
+          99.02912621359224,
+          89.33333333333333,
+          8.447937131630649,
+          99.61315280464216,
+          8.703535811423391,
+          2.3529411764705883,
+          100,
+          99.78145488604432,
+          98.76543209876544,
+          99.80704293294744,
+          83.6734693877551,
+          3.716216216216216,
+          0.081799591002045,
+          100,
+          2.6548672566371683,
+          4.183266932270916,
+          100,
+          94.11764705882354,
+          99.9213217938631,
+          0,
+          0,
+          100,
+          99.8570918185066,
+          100,
+          99.91773609740046,
+          4.158004158004158,
+          7.522123893805309,
+          96.81274900398408,
+          100,
+          1.702127659574468,
+          0,
+          99.53051643192488,
+          0.1661129568106312,
+          100,
+          91.48936170212764,
+          0,
+          2.380952380952381,
+          100,
+          94.91525423728814,
+          0,
+          100,
+          91.83673469387756,
+          0,
+          99.65095986038396,
+          99.74059662775616,
+          100,
+          100,
+          89.28571428571429,
+          99.85414235705952,
+          99.85742291926572,
+          2.25140712945591,
+          50,
+          100,
+          99.92877492877491,
+          99.6474217717056,
+          98.64864864864865,
+          91.83673469387756,
+          96.03960396039604,
+          97.4025974025974,
+          99.8931623931624,
+          88.73239436619718,
+          100,
+          3.7383177570093458,
+          100,
+          95.34883720930232,
+          100,
+          98.24561403508773,
+          99.92816091954025,
+          36.11111111111112,
+          97.91666666666669,
+          100,
+          98,
+          99.92344204562856,
+          100,
+          4.143126177024482,
+          99.86033519553072,
+          100,
+          96.07843137254902,
+          1.8867924528301887,
+          99.88665344290168,
+          94.87179487179488,
+          100,
+          88.73239436619718,
+          99.50149551345962,
+          100,
+          6.25,
+          100,
+          100,
+          1.6597510373443984,
+          100,
+          100,
+          100,
+          3.839732888146912,
+          100,
+          99.67637540453076,
+          99.08256880733946,
+          100,
+          99.05660377358492,
+          99.54389965792474,
+          99.5475113122172,
+          23.07692307692308,
+          100,
+          100,
+          100,
+          98.91304347826087,
+          95.1219512195122,
+          99.95455922447744,
+          99.67105263157896,
+          92.45283018867924,
+          0,
+          99.8928418345478,
+          88.57142857142857,
+          99.87351378699722,
+          99.89163415691374
+         ],
+         "y": [
+          -0.8257743120193481,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          1.0546702146530151,
+          -0.7718438506126404,
+          0.8486988544464111,
+          1.1701298952102661,
+          -0.6253857612609863,
+          -0.7718438506126404,
+          -0.8257743120193481,
+          -0.7591173648834229,
+          0.5863081216812134,
+          1.222296953201294,
+          1.2033441066741943,
+          -0.8130477666854858,
+          1.1701298952102661,
+          0.8940833210945129,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          -0.7591173648834229,
+          1.6415586471557617,
+          1.0771112442016602,
+          -0.8257743120193481,
+          -0.7591173648834229,
+          -0.8257743120193481,
+          -0.7591173648834229,
+          0.9068684577941895,
+          0.8755057454109192,
+          -0.8130477666854858,
+          -0.7718438506126404,
+          1.1701298952102661,
+          1.7194303274154663,
+          -0.8257743120193481,
+          1.0542405843734741,
+          -0.8130477666854858,
+          -0.8257743120193481,
+          1.0542405843734741,
+          1.5850471258163452,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          0.9609784483909607,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          1.0388500690460205,
+          -0.7718438506126404,
+          -0.7591173648834229,
+          -0.7718438506126404,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          -0.7591173648834229,
+          -0.7591173648834229,
+          1.1701298952102661,
+          1.0082461833953857,
+          -0.8257743120193481,
+          -0.7591173648834229,
+          -0.7591173648834229,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          -0.7718438506126404,
+          -0.8257743120193481,
+          -0.7718438506126404,
+          1.222296953201294,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          -0.7845404148101807,
+          -0.8257743120193481,
+          -0.7591173648834229,
+          0.9303745627403259,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          -0.7591173648834229,
+          -0.8257743120193481,
+          0.9068684577941895,
+          -0.7591173648834229,
+          -0.7845404148101807,
+          -0.8257743120193481,
+          1.2401206493377686,
+          -0.7591173648834229,
+          -0.8257743120193481,
+          -0.6030230522155762,
+          -0.8257743120193481,
+          -0.8130477666854858,
+          -0.8257743120193481,
+          1.153432011604309,
+          -0.8257743120193481,
+          -0.7718438506126404,
+          1.2083910703659058,
+          -0.7718438506126404,
+          -0.7214797735214233,
+          -0.8257743120193481,
+          0.9302908182144165,
+          -0.7845404148101807,
+          -0.7845404148101807,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          0.7628033757209778,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          -0.6030230522155762,
+          -0.8257743120193481,
+          -0.8257743120193481,
+          -0.7591173648834229,
+          -0.7718438506126404,
+          -0.8257743120193481,
+          1.0388500690460205,
+          -0.7718438506126404,
+          -0.8257743120193481,
+          -0.7591173648834229,
+          -0.7591173648834229
+         ]
+        }
+       ],
+       "layout": {
+        "coloraxis": {
+         "colorbar": {
+          "title": {
+           "text": "Predicted Proba"
+          }
+         },
+         "colorscale": [
+          [
+           0,
+           "rgb(52, 55, 54)"
+          ],
+          [
+           0.0000829981508126932,
+           "rgb(74, 99, 138)"
+          ],
+          [
+           0.0000829981508126932,
+           "rgb(116, 153, 214)"
+          ],
+          [
+           0.00013671237915774967,
+           "rgb(162, 188, 213)"
+          ],
+          [
+           0.0005593270272232338,
+           "rgb(212, 234, 242)"
+          ],
+          [
+           0.0007548679750698047,
+           "rgb(235, 216, 134)"
+          ],
+          [
+           0.0011038784401944904,
+           "rgb(255, 204, 83)"
+          ],
+          [
+           0.00990711983539214,
+           "rgb(244, 192, 0)"
+          ],
+          [
+           0.6543729178483172,
+           "rgb(255, 166, 17)"
+          ],
+          [
+           0.9974590304599056,
+           "rgb(255, 123, 38)"
+          ],
+          [
+           1,
+           "rgb(255, 77, 7)"
+          ]
+         ]
+        },
+        "height": 600,
+        "hovermode": "closest",
+        "template": {
+         "data": {
+          "scatter": [
+           {
+            "type": "scatter"
+           }
+          ]
+         }
+        },
+        "title": {
+         "font": {
+          "color": "rgb(50, 50, 50)",
+          "family": "Arial",
+          "size": 24
+         },
+         "text": "<b>%tcp_protocol</b> - Feature Contribution<br><sup>Response: <b>1</b></sup>",
+         "x": 0.5,
+         "xanchor": "center",
+         "y": 0.9,
+         "yanchor": "middle"
+        },
+        "width": 900,
+        "xaxis": {
+         "automargin": true,
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "%tcp_protocol"
+         }
+        },
+        "yaxis": {
+         "automargin": true,
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Contribution"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "xpl.plot.contribution_plot(\"%tcp_protocol\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [],
+       "layout": {
+        "barmode": "group",
+        "height": 550,
+        "hovermode": "closest",
+        "margin": {
+         "b": 70,
+         "l": 150,
+         "r": 20,
+         "t": 80
+        },
+        "template": {
+         "data": {
+          "scatter": [
+           {
+            "type": "scatter"
+           }
+          ]
+         }
+        },
+        "title": {
+         "font": {
+          "color": "rgb(50, 50, 50)",
+          "family": "Arial",
+          "size": 24
+         },
+         "text": "Local Explanation - <b>No Matching Entry</b>",
+         "x": 0.5,
+         "xanchor": "center",
+         "y": 0.9,
+         "yanchor": "middle"
+        },
+        "width": 900,
+        "xaxis": {
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Contribution"
+         }
+        },
+        "yaxis": {
+         "automargin": true,
+         "dtick": 1,
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          }
+         },
+         "type": "category"
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "xpl.plot.local_plot(index=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(100, 21)"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X_train[:100].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 5556.11it/s]\n",
+      " 40%|████      | 4/10 [00:02<00:04,  1.40it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from shapash.explainer.consistency import Consistency\n",
+    "cns = Consistency()\n",
+    "\n",
+    "cns.compile(x=X_train[:100], # Dataset for which we need explanations\n",
+    "            model=clf, # Model to explain\n",
+    "            #preprocessing=encoder, # Optional\n",
+    "            )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmMAAAJfCAYAAAAzcNGrAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8o6BhiAAAACXBIWXMAAA9hAAAPYQGoP6dpAAC7l0lEQVR4nOzddVwU2/sH8M/SgpSACgpYiHhFdHFXFBS7sLu7FRu7sOMa17p2d3ddFVBAQOxOGimlpOP8/uC382XdpWNQn/frdV9XZmZnnjk7M/vMOWfOCBhjDIQQQgghhBcKfAdACCGEEPIno2SMEEIIIYRHlIwRQgghhPCIkjFCCCGEEB5RMkYIIYQQwiNKxgghhBBCeETJGCGEEEIIjygZI4QQQgjhESVjhOQiPT2d7xAIIcWAzmVSlinxHQCR9fr1a9y9excvXrxAQEAA4uPjoaioCG1tbdSuXRtisRgdO3aErq4u36HywtraGgBgaGiIq1evlsg24uLisG3bNtSvXx+dO3cukW2Q4hMSEoKDBw/C29sbUVFRAAAdHR0MHz4cffv25Tk6/vj6+mLcuHEAgM6dO8PZ2ZnniEpfXufy2LFj8fjxYwDAlStXYGRkVNohEkLJWFny/PlzbN68GS9evJCZl5aWhuTkZISHh+PBgwfYtm0bRowYgREjRkBJib7G4vTo0SPMnz8f379/R7169fgOh+QhKCgIQ4cORVxcnNT08PBwqKmp8RQVKQvoXCa/CvoVLyN27tyJvXv3QvKqUEVFRTRs2BDm5ubQ0dFBeno6AgIC4OXlhZiYGKSkpGDnzp14/vw51q9fj3LlyvG8B7+PJ0+e4Pv373yHQfJpz549XCKmo6OD9u3bQ19fH/Hx8RAKhTxHR/hE5zL5VVAyVgZs3rwZR44c4f7u3r07JkyYAH19fZll09LScOTIEezcuRMZGRl4+PAhFi9ejPXr15dmyLySNCkQAgAfPnzg/v3333+jYcOGPEZDfjW7d+/mOwRCqAM/3+7cucMlYgKBAEuWLMGiRYvkJmIAoKysjJEjR2LZsmXctHv37uHmzZulEi8hZU1iYiL377/++ovHSAghpHAoGeNRSkoK/v77b+7v4cOHo2vXrvn6bIcOHdCpUyfu7507d3JNnIT8STIzM7l/q6io8BgJIYQUjoDRLzhvzp8/j5UrVwLI6uty7dq1AnU4DggIQM+ePQEApqam2Lp1K6pUqSJ32S9fvuDcuXN4/Pgxvn79itTUVOjo6MDc3BwtWrSAg4MDlJWV5X42NDQUXbp0AQBMnjwZI0aMQFBQEM6cOQNPT0+Eh4dDIBDA0NAQzZo1Q//+/XOs2ZPw9PTEzZs38fz5c0RGRgIAdHV1YW5uDjs7Ozg4OEBVVVXuZ/PzNGVh1r9kyZJcn85csmSJ3GQ5LCwM58+fx8OHDxESEoLExESubFu1agUHB4ccH7IoibIFsjq1nz9/Ht7e3ggKCkJqaiq0tbVhYWGB9u3bo3379lBUVOSW37JlCw4dOgQgf0/dJSUloV27dty+3rx5M8fjJzcZGRm4d+8e/vvvP7x+/RrR0dFQUlKCgYEBrK2t0aVLF1haWsp8bteuXXk2L+X0feXHy5cvceXKFfj6+iIqKgrp6enQ19dHgwYN0KlTJ9jY2Mj93Lp163Dq1CkAgLq6Os6cOYPKlSvLXTb7Pujp6eHUqVPcE9KSJ/wkx/iPHz9w/Phx3LlzB6GhoWCMwcTEBHZ2dujfvz/09PTkbiO/T1MyxuDm5oYHDx7g5cuXiIqKwo8fP6Curg5dXV1YWlqibdu2aNasmdzPl9Rx7OPjA1dXVzx79gyRkZGIi4uDqqoqdHR0YGFhgZYtW6Jt27ZSxzJQsHM5v09TJiQk4NKlS3B3d8enT58QGxsLDQ0NVKlSBTY2NujVq1eO33X27ZiamuL8+fNIS0vDhQsX8N9//8Hf3x8/fvyArq4uGjZsiO7du0MkEuVaNqGhobh48SK8vLwQEBCA5ORkaGlpwcjICGKxGN26dUPVqlVz/Hznzp3x9etXLjbJcUL4QX3GeJS9abF9+/YFfvLL1NQUO3bsgJmZGSpUqCB3meTkZGzatAnnzp2TqTmLiIhAREQEHjx4gP3792PNmjWoW7duntu9evUqVq9ejeTkZKnpnz59wqdPn3D69GmsW7dO7g9WUlIS5s+fj/v378vMCwsLQ1hYGNzc3LBnzx5s3LgRFhYWecZTmuv/2ZEjR/Dvv/8iJSVFanpkZCQiIyPh7u6OQ4cOYf369ahZs2ae6ytK2QJZtUTbt2/HkSNHkJGRITXv27dvcHd3h7u7O06dOoWNGzdyP+IODg5cMubi4oL58+fnmAwDwP3797nmwfbt2xcqEfv06RMWLlyIjx8/Sk1PSUlBQkIC/P39ce7cObRv3x6LFi0qlYdUUlJSsHLlSly7dk1mXkhICEJCQnDt2jXY2tpi5cqV0NTUlFrG0dERDx8+RGBgIBITE7Fu3Tps3LhRZl1v377Fvn37uL8XL16c41A1QUFBcHR0RFBQkNT0Dx8+4MOHDzh16hTWr1+Pxo0bF2aX4efnhzlz5uDz588y8+Lj4xEfH4/AwEBcu3YNTZs2xdq1a6Gurp7rOot6HEdGRmLu3Ll49uyZzLz09HQkJCQgJCQEd+7cwdGjR/HPP//kmJAWh3v37mHFihWIjY2Vmh4bG4vY2Fi8efMGR48exdixYzFixIg81xcSEoIZM2bg06dPUtPDw8Nx8+ZN3Lx5E7169cK8efMgEAhkPn/x4kWsWbMGaWlpUtO/f/+O79+/49WrVzh06BDGjBmDMWPGFGKPSWmjZIwnycnJUheavO6CcpLbBTg9PR1OTk7w9PTkpv31119o1KgR1NXVERgYCDc3N/z48QMhISEYPXo0tm3blusTaJ6ennj27BkyMzNRs2ZNNGnSBFpaWggICMDdu3eRnJyMhIQEzJ49G5cuXZL5gVm/fj2XKGloaKBZs2YwNTWFQCBASEgI7t27h4SEBERERGDSpEm4ePEitLS08l0eRVl/+/btUbNmTXh5ecHb2xsA0K5dOy5h+7k/UvbaJACwsrJCw4YNoaGhga9fv+L+/fuIiopCQEAARowYgX379sHMzKzEyhYAli9fjsuXL3N/16pVCzY2NtDQ0IC/vz/u3buHtLQ0vHr1ChMnTsThw4ehqqqKmjVrok6dOnj37h0SEhLg4eGBVq1a5RjrjRs3uH9nby7Pr0+fPmH06NGIj48HAKipqaFZs2aoWbMm0tLS8Pz5c/j6+gIAbt26heDgYOzevZu7YbGxseGSswMHDnBPU06dOpXbRkH7j6WlpWHixInceamkpARbW1uYm5tDIBDAz88PDx48QFJSEjw8PDB69GgcOHBAKjEpV64cli5ditGjRyMzMxNubm64d++eVFmmpKRg8eLFXLLct29f2NnZyY0pJSUF06dPR1BQEFRUVNCyZUvUqFED379/x7179xAZGYmEhARMnToVmzZtQpMmTQq0zxERERg1ahSXZOjr68POzg6GhoZQUFBAWFgYPD09uRoUT09PbN26FXPmzMlxnUU9jpOSkjB69GgEBwcDALS0tGBnZwdjY2MoKysjKioK3t7e8PPzA5CV2C5btgz//PMPt46Cnsu5uX79OhYvXszdzOrp6cHe3h6GhoaIiYnBw4cP8eXLF6SmpmLbtm2IiIjItXySkpLg6OiIgIAAaGpqokWLFjA2NkZcXBzc3Ny4pPvcuXMwNzdHr169pD7/5MkTrFixgotHKBSifv36KF++PKKiovDo0SN8/vwZGRkZ2LlzJypXrszVWpIyjBFevHnzhgmFQu6/79+/F/s2duzYwa3fzs6O3bt3T2aZ79+/M0dHR265tm3bsujoaKllQkJCpGIViUTswoULMusKDAxkHTt25Jbbt2+f1PyvX7+yRo0acdsJDg6WG0+fPn1yXAdjjJvn4OBQIuvfuXMnN//SpUsy8xljzNXVlVumZcuWzMvLS2aZ5ORktnbtWm65Hj16sNTUVKlliqtsGWPsv//+k1rPuXPnZJbx9/dn7du355bbu3cvN+/YsWPcdCcnJ7n7zRhj0dHRTCwWc/tUUKmpqaxLly7ctoYPH87CwsJklvP19WWtWrXillu2bJnc9Tk4OHDLFMWGDRu49QwYMIAFBQXJLBMREcFGjRrFLbdkyRK569q8eTO3TPv27Vl8fLzc7fTs2ZMlJSXJfH7MmDFSx0WXLl3Yly9fpJZJTExkTk5OUsukpKRILfPo0SNu/uLFi2W2s2jRIm7+1KlTWXJysswyaWlpbN26dVLXkp+XK87j+N9//+XmDxkyhMXGxsoswxhjhw4dktqmvGMoP+dy9rIOCQmRmvflyxfuWBcKhWzFihUsMTFRapnMzEx24sQJJhKJuOWuXbuW63aEQiGbPn06i4uLk1omLS1N6jvp3r27zHomTJjAzT9z5ozM/MzMTLZly5Zc10HKHurAz5Pw8HDu30pKSsU+mn50dDSOHz/O/b1ixQq0bNlSZjldXV1s2LABderUAZDVlJX9c/IMHz4c3bt3l5lubGyM8ePHc3/7+PhIzX/z5g3X2bpdu3Zy+7fp6upi1qxZ3N9v377NNZbSXL8EYwzbt28HkPUE7IYNG+TWUKqqqmL27NlcbUVAQIBUjZI8hS1bAFK1dI6Ojlx/wuxMTU2xfPly7u9z585x/+7YsSPX98bd3R0JCQlyY/zvv/+4V8sUplbs8uXLCAkJAQAYGRlh69atqFSpksxy1tbW2Lx5MxfT5cuXERAQUODt5UdERATX10tPTw87duyQ29/GwMAAmzZt4roFXLt2Tab5EAAmTJiAGjVqAMhqctuxYwcA4OnTpzhx4gSArPN+5cqVeXZPUFNTw/bt21G9enWp6eXKlcOqVatgbm4OIKvp6+LFi/ne56SkJNy5cwdA1rG6ePFiuU3TSkpKmDZtGtckm5iYmOf3UJTjOHtfr0WLFuVYMz506FCujIHCnct52bNnD3est2rVCgsWLJBpLhcIBOjfvz8cHR25af/++2+ur18yNjbG6tWrZZq5lZSUMHfuXK62NTAwEGFhYVLLvHr1CgCgqamJ3r17y6xbIBBg8uTJXP+1yMhI7q0UpOyiZIwn2R/H19HRKfb1P3jwgNuGtbU17O3tc1xWWVlZqnnn0qVLua67T58+Oc7L3tz67ds3qXnZO9m+efMmx4uVtbU1Tp48CXd39wKNn1bS65d48eIF17/G2to6z3GtRo8ezf1bXl+k7ApbtuHh4Xjz5g2ArOOpf//+ua5HJBKhcePGaN68OZKSkgBkJapNmzYFkNU85uLiIvfzkoRSIBCgY8eOue6PPNn7So4ZMwbly5fPcVlLS0u0b98eQFZ/uCtXrhR4e/lx9epV7njp3bt3ruekpqYmV76ZmZlyE2wVFRU4Oztzx+SZM2fw7NkzODs7czcMEyZM4G6CctO3b18YGxvLnaekpCTVJ+jevXt5rk8iPT0ds2bNwvDhwzF27Ngc+50CWdeIatWqcX//+PEj13UX9jhOS0vD2LFjMXr0aAwbNizXZn0AUvPziqmgkpOTuXNAIBBIXSPlGTRoEAwNDQFkda5/9OhRjst27do1xz6Z6urqUn1Zc7qOJiYmyvQ5kxAIBNi5cydu3boFd3f3fD0sQfhFyRhPsicOP3fCLA7ZLwS59f2REIvF0NbWBgBERUUhMDBQ7nKVKlWCgYFBjuvJ/iP2c6d2S0tLrqP38+fPMXLkSFy5ckXuxcbMzKzAHbZLev0S2Qedzc8DAHXr1uXievnyZY5JYlHKVtIvBsjqR5hXh/qdO3dix44dmDt3rlQ5ZH93361bt2Q+Fxoayr2uq0GDBjk+vZuT5ORkvHz5EkDWD4a82tqftW3blvv3kydPCrS9/Crod2plZcX9W14ncyDrex8+fDiArKRt4sSJXC2atbU1hg4dmq/Y2rVrl+t8W1tb7mndJ0+eyHSaz4mmpiZ69uwJR0dHLs6chIaGSt1A5lbrU5TjWFlZGV27dsWECRMwZcqUXGP69u0bYmJi8hVTYbx48QKpqakAAHNz81yfTAQABQUFqWttbsdqXq9myt5SIolBQtKnNyMjA2PGjMHu3bvx7t07mQe0jI2NKQn7hVAHfp5kr56Oi4tDRkaGzOPZRSFpBgLANWPkpXbt2lwSFxwcDBMTE5ll8jq5s/+w/3xxqFChAoYNG4a9e/cCyHoh+uvXryEQCFC7dm3Y2NjA1tYWVlZWhXrfZkmvX0LScRjIepoy+9sT8pKSkoLo6Gi5P1ZFKdvszd75eWozJ82bN4eWlhbi4uLg7e2N6OhoqR+GmzdvctsuTBNlZGQkd/NhZGQk00wjT+3atbl/Szp1F7fs3+m0adMK9Nmfm5GyGzNmDB48eIAPHz5wiUf58uXh7OwMBYW874WVlJTyrB1SUVFB1apV4e/vj4yMDERGRuZYk5aXiIgIBAYGIjg4GEFBQfDz88O7d++kji9A9vjLrijHsTzfv39HQEAAgoODERwcDD8/P7x//17mWMjPugqiMNfQ7Mtl//zP8iqj7E3X2cfRA4Dx48fD29sbSUlJiIuLw65du7Br1y5UqFABNjY2aNKkCWxtbbmba/JroGSMJ9kvlowxfP/+Pde7yYLK/gh2fp9GzH7y/vzSZYmCDL8h7+I4fvx4lCtXDrt37+Z+nBhjeP/+Pd6/f49Dhw5BR0cH7dq1w7Bhw3Idt0eekl4/AJnH2wsqPj5e7nddlLLN/v69/CQ4OVFRUUHbtm1x7tw5ZGRk4M6dO1JNTpImOclyBZW9JiO/Pxb5OS6LqijfaW4xKSsrw8nJSaopsUePHlxzVl60tLTydeOQ/Rz//v17gZKx79+/49ChQ7h582aufYsUFRVlhkuRp6jXCCBrTK/jx4/jypUruSY1+Y2pMIp6Dc3tmCpKGZmZmeHff/+Fs7Oz1E3E9+/fcf36dVy/fh2KiooQi8UYMGAAbG1t870twh9KxnhSpUoVrgYCyGrqKMyP28uXL5GWlibVRAdIn8DyxqmRJ/sdWH7u2gtDIBBg+PDh6NGjB+7cuQM3Nzf4+vpKNVfExMTg9OnTuHz5MtavX8/1YyoL6wcgdfHv0qWLVCfi/CjuhzUAFOsPkoODA9ex/+bNm1wy9v79e3z58gUA0KxZsyIlfUDZOi6zl9+ECRMKNJJ/buOxAdIPSQBZgz3369cvXwlZfmtws8dfkDHfnj17hhkzZsgkDioqKjA2NoaZmRksLS1hY2ODVatWlcp7Yf38/ODo6MgNpyGhqKiIqlWrolatWqhXrx7EYjFOnDiR6+CuRVFWr6FAVpeM06dPw9vbG/fu3YOHh4dU7aXkvcUPHz5E9+7dsXDhwnzvA+EHJWM8UVBQgEgkwt27dwEAXl5ehUrGdu3ahYcPH0JNTQ2jR4/mBhzMfoeWvTYiN9mXy61TdXHQ1tZGr1690KtXL6SmpuLFixfw8fGBu7s73r9/DyCrf9H8+fNx9erVAsdTkuvPfpdcv359uU8tlrbs8Re1I7OVlRWMjY0RFBSE58+fIyIiAhUrVpTqQ+bg4FCodWcvu7J0XGppaXF9C9u2bQtTU9NiWW/298YKBAIwxpCQkIBly5Zhx44def5A5ve7zF47l99+QjExMXBycuISMXNzc/Tv3x/169eHsbGxTLeJ/PZFK4q0tDQ4OTlxiVjVqlUxaNAgNGzYENWqVZNJNEsypqJeQ4t6s5IXBQUFNGnShHta28/PD48ePYKXlxe8vLy4G9CLFy9CKBQW+pwlpYM68POoQ4cO3L9dXFy4p9ry6+vXr9yj4cnJyVI/INmbKT58+JDnuhhjUiOh59VZtTipqKigUaNGmDhxIo4fP449e/ZAQ0MDQFaT3oMHD8rU+rN3Wpc8Zp6X/F7MCyv79+Xv75/n8leuXMGKFStw4MABucMUSPqDMca48pEMpqutrV3g2kSJypUrcz+ooaGh3KCvuZEkz0DJHZfZv9PXr1/nuXxaWlqOQ39IREdHY/Xq1dzfy5Yt47bj4+ODM2fO5LmdxMREmf5aP0tKSuKa8tTV1XN9KjK7ixcvcs3bderUwcGDB9G1a1dUq1ZNbv/V6Oho7t/F3T9LwsXFhWt6q1SpEo4cOYK+ffvCzMxMbo1fScaU/VjLzzUUkD5WC/pwS1FVr14dffv2xcaNG3Hjxg2pp1bzeoqb8I+SMR41b96cO+FjY2OlXo+SH//++y/XPCF555tEgwYNuH9Lat9y4+3tzf0w6urqFroDcG4OHDiA0aNHo3Xr1nj+/HmOywmFQm44AyCrU3Fprj+v2orsbyhwdXXNM4l+//49WrduDTs7OwwZMqTYn/oCpJ/u8/b2zrPZ8vr167hw4QK2bdsm1d9MonPnzlw5uLm5ISQkhPuRLOzrj4CsJj3JK7cYYzkOn5Fd9uM3+34Wp+zDk2QfeiMnZ86cQfPmzdGqVSusWrVK7jJr1qzhyrZ169bo1KkT5s2bx83fsmVLvh5I8PDwyHX+gwcPuOax7E9W5kXyVCuQ9X3n1jQbGhqK0NBQ7u+fO5UXl+wxtWnTJte+WsnJyVI3Q/KSsaI0zVlaWnJl+f79e7njyWWXmZkpdTyXxLH6/PlzTJ8+Hd26dcvxuAOybpgmTpzI/Z3fayjhDyVjPFJSUpJ6fPvQoUO4fv16vj57+vRpqbud8ePHS/1AtmnThntq6cmTJ3Bzc8txXWlpadi2bRv3d/v27Uukf8G3b9/w9OlTxMTE5Dn4afYEIb8PNhTX+rP39ZD3oyMSibhBSmNjY7Fnz55ctyUp26SkJBgZGRXpSc6c1KxZk3uSKyoqKtex4vz8/Li+P3p6enIfszcyMuISFF9fX9y+fZubV5inKLPLPnzGnj17cm2Ke/36Nf777z/u7+xJdHHKnnx6eHjkmgDFxcXh4MGDALK+/1q1asksc/v2bW5A1fLly8PJyQkA0KRJE65GPCkpCc7OznnW6Bw5ciTH5ri0tDTu6WEg72Ewfv6sRF41tz+/X7MkbigA6WEc8oppx44dUn1B5cWU17mcm3LlyqF169YAshK9rVu35rr8iRMnuFpMXV1diMXiAm0vP9TU1HD//n0EBwfD1dU119rZ7Ne4ihUrFnsspHhRMsaz1q1bcyNVZ2ZmYtGiRVi1ahUiIyPlLh8TE4M1a9Zg7dq13LR27dpJ/cABWX1gBg4cyP29cOFCuLq6yqwvNjYWTk5O3OjVenp6GDVqVBH3Sr5u3bpx/z579iwuXbok94fo7t27XJNYuXLl8t0kVlzrlzRhApCqDZBQVlaWGsj10KFD2L17t8yPQUpKCtavX8+9G1RRUVHqc8Ut+7r//vtvuQOAfv36FXPmzOFqzgYPHpxjLZekj0lKSgoOHDgAIGsEf0tLyyLF6eDgwNUIh4aGwtHRUW5T3NOnTzFt2jQu1q5du+ZrkNTCqFGjhlQiM2/ePLk3MFFRUZg5cybXv6xy5cpSxx2QdVOwZs0a7u+pU6dKJfyzZs3i+iM9efKEG5E/J4GBgZg9e7ZMk258fDycnJykBiDOz7htEtmHzDh79qzcmp+YmBjMnTtXpgazpPpqZR/G5M6dO1I1ZRJJSUlYt24djh07lmdMeZ3LeRk5ciRXY3j37l2sXLlSpiacMYazZ89KvRtz2rRpBXoIJL/Mzc25m65v375h4cKFcpv6v337JhVPfsaaJPyiDvxlwPz585GcnMw1j5w7d47rdFm3bl1oamoiMTERHz58wKNHj6TuBlu0aAFnZ2e56x07diz3wuXExETMnDkT9erVk3lRuORkVlFRwfLly/Pd56SgzMzM0KtXL5w7dw6MMSxbtgwnT56ElZUVKlasiKSkJLx48YJ7QTSQVeOX3zcUFNf6s/f1OHr0KNLS0lC+fHkIhUKutqhnz554+vQpV5O5a9cuXL16Fc2aNUOFChUQHh6O+/fvSyXVjo6OeY4ZVRStWrVC7969cfbsWaSkpMDJyQlWVlawtrZGuXLl4Ofnh3v37nE/WkKhUCph/1mbNm2wbt06pKSkcHfgRa0VA7KaKtetW4cxY8YgISEBL168QM+ePdG8eXPUqFED6enpePHiBR49esQl02ZmZpg9e3aRt52b+fPn4+PHj/jy5QsSEhIwY8YM7nxRVVVFQEAAXFxcuPNPVVUVK1eulHmacuXKlVyn+IYNG6JHjx5S83V1dTFt2jTuvN22bRtsbW1zfGhASUkJHh4e6N69O1q3bo3KlSsjLCwMd+/e5WqPKlSogAULFhSoRrtnz544ceIEUlJSEBMTg759+6JVq1YwNTVFamoq/P394eHhwdVWKSkpcTccRR3eJSft2rXDzp078f37d6SkpGDUqFHccSEQCBAUFCT1qq68YsrPuZybWrVqYfbs2Vi5ciUYYzh//jzc3NzQokULVK5cGXFxcfD09OQSYiDrpvDnm+Pi5OTkhHHjxiEjIwP3799Hly5d0Lx5c67WPTAwUKrWrG7duujatavMejp37sw9KDF27FiMGzeuxGImeaNkrAxQVFTEypUrYW1tjZ07d+Lbt2/IyMjAo0ePcnylhoaGBsaPH4/+/fvn+Ai1kpIStm7dijVr1uDy5ctgjOHVq1dyO52bmJhgzZo1+R7csLCcnJyQkpLCPY7+4cMHuZ1jVVRUMGbMGAwePLjU1y8Wi1G1alUEBwcjJSUFhw8fBgD0799f6gLu7OyMypUr4/Dhw0hPT0dISAhOnjwpsz5VVVVMmTIl11cUFZe5c+dCW1sbBw8eREZGBp4/fy63/5y9vT2WLVuWa5Np+fLl0aJFC+4pysK+/kgec3Nz7N+/H3PnzoWfnx+Sk5OlmkKz69y5s8ybAkpC+fLlsX//fixevJirOc3pfKlUqRKWL18u1TcTyOooLalRU1FRyTFB6tq1K65du8YNu7J06VLs27dP7rm8dOlSrF+/HjExMTLDZABZTdSbN2+GkZFRgfa3SpUqWLFiBRYuXIiUlBSkpqbK7S8nEAjQo0cPWFhYYOXKlQBK5j2QQNYTiH///TemT5+O2NhYZGRkwMXFRW7fwpYtW8LBwYF716y8mPJ7LuemR48eKF++PFavXo3Y2Fh8+/ZN7vegrKwMR0dHDBo0qCC7XGANGzbE6tWr4ezsjISEBMTHx+fYQV8sFmPVqlUlUktHihclY2VIz5490bFjR7i5ucHDwwMfPnxAREQEEhISoKysDF1dXZibm8PGxgYdO3bM12P+KioqWLx4Mfr164dLly7B19cX4eHhSEpKgo6ODurUqYM2bdqgY8eOhe6UXRDKyspwdnZG9+7dcfXqVbx8+RJhYWFITk6GlpYWDA0N0bRpU3Tp0qVQT84Vx/rV1NSwZ88ebNu2Dd7e3oiNjYWWlpbMa6sUFBQwadIkdOvWDRcuXICPjw9CQkLw48cPqKurw8TEBDY2NgUa5LOoBAIBJk6ciE6dOuH8+fPw9vbm9r9ChQqwtLREt27d8j0QZKdOnbhkrDCvP8pNrVq1cOrUKdy6dQsuLi54/fo1YmJiwBiDoaEhrK2t0bVr1yI3ixaEpqYmNm3axNV6PnnyBJGRkUhJSYGWlhbMzMxgb2+PLl26cC9zloiMjJR61+nIkSNlXu6d3YIFC9C/f3+kpKTgxYsXOHr0qNxXJFlZWeHMmTM4cuQIXF1dER4eDlVVVZibm6Njx45wcHAo9LnbqlUrnDp1CsePH4ePjw++fv2KjIwMaGhooGrVqqhXrx66desGc3NzREZGQkFBAZmZmXB1dYWTk1OJJMhWVlY4deoUTpw4AU9PT4SEhCAlJQUaGhowNDSEhYUFHBwcIBQKkZqaCk1NTcTHx+Px48cIDw+Xeul8fs/lvLRt2xY2Nja4cOECPDw84Ofnh9jYWKiqqsLExARNmjRBz549S+08b926NaysrHDp0iV4eXnBz88P8fHxUFFRgb6+PurXr4+2bdvCzs6uVOIhRSdgJfWMMiHkl3f58mWuOW3hwoUyTW6kZIwdO5Z7yOLKlSsFrvUihPxaqAM/ISRHkj5xampqhRqUmBBCSN4oGSOEyOXn58c97NCmTZsSfysDIYT8qSgZI4QAyBrtXdJrwc/PD3PmzOH+Lo2HDwgh5E9FHfgJIQCy+odt27YNKioqUsMEtG3bFhYWFjxGRgghvzdKxgghAMCNxZZ9UEsTExPMmTOHx6gIIeT3R82UhBAAWeNV1apVCyoqKjAwMEDPnj2xb98+6Orq8h0aIYT81mhoC0IIIYQQHlHNGCGEEEIIjygZI4QQQgjhESVjhBBCCCE8omSMEEIIIYRHlIwRQgghhPCIkjFCCCGEEB5RMkYIIYQQwiNKxgghhBBCeETJGCGEEEIIjygZI4QQQgjhUYGTMWtra1hbW+Py5ct5Lnv58mVu+d+ZZB+9vb1LdDu7du2CtbU1Ro4cKTW9c+fOsLa2xoULF0p0+6R0LVmyBNbW1li4cCHfoRRaUlISQkNDpaZJrgsdO3bkKaqSkZaWhh07dqBLly6wsbFBmzZtsGvXLr7DKjWhoaHctTAoKIibntv3HRUVhYULF6Jt27awsbFBhw4d4OnpCQC4evUqBgwYgKZNm8Le3h6TJ08utX0pLenp6QgICOA7jCKJjY1FVFSU1LScfqv4UtzXnMTEROzfvx+DBg1Cs2bN0KRJE3Tt2hXLli3D58+fC7VOqhkjhJSIGzduoGfPniV+k1JWbNq0Cfv27UNoaCiMjIxQsWJFGBoa8h1WmZWZmQlHR0fcuHEDsbGxqFGjBjQ1NWFoaIi7d+9iyZIl+PDhAzQ1NWFiYoIqVarwHXKxevjwIfr27Ytr167xHUqhHT9+HN27dy90AvIrioiIwODBg7F9+3a8e/cOmpqaMDY2RlhYGC5duoRBgwYV6jtVKoFY/zhnz54FAFSuXLlEt9O3b1+0a9cOampqJbodQorD9u3bERERITO9ZcuWsLS0hJLS73X5+e+//wAAw4cPh6OjI8/RlB05fd8BAQH48OEDAGDz5s1o2rQpN09So9igQQPs2rXrtztWAODAgQO/fK3Yhg0b+A6h1M2bNw8BAQEwMDDAqlWrIBQKAQDR0dFYvnw53Nzc4OzsjBo1asDCwiLf66WasWJQvXp1VK9eHeXKlSvR7ejq6qJ69ep0t01+aZqamqhevTqMjY35DqVYxcTEAMBv3y2joHL6viXlBQCNGjWSO69Bgwa/ZSJGfk1PnjzBs2fPAGR1I5EkYkDW7/OaNWtQs2ZNZGRk4MiRIwVaNyVjhBBSDDIzMwEAKioqPEfya8jIyOD+/XOZUVmSssjDwwMAUKVKFTRp0kRmvoqKCtq1awcAePfuXYHWzestR0REBI4fPw53d3eEhoZCQUEBxsbGaNmyJQYMGABNTU0AAGMMnTp1QkREBFasWCHTCe/69etYtGgRAODUqVOoVauW1PyNGzfi2LFj6NevH2bPnp1nXH5+fjh8+DBevXqF0NBQKCoqomrVqrC1tcWAAQNQoUIFqeUld8I7duxA48aNAWR1GHR2dkbHjh0xd+5c7N+/H3fu3EFkZCR0dXVhb2+PSZMmoXz58vjw4QP27t2Lx48fIyEhAVWqVEHPnj0xcOBACAQCbju7du3C7t27YWVlhf379+erjN+/f48zZ87g6dOniIyMREpKCrS0tGBhYYGuXbuiTZs2UstL4m7Xrh369euHtWvXws/PD9ra2hg6dCgGDRqU5zYjIyNx+vRpeHt7IygoCAkJCdDQ0EC1atXQqlUr9OnTR6qpNTQ0FF26dIGenh6OHTuG5cuXw9fXF6qqqmjSpAlWrVrFLfvkyROcPHkSz549Q2xsLLS0tGBpaYn+/ftDLBbnq0x+5urqivPnz+PNmzeIj4+Hrq4uhEIhhgwZIlXNzBjDhAkT8OjRI+jp6eHMmTPQ1taWWteSJUtw9epVGBgY4MSJE9DV1eW+twEDBmDYsGHYunUrHj58iISEBBgZGaFdu3ZSx3t+FKWMb926hUuXLuH8+fPw8/MDANSsWRM9e/ZEly5dpI45iYIcR5L9lVixYgVWrFiBsWPHYty4cdwxVrFiRdy4cUNmWz4+Pjhz5gyeP3+O2NhYlC9fHnXr1kWPHj3QqlUrmeU7d+6Mr1+/4uzZs/j+/TsOHTqEV69eISkpCUZGRmjbti2GDh0KdXV1qc9lZGTg/Pnz+O+//xAQEIDY2Fhoa2ujXr166NatG5o3b56v70KyfYlx48YByLou7N69myuPYcOGwdLSElu3bkVoaCj09fXh6OiI9u3bAwCSk5Nx7tw53L59G35+fkhLS4OBgQFsbGwwePBgmJiYSG3X19cX48aNg5WVFXbt2oUjR47g2rVrCA0NhaamJmxsbODo6AgDAwOEhoZi165dePjwIeLi4lCxYkV06NABo0ePLnDC8+7dOxw+fBjPnj1DTEwMqlatit69e0s1M2b38/ctORazk1xDO3fujKtXr3LTd+/ezR1Ljx8/5qb/+PEDJ06cgIuLC4KCgpCZmYkqVaqgVatWGDRokMy5lN/rWkZGBq5fv46rV6/iw4cPSEpKgoGBARo3boyhQ4fKfAeFOa8ksUjs27cP+/btQ+fOnaWmy1OS3/m3b99w9OhRPHjwgPvdq1atGtq1a4e+fftCVVWVW1ZynZOYOHEiN71r165S642OjsaBAwfg5uaG8PBwaGlpoUGDBhg+fDjq1q0rdz8DAgJw7NgxeHt7Izw8HCoqKqhevTratWuHXr165dhV5969ezh9+jQ+fPiAtLQ0WFhYYMSIEbmW6cuXL3H8+HG8f/8eYWFhUFFRgampKVq0aIG+fftCQ0ODW7ZHjx6wtLTMtauQZJ6ysnKu2/0Zb8mYj48PnJyc8OPHDygpKaFmzZpIT0/Hp0+f8OHDB1y8eBH//PMPzMzMIBAI0KxZM5w7dw4PHz6UScaydxB+9OiRTDL24MEDAIC9vX2ecb148QITJ05EUlISNDU1YWpqitTUVHz69Anv37/H1atXceDAgXz3D4uOjsaQIUMQGBiIatWqoXLlyggMDMTp06fx7t07DB8+HHPmzIGCggJMTU0RFRUFf39/bNy4Ed+/fy9S35MzZ85g3bp1yMzMhJaWFqpWrYqUlBSEhobCw8MDHh4eGDlyJCZNmiTzWX9/fzg6OkJBQQE1atSAv78/atSokec2X758CUdHR8THx0NVVRVVq1aFoaEhQkJC8OLFC7x48QJubm7YtWsXFBUVpT6bmpqKSZMmISAgADVr1kRYWBiMjIy4+Vu2bMGhQ4cAAFpaWjAzM0NERATc3Nzg5uaGYcOGYcqUKfkun/T0dCxdupRLCCpUqIDatWsjJCQEt27dwp07dzBz5kz069cPACAQCODs7Iz+/fvj27dvWL9+PVasWMGt7/bt27h69SoUFBSwbNky6OrqSm0vIiICQ4YMQWRkJExMTKCnp4fPnz9j165duH37NrZv345KlSqVaBkzxrBkyRJcu3aN6xgdEhKCly9f4uXLl/D395cpw4IeR5UrV4aVlRXevn2L1NRUGBsbo0KFCvk6Z9atW4dTp04BALS1tWFubo6IiAh4enrC09MTbdu2xfLly+Ve6C5cuIDjx49DRUUFJiYmiIuLg7+/P/bs2QMfHx/s2bOHKw/GGObNm4e7d+8CAIyNjVGxYkV8/foVrq6ucHV1xejRozFhwoQ8Y65bty4qVqyI58+fA8j6AS5fvrzMdejJkyc4evQotLS0UL16dXz58gXm5uYAgPDwcEycOBH+/v4AAFNTU6irq+PLly84d+4crl69iqVLl3J33dmlpKRg3LhxeP78OapUqYKqVasiICAA165dw7Nnz7B06VJMmzYNKSkpMDU1hZKSEkJCQrBv3z4EBwdL3ezk5fr163B2dkZ6ejq0tLRQs2ZNhIaGYu3atflunlVRUYGVlRV+/PjBdfy2srLi9tvKygqfPn1CQkICKlWqJHPc+Pn5YcqUKVzCUKVKFaipqeHz58/Ys2cPrl69iq1bt6J69eoy287tupaYmIhZs2ZxvycVK1ZElSpVEBgYiAsXLuD69etYsWKF3BuCgpxXenp6cvfR1NQ0n99C8X/nz549w4wZMxAbGwslJSWYmpqCMYa3b9/izZs3uH79OrZu3Qp9fX2p7+nnY15PT09qvVFRURg0aBDCw8NRtWpVmJiYICAgAHfv3oWbmxu2bt0qcxN9/fp1LF++HKmpqVBVVUWtWrWQmJiIV69e4dWrV7h8+TK2bNkic61cs2YNzpw5AwCoVKkSjIyM8OrVK0yePDnHY/PevXuYO3cuMjIyoKOjgxo1aiAhIQGvX7/Gq1evcOPGDRw4cIBLyKpWrYqqVavm+L2kpqbiypUrAArRXYEVkFAoZEKhkF26dCnPZS9dusQtn11oaCizs7NjQqGQTZ8+nUVFRXHzgoKC2PDhw5lQKGSdOnVicXFxjDHG3N3dmVAoZO3atZPZTvv27bntTJ8+XWpeQEAAEwqFzN7enqWmpuYZ89ChQ5lQKGTr1q1jKSkpUnF1796dCYVCtnLlSrll4uXlJXff27Vrx169eiV3XqNGjdj8+fNZfHw8Y4yxtLQ05uzszIRCIWvSpAlLSkriPrdz504mFArZiBEjpLbv4ODAhEIhO3/+vNR+i8ViJhQK2d69e6X2PSYmhs2ZM4cJhUImFotZbGys3NiGDRvGlX90dDTLzMzMtezS09NZ165dmVAoZDNmzJBab2pqKjtw4AC37vv373PzQkJCuOktW7Zknz9/5j4jKZezZ89y3+O1a9e4z2ZmZrJbt24xW1tbJhQK2YULF3KNMbstW7YwoVDIOnbsyDw8PKT248SJE0wkEjFra2v28OFDqc/dunVLZj++fv3K7O3tmVAoZNu3b5daXvK9CYVC1qJFC+bt7c3N+/LlC+vRowcTCoVs0qRJUp9bvHgxEwqFbMGCBcVaxiKRiB0/fpylp6czxhhLTk5mCxcu5OZ9//6d+1xhjyPG5B+XjP3vGOvQoYPU9MOHD3MxnDp1imVkZHDzbt++zV0z1q1bJ3c7QqGQLV26lDtmMzMz2alTp7h59+7d4z7j4eHBhEIha926Nfvw4YNU+e7bt4+LIywsjOWXZDuPHj2Smp79+585cyZ3XZGUc3p6OhswYAATCoWsR48e7P3799xn4+Pj2bJly7gyfvHiBTfv0aNH3HqbNWvG3N3duXne3t7M2tqau8ZMmDCBRUREcOWSPaaQkJB87V9QUBBr0qQJEwqFbMOGDdyxkJ6ezvbv38+tTygUssDAQO5zOX3f2eP/2ZgxY5hQKGQ7d+6Ump6YmMi6devGXesl+8QYY5GRkWzKlClMKBSy7t27S10783NdmzdvHhMKhaxPnz7s5cuX3GeTk5PZtm3buGvyx48fuXmFPa+y7+PP14vclMR3Hh4ezlq2bMmEQiFbvnw5VzaMMRYYGMj9Jo4aNUomHnm/fYxJH/OdO3eWKs/g4GDumjdkyBCpz7148YKJRCIuFsn1nzHG3r17x31u4MCBLC0tjZt37do1JhQKWePGjdn169e56XFxcWz27NlcLNmPwYyMDNauXTsmFArZoUOHuO+NMcbevHnDWrduzYRCIdu/f38u38j/pKamspkzZzKhUMiaN2/OQkND8/U5iUL3GXN2dubGlMnpv5yqXA8cOIDExETUrFkTa9eulcqmq1atin/++Qd6enoICwvj7pJFIhHU1dURFRWFjx8/cst//vwZkZGRaNCgARQUFPDkyROuvwHwv1oxOzu7fFUbStbdtWtXqarcqlWrYvr06WjWrFmBn5qcOXMm/vrrL+7vLl26wMDAAABgaGiIZcuWoXz58gAAJSUljBkzBkDW3Y/kTrmgvLy8oKioCAsLC4waNUpq37W1tTFt2jQAuY9zM3HiRK66X0dHR27zVXYfPnxAbGwsVFRUsGjRImhpaXHzlJWVMXz4cO7x9E+fPsldR58+fbg7VWVlZZQvXx5paWnc01WLFy9Gp06duOUFAgHatWuHqVOnAshqIktPT881TgD4/v07jh8/DiDriaDsTSyKioro378/Bg8eDMYYduzYIfXZdu3acTGsXr0a8fHxWLx4MeLj42FlZYWxY8fmuF1nZ2epO8Hq1atjw4YNUFBQwMOHD/Hy5ctc4y6OMu7duzcGDBjA1RKpqqpi5syZEAgEyMjIwKtXr7hli+M4yo+UlBTs27cPADB+/Hj07dsXCgr/uzy1bduWG2/tzJkzMmOXAUDt2rWxePFi7pgVCATo27cvzMzMAIC7iwfAPcVXv359bj6Q9d2PHDkSbdq0QYcOHRAXF1fofZJn2rRp3HVFUnN6584dvH//HqqqqtiyZQtq167NLV++fHksWrQITZs2RXp6usyxKDFy5EjY2tpyf4vFYlhaWgIAypUrh7Vr13LXHIFAgJEjR3LfZX77thw+fBgpKSmwtrbGjBkzuM8rKipixIgRMs1TJeHChQsICgpCnTp1sH79em6fAEBfXx9r166FoaEhAgMDuRqKn8m7rn348AG3bt2Cmpoatm3bhnr16nHLq6qqYtKkSWjbti1SUlKwd+9euestyHlVHIrrOz9y5AhiY2Nhb2+PhQsXSjXxGhsbY+PGjdDQ0MDTp0+5PlMFsWLFCqnyrFKlCvcb9+bNG6SkpHDzdu3ahYyMDNjY2GDhwoXc7yIAmJubY+vWrVBVVcW7d+9w+/Ztbp7k2jFy5EipljNNTU2sWLFCbq1jdHQ0Nz5ajx49pFoRLCwsMHHiRLRo0UKmK4o8ycnJmDlzJlxcXKCqqor169cX+EG7QidjJiYmsLKyyvW/n9vXJSQJUp8+feQmSFpaWujWrRuArP48QFbVto2NDYCs8VkkJFXKLVu2RM2aNREfH4/3799z893d3QHkr4kSAPfEz6pVq+Dj44O0tDRuXvPmzbF58+YCDWQnEAhk+lIIBALui7KxsZFpSpJUBQNAQkJCvreVXd++feHp6ZnjhSN7m3dSUpLMfAUFBdSvX79A27SwsICrqytcXFygo6MjMz81NZU7sJOTk+Wuo0GDBjLTnj9/jm/fvkFDQwMtWrSQ+7mOHTtCQUEBERER+fpxcXd3R2pqaq6PH0sSrtevX+P79+9S8+bMmQNDQ0OEh4dj+PDhePz4MTQ1NbFy5cocn/4yNjaW2w+pevXq3FM5kuM9J8VRxvJi0NHR4ZKD+Ph4bnpRj6P8evr0KeLj46GoqIi+ffvKXaZdu3aoWLEiMjIyuGtIdnZ2dnJvGKpVqwZAer8k1yZ3d3fs378fYWFhUp9Zu3Ytli1bJpWoFZWenp7cJo779+8DyPpecmoCkfRpevz4sdR+SNjZ2clMk1xjrKysZPpQKSsrc8dPfq8xkmvpz/29JHr37p2v9RSF5Pxo3769zHUTyDoeW7duDQByj5GcrmsuLi4AspqWKlasKHfbkuuBp6en1MMHEgU5r4pDcX3nkn3PaUBUPT097rdXcqzml6RJ9meS84oxhtjYWABZ1w9fX18AwMCBA+Wur0qVKmjZsiWA/x0LwcHBXKWFvGNTWVkZ3bt3l5muo6PD3cwuWLAAL168kKrI6dmzJzZs2ICePXvmuo+MMcyZMwceHh5QV1fHP//8U6j+y4XuM5afO6GfOyoCWQeBZOyh3MbgkMzLfrfdvHlz3Lt3D15eXhg6dCiArDt3IOuuICQkBB8/fsSjR49gYWGBhIQEPH36FCoqKlJ3ELmZOnUqpk2bhlevXmHChAlQV1dHw4YNYWNjAzs7uxwTzJyUL19eKruXkCShP/cryj4PyPqii0JVVRWvXr3C58+fERwcjODgYHz69Emqxk3eNjQ1NQs9npmamhoCAwPx5s0bBAcHIyQkBJ8/f8anT5+4u6Cc9it7Iioh6VeSlpaG0aNH57hdBQUFZGZmwt/fX+pOTB7JOsPDw3NMrrPH6O/vL/XgRvny5bF8+XKMHTuWK8sFCxbkejeUvXb0Z2ZmZvD19UVgYGCucUsUpYxz+rGRdNCV90NT2OMovyTrMTExkXu+AFk3MXXq1EFERITcWrjstSQ/xw5I71fz5s1hbW2Nx48fY/v27di+fTuqVauGxo0bo0mTJhCLxVIdlotDTvFJ9j0/18OMjAwEBwfLLCuvr2Fu1xgA3E1Dfr635ORkhIeHA4BMXziJ2rVrQyAQFPmalRtJbe+FCxdyvHH59u0bAMhtVcjpuia5Hrx9+zbH64HkvJL8hv18rhfmvCqK4vjOExMTuYdP9uzZgxMnTsj9nGSZgrbU5FQm2R+mkZRrcHAwV/mR17lw8+ZNLhbJtUBDQyPH62/22mYJRUVFODo6YuXKlVzfVy0tLTRq1Ij7vc9PH94LFy7A3d0dampq2LFjB1c7WVCl3oE/e0ae00UXANdhLjExEYwxrhO/oqIinj17huTkZCgqKuLJkyfQ0dGBmZkZRCIRTp8+jUePHmHo0KF4+PAh0tLSYGtrK/MkVU6aNm2KI0eO4NChQ3B3d0dCQgL3RW3YsAENGjTAggUL8tWZHUCeY49lb4opbtevX8eePXtkfuCrVKmCbt265fr6pML+EL18+RJbt26VevIJyLoLsbW1xfv37xESEpLj5+VdKH/8+AEgq9Yne1NTTvJzBypZZ0JCQqHXaWFhAQMDA4SHh0NJSSnPYyK36m7J8Zmf2Itaxnk11//8Y1qU4yi/JNeF3K4JwP+uC/JqcwqyX0pKSti+fTtOnTqFK1eucImlv78/Tp06BQ0NDQwbNgwjR47Ms3k+v3I6p/Kz79mf6JK377ldZ4oj/uzHZU7bUlZWhpqaWpFqSPMiOW8DAwPzvHGRdy7l9B1I1vv9+3eZWvDcls+uoOdVURXHd559P/Izin5Ba/cK8qRuYXIDAFxXgtwqD7J358iuZ8+eMDEx4Z7cjIuLw71793Dv3j0IBALY2dlh3rx5uSZlkldDDho0qNCJGMBDMpY9KZJ3QEtIClhdXZ07sHR0dFC/fn08ffoUT548gYqKCpKSkrjmCZFIxCVr6enpXLV6Tk1bOTE3N8eqVauQlpaGV69ewdfXF97e3nj+/DmePXuGCRMm4OLFiyU+yGtRXLlyBUuXLgWQlWBKmnGrV68OLS0tpKWlFfu7LP38/DBu3DikpKSgRo0a6Nq1K2rXro3q1atzd0gjR47MNVGQR1LOFhYWOHr0aLHEKlln69atsW7dukKtY/PmzQgPD4eCggLS09OxaNEiHDp0KMeLcm4/UpJz4edhU35WUmWck9I6jiTXhdyuCcD/rgvZk5PCUlZWxuDBgzF48GCEh4fD19cXvr6+8PDwwLdv37Bjxw6oqqpi8ODBRd5WbvKz79l/BItj3wsq+41ETs2ajDGkpqaWaBzlypXDjx8/sGnTpnwPPZIfkh/ywYMHY/r06cW23rIu+2+YvGGhSlP24/rHjx85Xgsl54LkvJEcm5LkTJ7s/dJ+1qhRIzRq1AjJyclcbvHw4UO8ffsWDx48QHh4OI4fP55jgvvlyxcABc8zflbqg76WL1+eq65/+/ZtjstJ5v08arPkBPTy8uLalyXts5qamqhTpw4SExPx8uVLeHh4QCAQ5PukzcjIQFBQEJ48eQIg62LdsGFDjBkzBnv37sXevXshEAgQFRVV5t+3d+DAAQCAg4MDtm7dip49e8LKyoq7Q5D3mpqiOnHiBFJSUlCtWjUcPnwYQ4YMQePGjaWqqiVNHQUh6XwZGBiYY+d8xhgePXqEwMBAqX5+ea0zt7vBpKQkPH78GMHBwTJNDJ6enjhz5gwUFBSwefNm6Ovr4/379/j3339zXF9u25L0c8yrdq2kyjgnpXUcSfp1BQYG5piUZGZmcuVU1NH74+Li8PLlS66vWKVKleDg4MANTyC5Zly/fr1I28kPyb7ndj188+YNgKwaj9werS8pKioqXBNQ9j652fn7+xd7U9zPJOet5AdQHknzfXR0dL7XK/kOcltvTEwMnj17hq9fv5ZoU2xp0tTU5B6gy23fP378iPfv3xf7Ay3ZVa1alWtGzc+5IOkyJPnukpKScnyISN61Ny0tDX5+ftxDU2pqamjSpAkmTZqEo0ePcsN/fPjwQeqhwZ+pqalBT09Pbh/eguBlBP5mzZoByHoqSt4PZ1xcHDeg3M99vSTZp5eXF9dMk72znGTQ1YMHD+L79++wtLSU2w9Jns+fP6N79+4YP368zFvogawnryTZePaOfmWR5GmznNreL168yP27uC6gktqYnF4N5eXlxf345eeJRwmhUIjy5csjISGBqxL+2Y0bNzB+/Hj06tVLpjO2PHZ2dlBUVIS/vz/X7/Bnx48fx9ixYzFw4ECpWq3o6GiutmjQoEGwtbXF3LlzAWQ9mSRJ5n/25s0buSf1x48fuaZSSefjnJRUGeekKMeRpAk+Pz9cDRo0gJaWFjIyMnD69Gm5y9y6dQtRUVFyH4opKGdnZwwfPpwbty47ZWVl7oGKkk4ugP/dYN6/fz/HGk3Jk7/169cv0ODAxUkyvtb58+fllktx17TLIymrixcvyn1AJT09HTNmzMCQIUOwadOmfK9X8pvk7e3NDdj6s61bt2LUqFEYN25csVz/JTUtfCd2kgcBTp06JXe/4uPjMX78eAwcOJA7DiWKcx/KlSvHvRbr5+1IBAcHcw8RSK4BRkZGqFOnDoD/vSc6u8zMTLm/Gx4eHujduzemTp0qt0ZXkksAuV8Hbt++jdu3b0uNiVkYvCRjw4YNg4aGBj5//ow5c+ZItdGHhIRg6tSp+PbtGypWrCjzVIWJiQlMTU3x+fNnvHjxAkZGRlJ3iiKRCEDBn6IEsjr51apVCxkZGZg/f75UDUNaWhq2b9+OhIQElCtXDg0bNizUvpcWyd3C+fPnpWovfvz4gV27duHgwYPctJyeuivsNr28vPD06VNuenp6Om7evIl58+YVapvlypXjRlH++++/cfnyZamLhqurK1avXg0gawiE/NSaGBoack/YzJ8/X+opoczMTFy4cIEbTqNPnz5SfRhWrlyJb9++wdTUlBsUtGXLlmjfvj0yMzOxePFiubU7jDE4OTlJ3aV9/PgRM2fOBGMMnTt3ljtQZXYlVcZ5ba8wx5EkWcxPcpz9O965cydOnz4t9R3fvXuXu1Pt2bNngQbIlMfBwQEAcO7cOVy7dk3qx+Tz5884efIkANmbwZLQpk0bmJmZISUlBY6OjtywG0BWk+CKFSu4IUb4fAH50KFDoa2tjbdv38LZ2ZlrrmSM4cyZM1yZlaS+fftCX18fQUFBmDFjhtSbD6KjozF37lz4+flBWVkZQ4YMyfd6GzZsiKZNmyIjIwNTpkyR6keampqKvXv3cjcew4YNk/skZ0FJbuyz7wMfRowYAXV1dTx79gwLFy6UqlH8+vUrpk6dipiYGJQvX17mSefi3odx48ZBUVERXl5eWLFihVST+IcPHzBlyhSkpKSgdu3a6Ny5Mzdv8uTJAICTJ0/i+PHj3LUjKSkJK1aswOvXr2W2ZWtrCx0dHcTGxmLJkiXcU51AVpOnJJmvVKlSjs23kto1Pz+/Ij8ty8sI/FWrVsXatWsxZ84cuLm5wcPDgxuB38/PD5mZmahcuTL+/vtvuU+F2Nvb4/Dhw0hPT+eSL4kGDRpAVVWVayMuaDvu6tWrMWLECDx+/Bhdu3blRncODQ3lHr1fsGBBjk+rlBUTJ07EzJkz8eXLF3Tt2pX78QoKCkJKSgqqVKkCgUCA4ODgYmvWGjx4MG7evImYmBiMHj0aJiYm0NDQQEhICOLi4qCuro769evjxYsXBW7eGjZsGIKDg3HhwgU4Ozvjn3/+QZUqVRAREYHIyEgAWY9zS16LlR8zZ85EREQEHjx4gOnTp8PAwAAVK1ZEaGgod0Fq3bo196oPIOuO3MXFBQoKCli6dKlUh2AnJyc8evQIX79+xbp167Bs2TKp7VWqVAkxMTHo168f1xz55csXMMYgEokwa9asPGMuyTKWpyjHkbm5OT59+oSDBw/C3d0drVq1yvVp2CFDhiAkJARnz57F2rVrsWvXLpnvuHXr1pg5c2aR96tVq1bo0aMHLly4gMWLF2PTpk2oXLkyfvz4geDgYDDG8Ndff2HUqFFF3lZelJSUsHHjRjg6OsLf3x8DBgyQGoE/JSUFqqqqmD9/Pq83gfr6+lizZg1mzZqFa9eu4d69e6hRowbCw8MRFRUFe3t7uLu7l2htopaWFjZt2oRp06bB29sbXbt2RfXq1aGgoICAgACkpqZCUVERq1atKvCwJMuXL8fUqVPx6tUrjBw5ElWqVIGWlhaCg4O5H9qBAweiV69exbIv5ubmuH//Pm7cuIGPHz+iYcOGXA17aTI2NsaaNWswb9483Lp1C3fv3kXNmjWRlpaGgIAAZGRkoFy5ctiyZYtMPy5zc3M8efIE69atw7lz59CnTx9uWKrCqF+/PhYvXowVK1Zwbz2oUaMGEhMTuSbIWrVq4e+//5Z6OKBJkyaYMmUKtm7dig0bNuDgwYOoXLky/P39kZCQgJYtW3JDeEgoKytj7dq1mDx5Mm7fvg03NzdUrVoVCgoKCA4ORlJSEtTU1ODs7JxjP+DIyEhuSBd5r4IqCN5eFN6kSROcOXMGgwYNQpUqVeDv74/w8HCYm5tj8uTJOHnyZI5NI9lru34ez0NFRYUbq6patWrcnX1+1ahRA8eOHUPv3r1RpUoVhIWFwc/Pjxv77MSJEzmOx1KWNG/eHIcPH0aLFi2gp6cHPz8/hIWFoVatWlz5SvZD3ng8hWFoaIiTJ0+id+/eMDU1RXh4OPz9/aGnp4d+/frh5MmTXGLj6+tboKeuBAIBFi5ciG3btqFly5ZQVFTEu3fvkJiYCEtLSzg5OWHXrl0FeqhCVVUVmzZtwurVq9G0aVOkpaXh3bt3yMjIQKNGjeDs7Iw1a9Zwd8HBwcHYsGEDAGDAgAEy4xXp6upy7z69du2a1KCEQNZrgg4fPow2bdogMjISYWFhqFu3LubPn49t27blq/mpJMtYnqIcR9OnT0fr1q1Rrlw5+Pv759j8IyEQCDBv3jxs27YNLVq0gKKiItc/qXnz5tiwYQPWrVtXbENOzJ8/H0uWLEGjRo2QmZnJDajboEEDzJkzB/v27Su1zvJGRkY4evQopk6dir/++gtRUVH48uULKleujAEDBuDkyZNSNQF8EYvFOHbsGHr27AkdHR18/PgRampqGDduHNauXVsqMdStWxenT5/GmDFjYGZmhq9fv8LPzw8VKlSAg4MDjh07JveVRXnR0dHB3r17sWDBAlhbWyM+Ph4fPnyAkpISbG1tsXHjxmK5EZAYNmwYunfvDm1tbQQGBubaL6mk2dra4vTp0xg0aBCMjY3h7++PoKAgGBkZoU+fPjh16pTc8cIWL16Mxo0bc10+ijLws0Tnzp1x4sQJ9OjRA/r6+vj8+TNiYmJgZWWFOXPm4PDhw9zA1tkNGzYMu3bt4pqyP336BFNTU6xatSrHdyo3atQIhw4dgoODA/T19REYGIigoCBUrFgR/fr1w9mzZ2UqfEqKgPHdYE3Ib64wL3gnhBDy5+CtZowQQgghhFAyRgghhBDCK0rGCCGEEEJ4RMkYIYQQQgiPqAM/IYQQQgiPqGaMEEIIIYRHlIwRQgghhPCIkjFCCCGEEB5RMkYIIYQQwiNKxgghhBBCeETJGCGEEEIIjygZI4QQQgjhESVjhBBCCCE8omSMEEIIIYRHlIwRQgghhPCIkjFCCCGEEB5RMkYIIYQQwiNKxgghhBBCeETJGCGEEEIIjygZI4QQQgjhESVjhBBCCCE8omSMEEIIIYRHlIwRQgghhPCIkjFCCCGEEB5RMkYIIYQQwiNKxgghhBBCeETJGCGEEEIIjygZI4QQQgjhESVjhBBCCCE8omSMEEIIIYRHlIwRQgghhPCIkjFCCCGEEB5RMkYIIYQQwiNKxgghhBBCeETJGCGEEEIIjygZI4QQQgjhESVjhBBCCCE8omSMEEIIIYRHlIwRQgghhPCIkjFCCCGEEB5RMkYIAIFAgBYtWkhNGz58OAQCAfz9/XmJ6Xd18OBBCAQCHDx4kO9Q/mhLly6FQCCAq6sr36Hw6ncoBzqnfn2UjJVxQ4cOhUAgQOXKlZGens53OCSf/P39IRAIMHz4cL5D+SPJS67/NHQM/j7ou/z9UTJWhsXFxeHcuXMQCAQIDw/HtWvX+A7pj7J69Wq8ffsWVapU4TsUQgjJUY8ePfD27Vv06NGD71BIIVEyVoadOHECiYmJmDlzJgQCAfbt28d3SH8UQ0ND1KlTB8rKynyHQgghOdLW1kadOnWgra3NdyikkCgZK8P27dsHFRUVzJs3D7a2trh+/Tq+fv3KzQ8ICICCggJat24t9/PJycnQ1tZGrVq1pKanpqZi48aNEAqF0NDQgKamJpo1a4bLly/LrEPSb+rLly/YtGkT/vrrL6iqqnLV5aGhoViyZAlsbGxQsWJFqKqqolq1apg4cSIiIiLkxuXv749+/fqhQoUKKF++POzt7XH//v1c+27cv38fXbp0gb6+PlRVVWFmZoaFCxciMTExn6WZZe/evahXrx7U1NRgbGyM2bNnIzk5We6yOfUZO3fuHOzt7VGxYkVuPR06dMDFixcBZPXfqF69OgDg0KFDEAgE3H+SfStouWWPZceOHbCwsICamhpMTU3h7OyMzMxMuftw+fJltG/fHnp6elBTU0O1atUwZMgQvHr1Smq5ghwTsbGxWLx4MerWrYvy5ctzPwQjRoxAUFBQbsUv48KFCxCJRFBXV0flypUxYcIEREdHy13Wz88Po0ePhomJCVRVVWFoaIjhw4cjICCAW8bV1RUCgQAA4ObmJlX2Bw8exLNnzyAQCDBt2jSpdZ85cwYCgQAaGhpITU2Vmle5cmVYWFhITWOMYf/+/bC1tYWWlhbU1dXRqFEj7N+/X27sBVk++3lw+vRpCIVClCtXDoaGhpgyZQqSkpLyLNf8HIPZFWQ7xXUuvnjxAv3794ehoSFUVFRgamoKR0dHfPv2jVsmMjIShoaG0NbWxpcvX6Q+HxERgUqVKkFHR0fqGJA0UQcFBaFfv37Q09ODhoYGWrRoAU9Pz3zHt3//fnTr1g3VqlWDmpoaKlSogPbt28PFxUVmWclxt3TpUjx58gTt27eHpqYmtLW10aNHD7n9Ti9cuIABAwagVq1aUFdXh7a2Npo1a4Zz585JLZef7zK3PmOenp5wcHBAhQoVoKamhjp16mDp0qVyvy9J2UVGRmLkyJGoWLEiypUrBxsbG7nHzdevXzF16lSYmZmhXLlyqFChAiwtLTFx4kTExcXlXcjkfxgpk168eMEAsB49ejDGGNu9ezcDwFavXi21XPPmzZmCggILDg6WWcfJkycZALZkyRJuWnJyMmvRogUDwBo2bMgcHR3Z+PHjmbGxMQPAtm7dKrWOYcOGMQCsU6dOrEKFCmzIkCFs9uzZbMOGDYwxxk6cOME0NDRY165d2ZQpU9jMmTNZq1atGABWo0YNFhMTI7W+4OBgZmhoyK1z3rx5rGfPnkxVVZV16NCBAWAuLi5Sn/n333+ZQCBgFSpUYMOGDWOzZs1i9vb2DABr2rQpS0lJyVeZLlu2jAFglSpVYpMnT2bTp09nJiYmrHPnzgwAs7e3l7vvfn5+3LQdO3YwAMzQ0JCNHTuWzZs3jw0fPpzVrVuXDRs2jDHG2NOnT9nUqVMZAGZlZcWWLFnC/SdZV0HLTRJL7969mb6+Phs+fDibMmUKMzExYQDY/PnzZfbXycmJAWAVKlRgI0eOZHPnzmWDBg1ilStXZps2beKWK8gxkZmZyRo3bswAMFtbWzZ9+nQ2c+ZM1qtXL6atrS3z3clz4MABBoA5ODgwFRUVNmjQIDZ37lzWpEkTrswSExOlPuPl5cW0tbWZkpIS69GjB3NycmJ9+vRhSkpKrGLFiuzz58+MMcb8/PzYkiVLGABmamoqVfZPnz5lmZmZrEKFCqx+/fpS6584cSIDwACw+/fvc9PfvHnDALAJEyZIlcHAgQMZAFa7dm02btw45ujoyOrUqcMAsJkzZ0qtu6DLS+Lv3bs309DQYAMHDmTTp09nFhYWDAAbOHBgnmWcn2OwMNsprnPx0qVLTFVVlamrq7P+/fszJycn5uDgwAAwMzMz9v37d27Z27dvM4FAwBo3bszS0tK4Mu3YsSMDwE6cOCG1bgCsfv36zNjYmInFYjZ37lw2ZMgQpqKiwlRUVGSOUUk5/DxdTU2NNW7cmI0aNYpbh6amJlNQUGAXL16UWtbFxYU7ptXV1VmnTp2kzumaNWuypKQkqc+Ym5szS0tLNmzYMDZ37lw2atQoZmBgwACwLVu2FOi7lJxTBw4ckNrG2bNnmZKSElNXV2cjRoxgc+bMYdbW1gwAa9KkCUtOTpYpOysrK2ZmZsasra3ZtGnT2MCBA5mioiJTUVFhL1++5JZNSEhg1atXZwKBgLVv3545OTmxqVOnsi5durBy5cpJXTdJ3igZK6MkJ9/58+cZY4zFxMQwNTU1ZmZmJrXcnj17GAC2bt06mXVIkoyPHz9y0+bPn88AsKVLl7LMzExuelxcHGvUqBFTUVFhISEh3HRJElC1alUWEBAgs43w8HAWHx8vM/3QoUMMAFuxYoXU9MGDBzMAbP369VLTJReTny+Kr1+/ZkpKSqxhw4bs27dvUp9ZvXo1A8D+/vtvme3/7OPHj0xJSYlVqVKFhYeHc9NjY2OZubl5vpMxoVDIVFRUWEREhMw2oqKiuH/7+fkxAFyC9rOClpsklurVq7PQ0FBuemRkJNPR0WGamppSP4TXrl1jAJilpaVUXIwxlpaWxsLCwri/C3JM/HyTkF1ycrLcffpZ9u/6zp07UvNGjBjBALBly5Zx01JTU1m1atWYpqYme/bsmdTyDx48YIqKiqxz585S0+V9nxI9evRgAoGARUZGctMsLCxYixYtmKKiInN2duamb9++nQFgp0+f5qZJboxGjRrFJQeMMZaSksK6dOnCADBfX99CLy9JDrS1tdm7d++46YmJiax27dpMIBBInaM5yesYLOh2iutcjIqKYlpaWnKvKcePH2cA2OTJk6Wmz5o1S+qmY/PmzTnum+TYGjJkiNTx7OrqygQCAatVqxbLyMiQKYefk7EvX77IrDs0NJQZGRnJXIclyRgAdvLkSal5Q4YMkZs0Sm4gsouPj2eWlpZMW1ubJSQkcNPz+i7lJWNxcXFMR0eHqaqqsufPn3PTs98cLF++XGo9kn2YOHGiVBnt3buXAWDjxo3jpl2+fJkBYNOnT5eJJy4uLt+JOclCyVgZlJKSwvT09Jiurq7UAd2vXz8GgLm5uXHTYmJimKqqqsydfmRkJFNWVmY2NjbctIyMDKarq8tq1aoldZGSkJxc2WtCJEnAP//8U6B9yMzMZFpaWqxFixbctOTkZKaqqsoqVaokc6JmZmZyNQXZL4pTpkxhANiDBw9ktpGRkcEMDAyYtbV1nvE4OzszAFyNXnZHjhwpUDKmoaHBoqOjc91eXhfPnMgrt+yx7N+/X+YzknkvXrzgpnXq1IkBYPfu3ct1ewU9JiTJWH5qZ3Ii+eFo27atzLyQkBCmrKzMatasyU07f/683B8OiZ49ezIFBQUWGxvLTcstGfvnn38YAHbmzBnGGGNhYWEMANu0aRMTi8VSn+vduzcDIJXA169fn2loaMjUdDD2v/LJXttV0OUlycHixYtllpfMu3z5stx9yy6/yVh+t1Nc5+LGjRsZAHbkyBG584VCIdPX15ealpKSwoRCIVNQUGBbtmxhqqqqrGbNmiwuLk7m8wCYoqIiCwwMlJknqX3Lvg85JWM5cXR0ZACYv78/N02SjDVv3lxmecm8GTNm5Gv9GzZsYACYq6srN60wydjhw4dlanUlAgMDmZKSktR5xlhW2WloaMjcVKWlpTElJSUmFAq5aZJrg7xaeVJwSiBlzsWLF/Ht2zeMHz8eKioq3PShQ4fi1KlT2L9/P5o3bw4gq+Nmly5dcPbsWbx8+RKWlpYAgJMnTyItLQ1DhgzhPv/+/XtER0fDyMgIzs7OMtuNjIwEALx7905mnlgszjHe8+fPY9euXXjy5Amio6ORkZHBzQsNDZXafkpKCho1aiS1X0BWX4UmTZrIbNvLywsAcPPmTdy5c0dm28rKynLj/dnz588BAM2aNZOZJ29aTvr27Yu5c+eiXr166N+/P1q0aAE7Ozvo6Ojkex0S+S237IRCocy0qlWrAgBiYmK4aT4+PlBVVYW9vX2uMRT0mLCwsIClpSWOHz+OoKAgdO/eHc2aNYNQKISiomLuO/wTeeVuZGSEmjVr4t27d4iPj4empiZ3DLx79w5Lly6V+UxYWBgyMzPx4cMHNGrUKM/ttmzZEgDg4uKC3r17c32AWrZsibCwMGzevBnJyclQVVWFm5sb/vrrL1SsWBEAkJiYiJcvX8LIyAhr1qyRWXdaWhoXa2GWzy6/33VR5Xc7xXUuStbj5eWFT58+ycxPTk5GVFQUoqKioK+vDwBQUVHBiRMnIBQKMWXKFCgpKeH48ePQ1NSUuw1TU1MYGxvLTG/WrBmuXbuGZ8+ewc7OLtc4v3z5gtWrV+PevXsICQlBSkqK1PzQ0FCYmppKTSvIdxYREYE1a9bgxo0bCAgIkOmjl9M1IL+ePn0KAHKHeDE2NkbNmjXx/v177jyTMDMzQ/ny5aWWV1JSQqVKlaT2oXnz5qhcuTJWr16NZ8+ewcHBAXZ2drC0tOT6bZL8o2SsDJJ06s2eSAFA+/btUblyZZw5cwZbtmyBlpYWt9zZs2dx7Ngx7oJ/9OhRKCsro1+/ftznv3//DgB4/fo1Xr9+neP2ExISZKZVqlRJ7rIbNmzArFmzYGBggHbt2qFq1aooV64cAGDz5s1SFzBJh04DAwO565K3DUnMK1euzDHe/IiNjQUA7kc1r+3mZPbs2dDT08POnTuxceNGbNiwAUpKSujUqRM2b97MdbTNS0HKLTt5T0spKWWdxtmTuZiYGFSpUgUKCrk/o1PQY0JJSQn37t3D0qVLcf78ecycORMAoK+vD0dHRyxYsCDfSZm87wLI+j7evXuHuLg4aGpqcjEeO3Ys1/XJO27lqVevHgwMDLgkzMXFBXp6eqhfvz7CwsKwdu1aeHp6wsDAAJGRkVLnUHR0NBhjCAkJkZu8/hxLQZfPLr/fdVHldzvFdS5K1rN9+/Zcl0tISOCSMSArSbC0tISXlxfEYnGuN4i5HVvA/64HOfn06RPEYjHi4uLQsmVLdOnSBVpaWlBQUICrqyvc3NzknqMFKUuRSITAwEDY2tqiTZs20NHRgaKiIp49e4ZLly7leA3IL8n1NqfrW+XKlfH+/XvuPMttHyT7kX0ftLW18fDhQyxZsgRXrlzB9evXAWQln/PmzcPEiROLFP+fhpKxMiYoKAj//fcfAMDW1jbH5U6ePImxY8cCADp27Ah9fX0cP34cq1evxufPn+Ht7Y1u3bpBT0+P+4wkeevVqxfOnj1boLjk3emkp6dj+fLlMDIywrNnz6SSLMYY1q1bJ7W8ZPuS2pafhYeHy0yTfObnC0ZBSS4wERERMnez8rabE4FAgNGjR2P06NH49u0bHjx4gBMnTuD06dP4+PEjXr58mWcyUtByKwwdHR2uxii3hKwwx4S+vj62bduGrVu34t27d7h37x62bt2KJUuWQFlZGfPmzcvXenJ62lbyfUhik/z/ypUr6Ny5c77WnRuBQAB7e3ucPXsWYWFhcHV1hb29PQQCAezs7KCsrAwXFxfuB11Sk5Y9Fmtra/j6+ua5rYIuX5YV17koWc/Lly9Rr169fH9u/fr18PLygp6eHjw9PbFnzx6MGTNG7rJ5HVt5DQGxadMmREdH4+jRoxg0aJDUvPHjx8PNzS3fccuzb98+BAYGYsWKFViwYIHUvDVr1uDSpUtFWj/wv3LO6fr283lWGNWqVcOhQ4eQkZGBly9f4vbt29iyZQsmTZoEXV1dDBgwoNDr/tPQ0BZlzIEDB5CZmQk7OzuMGjVK5j9JbVn2MceUlZXRt29fBAUFwc3NDUePHgUADB48WGrdFhYW0NLSgq+vL9c8UhRRUVGIjY2FjY2NTG2Xr6+vTLW7ubk5VFVV8fjxY5nhAxhjXPNFdo0bNwYAufMKwsrKCgDw4MEDmXnypuWHnp4eunfvjlOnTqFVq1Z4+/Yt1+wiScjk1WAUtNwKQywWIyUlJc8fjaIcEwKBABYWFpg0aRJ3AyFvKIycyCv30NBQfP78GTVr1uR+8CXHwMOHD/O9bgUFhVxrjyRNN8eOHcOHDx/QqlUrAICGhgbEYjHu3bsHFxcXLnGT0NTUhIWFBd6+fZuvpsKCLl+ccjsGC6O4zsXCfJ+PHz/GwoULYWFhgZcvX8LU1BTTpk3D+/fv5S4fEBAgd5gVyTHXoEGDXLf3+fNnAEDXrl2lpmdmZsLDwyPfcRd0/dljzK4w32XDhg0BQO6QFCEhIfj8+TNq1KhRpMQ6e3wNGjTA7NmzceLECQAFuxYQSsbKFMYYDhw4AIFAgMOHD2Pv3r0y/x0+fBgNGzaEj4+P1FhRkiTt6NGjOHbsGHR0dNClSxep9SspKWHChAkICAjArFmz5P74vnr1Kse7yp9JxqB58uSJ1Jg10dHRcHR0lFleVVUVvXv3RlhYGLZs2SI17/Dhw3j79q3MZyZOnAglJSU4OjrKvbjGxMRwfSNyM3DgQCgqKmLjxo1S+xcXF4cVK1bk+XmJW7duybyWKi0tjWt6kTQ16urqQiAQIDg4WGYdBS23wpg0aRIAYOrUqVxsEunp6dxdcUGPCT8/P7x580ZmGcn6JPufH//99x/u3r0rNW3hwoVIS0vDsGHDuGndunWDiYkJNm7ciPv378usJy0tDe7u7lLTKlSoILfsJSS1XWvXrpX6W/LvR48ewcXFBZaWllK1ywAwZcoUJCYmYsyYMXKbF/38/KTGlSro8sUlt2OwMIrrXBwxYgQ0NTWxYMECuU3jiYmJUglfQkICBg4cCIFAgOPHj8PQ0BBHjx5FSkoKBg4cKHNjB2QlLQsWLABjjJvm5uaG69evo1atWmjatGmuMUpqz38+rtauXSszRl9h5LT+48ePc8192RXmu+zWrRu0tbVx4MABqXJmjGHevHlIS0sr0uuVXr16JTW+m0RhrgWEminLlLt378Lf3x8tW7bMte/RiBEj8PTpU+zbtw+bNm0CANjY2MDMzAyHDx9GWloaxowZA1VVVZnPOjs748mTJ9iyZQuuXbsGe3t7GBgYICQkBC9fvsTz58/x8OHDHPtcZKegoICJEydiw4YNsLKyQpcuXRAXF4cbN27A1NQURkZGMp9ZvXo17ty5AycnJ7i4uKBBgwZ4//49rl69ig4dOuDmzZtSzWr16tXDjh07MGHCBJibm6NTp06oWbMm4uLi8OXLF7i5uWH48OHYuXNnrrHWqlULixcvxpIlS1C/fn307dsXSkpKOHfuHCwtLXO8w/5Zv379oK6uDjs7O5iamiItLQ3//fcf3rx5g379+sHExAQAUL58eYhEIty/fx8jRoyAmZkZFBQUMHDgQJiYmBS43AqqU6dOmDVrFv7++2+YmZmhR48eqFixIkJCQnD37l3MmjWLG/i0IMfE8+fP0aNHD4hEItSrVw+VK1dGSEgILl68CEVFRa4PWX44ODigU6dO6NOnD4yNjeHm5oaHDx/CysoKs2bN4pZTVVXF2bNn0bFjR9jb26N169Zc81ZgYCAePHgAPT09qc7jrVq1wunTp9G7d280bNgQioqKcHBw4B5wqVu3LipVqoTw8HBUqlQJdevW5T7bsmVLrFixAjExMVJJocS4cePg5eWFQ4cOwcPDA23atIGRkRHCw8Px7t07eHt74/jx46hWrVqhli8ueR2DBVVc56KBgQFOnDiBPn36wMrKCh06dECdOnWQnJyMgIAAuLm5oWnTprh58yaArGT2w4cP2LhxI1ejZWdnh/nz52P58uWYP38+/v77b6lt1K9fH66urrCxsUGrVq0QGhqKkydPQllZGXv27MmzL+X48eNx4MAB9OzZkxs41svLC0+ePIGDg0ORX003ZMgQrF27Fo6OjnBxcYGpqSlevHiBO3fuoGfPnjh//rzU8oX5LrW0tLBnzx4MGDAAjRs3Rr9+/WBgYIC7d+/C19cXYrEYTk5Ohd6HO3fuYObMmbC1tUWdOnWgp6eHL1++4PLlyyhXrhwmT55c6HX/kfh7kJP8rH///rk+8i0RFRXFVFRUmL6+vtQQEZLhG/DT8Bc/S09PZ7t27WK2trZMS0uLqaqqMhMTE9ahQwf277//sh8/fnDLyhveIbvU1FS2cuVKZmZmxq1nxowZLD4+npmamjJTU1OZz3z58oX16dOHaWtrM3V1ddasWTPm5ubGJk+ezACwp0+fynzGx8eH9e/fnxkZGTFlZWWmr6/PhEIhmzt3Lnv79m2u5ZXdnj17WN26dZmKigqrWrUqmzVrFktMTMz30BY7duxgXbt2ZaampkxNTY3p6emxxo0bs127dkmNIcUYY+/fv2edOnViOjo6TCAQSD0+X9Byy+17yO3R/HPnzrGWLVsybW1tpqqqyqpVq8aGDBnCXr16JbVcfo+JoKAgNnfuXGZjY8MqVqzIVFRUmImJCevduzfz9vbO13eQ/TH88+fPM2tra6ampsYqVqzIxo0bJzOGlURwcDCbOnUqV2ZaWlrMwsKCjR49mt29e1dq2a9fv7K+ffsyfX19pqCgIHdATMlQMf369ZOanpSUxFRVVRkAduHChRz349SpU6xNmzZMV1eXKSsrsypVqrAWLVqwDRs2SI1hVtDlc/s+cxrcMye5HYOF3U5xnYvv3r1jo0aNYqampkxFRYXp6uoyS0tLNmXKFObj48MYY+zMmTPcMCg/D72SlpbGbGxsmEAgYLdv3+amS87lgIAA1qdPH6arq8vKlSvHmjdvztzd3WXiyKkcXFxcmK2tLdPU1GQ6OjqsU6dO7PHjx3KXlwxfkX2AbYmchqV49uwZa9euHdPV1WWamprM3t6e3blzJ8eyz+27zO37un//PuvYsSPT0dFhKioqrHbt2mzRokVS1/mfy06en69Lb968YVOnTmUNGzZkenp6TFVVldWoUYMNHz6cvXnzRu46SM4EjGWrxyWER3Z2dnj48CFiY2NlHq0mhJD8kPTzk9dXipCyivqMkVKX/f2aEseOHeOacCgRI4QQ8iehPmOk1NWrVw8NGzZE3bp1uXF1XF1doampKdP3gxBCCPnd/XLJWGZmJkJDQ6GpqUmj/P6iRowYgZs3b8LX15cb2LFPnz6YPXs2TE1NucEKCSGkMDIyMug6QkoMYwzx8fEwMjLK82GQ/Prl+owFBwfLfc0FIYQQQkhpCQoK4l53VVS/XM2YZIC6Dx/eFstgdb8LdXVNJCbG8x1GmUHlIY3KQxqVhzQqD2lUHrKoTP4nPj4etWtbFGsO8sslY5KmSU1NzSK9xuF3o66uCSUlaraVoPKQRuUhjcpDGpWHNCoPWVQmsoqzqxQ9TUkIIYQQwiNKxgghhBBCeETJGCGEEEIIjygZI4QQQgjhESVjhBBCCCE8omSMEEIIIYRHlIwRQgghhPCIkjFCCCGEEB5RMkYIIYQQwiNKxgghhBBCeETJGCGEEEIIjygZI4QQQgjhESVjhBBCCCE8omSMEEIIIYRHSnwHkJeUlBSkpKRwf8fFxfEYDSGEEEJI8RIwxhjfQeRm6dKlcHZ2lpkeGxsLLS0tHiIihJCCGT58OGJiYnDx4kW+QyGEFFFcXBy0tbWLNQ8p8zVj8+bNw4wZM7i/4+LiYGxsjMTEeCgpCXiMrGxRV9dEYmI832GUGVQe0qg8pJV2eaSnpyEjI73Mfgd0fEij8pBFZfI/JVEOZT4ZU1VVhaqqKt9hEEIIIYSUCOrATwghxeTChYsQiWygp1cRxsamcHDoioSEBG7+5s1bUKOGGYyNTTF9+gykpaVx806cOAk7O3tUqmSE6tVrYfjwkYiIiOTm37//ABoaWrh58yYaN26KChUMYG/fEq9evS7VfSSEFD9KxgghpBh8/RqG4cNHYujQwXjy5BFu3LiObt26QNIt9/79B/Dz88ONG9ewe/dOHD16HEePHuM+n5qahkWLFsDLywOnTh1HQEAAxo0bL7OdBQsWYdWqFbh/3xUGBgbo27e/VFJHCPn1lPlmSkII+RWEhYUhPT0d3bp1hYmJCQCgXr2/uPk6OjrYuPFvKCoqwty8Njp0aA9XV1eMGDEcADBs2BBu2erVq+Pvv9ehefOW+PHjB8qXL8/NmzdvLlq3bgUA2L17J2rXtsDly1fQq1fPUthLQkhJoJoxQggpBvXrW6JFixYQi5tg8OChOHDgIKKjo7n5FhZ1oKioyP1dqVIlREREcX8/e/Ycffv2R506f6FSJSN06OAAAAgKCpbaTuPGYu7fFSpUgJmZGd6/f19Su0UIKQWUjBFCSDFQVFTE1auXcOHCOdSpY45//92FBg2s4e/vDwBQVlaWWl4gEICxTABAQkICunXrDg0NDezbtwf377vixImsJszU1NQ8ty0Q0JPlhPzKKBkjhJBiIhAI0KSJDRYuXICHD92hoqKCy5ev5vm5Dx8+ICrqG5Yvd4atbVOYm9dGZGSk3GV9fB5x/46OjsanT59Qu3btYtsHQkjpoz5jhBBSDB49egRXVze0bt0KBgYGePTIF1FRUTA3r41Xr17l+tmqVY2hoqKCf//dhdGjR+LNm7dYu3ad3GVXr16LChUqoGLFinB2XgY9PT106dK5JHaJEFJKqGaMEEKKgaamFtzdPdCjR29YWQmxbNlyrF69Eu3bt8vzswYG+ti1619cuHAR1tZibNiwEatWrZS77PLlS+HkNAd2ds0RFhaG06dPQkVFpbh3hxBSisr865B+JnkNwdevwfQ6pGxodGRpVB7SqDyk/Yrlcf/+A3Ts6ICQkEDo6OgU67p/xfIoSVQesqhM/icuLg6GhlWL9XVIVDNGCCGEEMIjSsYIIYQQQnhEHfgJIeQX0Lx5MyQkxPEdBiGkBFDNGCGEEEIIj6hmjBBCfmMZmQyPA2MR+SMVBuVVYG2iDUUFGiSWkLKEkjFCCPlN/fc2CqtufUJ43P9G8a+kpYL57WuhrYU+j5ERQrKjZkpCCPkN/fc2CtPOvJFKxAAgIi4V0868wX9vo3L4JCGktFEyRgghv5mMTIZVtz5B3iCSkmmrb31GRuYvNcwkIb8tSsYIIeQ38zgwVqZGLDsGICwuBY8DY0svKEJIjigZI4SQ30zkj5wTscIsRwgpWZSMEULIb8agfP7eVZnf5QghJYuSMUII+c1Ym2ijkpYKchrAQgCgspYqrE20SzMsQkgOKBkjhJDfjKKCAPPb1wIAmYRM8ve89jVpvDFCyghKxggh5DfU1kIfm/vURUUt6abISlqq2NynLo0zRkgZQoO+EkLIb6qthT5amevRCPyElHGUjBFCyG9MUUEAcTUdvsMghOSCmikJIYQQQnhEyRghhBBCCI8oGSOEEEII4RElY4QQUsYwxvD161c8eOCOhQsX4/HjJ3yHRAgpQdSBnxBCyoDDh4/izp07+PTpMz5//owfP35w84KDg3Hw4H4eoyOElCSqGSOEkDLAzc0NEREREAobol+/vtDT04OioiI0NDSwadMGvsMjhJQgSsYIIaQM2LdvDy5dugAtLS3s338ApqYmAICFCxdAV1eX5+gIISWJmikJIaQMePXqNUaNGoP3799j2TJneHt7IyrqG8aNG8N3aISQEkY1Y4QQwqPMzExs2bINzZrZIyMjA25uLmjSxAZXr17D4sULoaqqyneIhJASRjVjhBDCk+DgYIwZMx7379/H5MmT4Oy8BGpqahg6dDjq16+Pfv368h0iIaQUUDJGCCE8OHXqNKZPnwkNDQ1cvXoZLVu24OY5Oc1ChQq6UFCgxgtC/gR0phNCSCmKjo7GsGEjMHLkaLRt2wY+Pg+lEjEAsLSshypVqvARHiGEB1QzRgghpcTFxRVjx45HQkIC9u/fS82QhBAAVDNGCCElLjk5GbNnz0Xnzl1Rq1Yt+Pg8pESMEMKhZIwQQkrQ8+cvYGdnjz179mL16lW4du0yqlatymtMqamp2LRpMzIzM3mNgxCShZIxQggpARkZGdi4cTPs7VtCUVERDx64YcqUyWWiU/7u3XuxcOFiTJ48he9QCCGgZIwQQopdQEAAOnXqjMWLl2DSpIm4f98F9er9xXdYnA8f3gMADh06jIsXL/EcDSGEOvATQkgxYYzh+PETmDnTCTo6Orh+/SqaN2/Gd1gyPDw8oa+vj3LlymHs2PGoX78BatQw5TssQv5YVDNGCCHF4Nu3bxgyZBjGjh0PB4dO8Pb2LJOJWFhYON69e48GDaygpKSI6tWro1u3bvj+/TvfoRHyx6JkjBBCiui//+5ALG4CV1dXHD58EPv27YG2tjbfYcn14MEDAICDQyf4+fnj3393ICYmBqNHj+U5MkL+XJSMEUJIISUmJmLmzFno3r0n6ta1gI+PF3r16sl3WLm6f/8BzM1ro127tgCAiIgwnD9/Hrq6ujxHRsifi/qMEUJIITx9+gyjRo1GQEAg1q9fi/Hjx5WJJyXzoqiogH79+sLU1BQGBgbw8XmENWvWQSQS8h0aIX8sSsYIIaQAsoas2IQVK1ahbt26cHe/DwuLOnyHlW+bN2/i/i0Wi+Dj48tjNIQQgJopCSEk3/z8/NCuXQc4Oy/HtGlT4eZ275dKxH4mEonw+PFjGvyVEJ5RMkYIIXlgjOHQoSOwsbHF169huH37Jpydl0BFRYXv0IpELBYhLi4O79694zsUQv5olIwRQkguIiOjMGDAIEycOAndu3eDl5cHmjZtwndYxUIobAiBQAAvLy++QyHkj0bJGCGE5ODmzVsQi23g6emJ48ePYteuf6GlpcV3WMVGU1MTdevWpWSMEJ5RMkYIIT9JSEjA1KnT0atXH1hZ1Ye3txe6devKd1glQiwWUTJGCM8oGSOEkGx8fX1ha9sMx44dx6ZNG3DhwjkYGlbmO6wSIxKJ8OrVK8THx/MdCiF/LErGCCEEQHp6OlavXoNWrdpCU1MTHh4PMHbsGAgEAr5DK1FisQiMMTx+/ITvUAj5Y1EyRgj543369Alt2rTDqlVrMGvWDNy7dwfm5rX5DqtUmJvXhpaWFh49ovHGCOELDfpKCPljMcZw4MBBzJkzD5UrV8KdO7fQuHFjvsMqVQoKCmjcuDEePXrEdyiE/LGoZowQ8kcKD49A37794eg4FX379sHDhx5/XCIm0bhxY/j4PAJjjO9QCPkjUTJGCPnjXLlyBWKxDXx8HuHUqRPYvn0rypcvz3dYvLGxsUFkZCQCAgL4DoWQPxIlY4SQP8aPHz8wefIUdO3aFY0aWcPHxwudOzvwHRbvJDWCPj7UVEkIHygZI4T8Eby9vdGkiS1OnTqNXbt24ezZ06hUqSLfYZUJ+vr6qFmzBiVjhPCEkjFCyG8tLS0Ny5evQJs27aGnp4eHD90xduzY337IioISiUTUiZ8QnlAyRgj5bX348BGtW7fF+vUbMG/eHNy5cxu1atXiO6wySSwW4cWLl0hJSeE7FEL+OJSMEUJ+O4wx7NmzF02b2iE2NhZ3797G/PnzoKREo/nkRCwWITU1Fc+fP+c7FEL+OGU+GUtJSUFcXJzUf4QQkpOwsHD07Nkb06bNwKBBA+Hp6Q6RSMR3WGVevXr1oKamRv3GCOFBmb9NXL16NZydnWWmq6trQl1dk4eIyi4qD2lUHtL+hPK4cOECxowZA0VFRVy9ehUODjk/KfknlEdBaGtXgLW1NZ48eUZlAzo+5KEyyZKeXvzj8QlYGR/lLyUlRaoPQ1xcHIyNjfH1azC0tLR4jKxsUVfXRGIivehXgspD2u9eHvHx8XBymoMjR46ic2cHbNu2FQYG+jku/7uXR0FJymPevAW4ePES3r59xXdIvKLjQxaVyf/ExcXB0LAqYmNjiy0PKfPNlKqqqtDS0pL6jxBCJDw9H8LGxhbnz1/Ajh3bcPLk8VwTMZIzsViEwMBAfP0axncohPxRynwyRggh8qSmpmLJEme0b98RlStXgpeXB4YNG0pDVhSBWJzVt87Xl14aTkhpomSMEPLLeffuPVq2bIPNm//BokULcOvWDdSoUYPvsH55VapUgZGRER49omSMkNJEyRgh5JeRmZmJf//dCVvbZkhMTICLyx3Mnu1EQ1YUI5GoEQ3+Skgpo2SMEPJLCA0NRffuPTFr1mwMGzYEHh4PIBQK+Q7rtyMSifD48ROkp6fzHQohfwxKxgghZd758xcgFtvg9es3uHDhHDZu3AB1dXW+w/oticUiJCQk4M2bt3yHQsgfg5IxQkiZFRsbi9Gjx2LIkGGwt7eHj89DtGvXlu+wfmsNGzaAoqIiNVUSUoooGSOElEnu7h5o3Lgprl69hl27/sXRo4ehp6fHd1i/PXV1dVhaWtJI/ISUIkrGCCFlSkpKChYsWIQOHTrB2LgqvL09MXjwIBqyohSJxY1oeAtCShElY4SQMuP16zewt2+F7dt3wNl5KW7evA5TU1O+w/rjiEQivHv3HjExMXyHQsgfgZIxQgjvMjMzsXXrNjRrZo/09DS4ut7DzJnToaioyHdofySRqBEAwNf3Mc+REPJnoGSMEMKr4OBgdO7cDXPnzsfo0aPw4IEbGjSw4jusP1qtWrWgq6tDnfgJKSU0UiIhhDenT5/B9Okzoa6ujitXLqFVq5Z8h0QACAQCiEQi6sRPSCmhmjFCSKmLjo7G8OEjMWLEKLRp0wre3p6UiJUxYrEIjx49AmOM71AI+e1RzRghpFS5urph7Njx+PHjB/bt24N+/frSk5JlkEgkQnR0DD59+gQzMzO+wyHkt0Y1Y4SQUpGcnIw5c+bBwaELatasAW9vT/Tv348SsTKqUSNrAKCXhhNSCigZI4SUuBcvXqJZsxbYvXsPVq1aiWvXrsDY2JjvsEgudHR0UKeOOXXiJ6QUUDJGCCkxGRkZ2LTpH9jbt4RAIMD9+66YOtURCgp06fkVNGrUCD4+VDNGSEmjKyIhpEQEBgbCwaELFi1ajPHjx+H+fRdYWtbjOyxSAGKxCC9fvkRiYiLfoRDyW6NkjBBSrBhjOHHiJBo3bgo/P39cu3YFq1evhJqaGt+hkQISiUTIyMjA06fP+A6FkN8aJWOEkGLz/ft3DB06HKNHj0XHjh3g7e0Je/vmfIdFCqluXQtoaGjQeGOElDAa2oIQUizu3r2HceMmICkpCYcOHUDv3r34DokUkZKSEqythdSJn5ASRjVjhJAiSUpKwqxZs9G1a3eYm5vDx+chJWK/EZFIRMNbEFLCKBkjhBTas2fP0ayZPfbvP4B169bgypWLqFKlCt9hkWIkFosQGhqKkJAQvkMh5LdFyRghpMAyMjKwfv0GtGjRCsrKKnB3v49JkybSkBW/oUaNGgEA9RsjpATRlZMQUiD+/v7o0KETnJ2XwdFxMlxd76JuXQu+wyIlpHLlSjAxMaFkjJASRB34CSH5whjD0aPH4eQ0G7q6urh58zrs7Gz5DouUArG4EXXiJ6QEUc0YISRPUVHfMGjQEIwfPwFdu3aBl5cHJWJ/EJFIhKdPnyE1NZXvUAj5LVEyRgjJ1a1btyEW2+DBgwc4duwIdu/eCW1tbb7DIqVILBYhOTkZr1694jsUQn5LlIwRQuRKTEzE9Okz0LNnb1ha1oOPjxe6d+/Gd1iEB1ZWVlBRUaEhLggpIZSMEUJkPHnyBLa2zXD48FFs2LAeFy+eh6GhId9hEZ6oqqrCyqo+deInpIRQMkYI4aSnp2Pt2nVo2bINNDTKw9PTHePHj4NAIOA7NMKzRo2oEz8hJYWSMUJ+Ebt370HdupaoUMEAtrbN4eHhma/PPXzoBSUlJdjYSHe479ChEzQ0tKT+09augGXLVmDGjGm4d+8/mJvXLoldIb8gsViEz5+/ICrqG9+hEPLboWSMkF/A2bPnMHv2XMyePQuenu5o2rQJevTohaCgoFw/FxsbizFjxqJ169Yy844fP4rPnz/i8+cPWLVqJcqVKwcAcHKahSVLFkNFRaVE9oX8msRiEQDA15dqxwgpbpSMEfIL2Lp1G4YNG4rhw4ehTh1zrF+/FlWrVsGePfty/dyUKVPRt28fNGnSRGZehQoVoKCggClTpmH+/AX466+/UL58eTg5zSyp3SC/MFNTUxgYGFC/MUJKACVjhJRxqampePr0GVq3biU1vVWrVvD29s7xc4cPH8WXL36YP3+e3Pk3btyAWGwDb29vnDx5HImJiejTpzc0NDSKNX7yexAIBBCL6aXhhJQESsYIKeO+ffuGjIwMVKxYUWp6pUoVER4eLvcznz59wuLFS7B//14oKUm/aCMhIQGOjlPRu3c/CIUN4e3tBUPDynjz5g2GDx9aYvtBfn0ikQi+vo+RmZnJdyiE/FYoGSPkF/HzA42MMblPOWZkZGDEiFFYuHA+zMzMpOY9evQITZrY4uTJU/jnn004d+4MKleuhEOHjqBu3brcS6EJkUckaoS4uDi8f/+B71AI+a3QuykJKeP09PSgqKiI8PAIqekREZEytWUAEB8fjydPnuL58xeYMWMWACAzMxOMMbRo0RpmZmbw9HzAJWqJiYk4e/YcFi6cX/I7Q35p1tZCCAQC+Pg8goVFHb7DIeS3QTVjhJRxKioqaNiwAe7duyc13cXFBY0bN5ZZXktLCz4+Xnj40AMPH3rg1KnjMDAwAACMHj0Krq53pWrMzp27gJSUFPTv369kd4T88jQ1NVG3bl0ab4yQYkY1Y4T8AhwdJ2P06LFo2FCIxo3F2L//AIKCgjF69EgAwOLFSxEaGoq9e3dDQUEBf/1VF4wx7Nu3H/PmLYCqqipq1qyJf/7ZJLPuw4cPo0sXB+jp6ZX2bpFfkFgsoicqCSlmlIwR8gvo3bsXvn//jjVr1iIsLAx169bF+fNnYWJiAgAICwtDcHAwt3xYWDgmTZqMmzdvYeTIEahUqTKuXr0qs96PHz/C0/MhLl++WFq7Qn5xIpEIBw8eQnx8PDQ1NfkOh5DfgoAxxvgOoiDi4uKgra2Nr1+DoaWlxXc4ZYa6uiYSE+P5DqPM+JPL4+rVa5g0aTIEAgXs2LENnTp1/KPLQx4qD2kFKY+3b9+hUSMxrl+/Cnv75iUcGT/o+JBFZfI/cXFxMDSsitjY2GLLQ6jPGCG/ifj4eEycOBn9+g1A48aN4ePjhU6dOvIdFvnNmJvX/v9+idRUSUhxoWZKQn4DXl7eGD16DCIiIrF9+1YMGzaUXu5NSoSCggKsra2pEz8hxYhqxgj5haWlpcHZeRnatm0PAwMDPHzojuHDh1EiRkqUWNwIPj6P8Iv1ciGkzKJkjJBf1Pv3H9CyZRts2LAJCxfOx3//3ULNmjX5Dov8AcRiESIjIxEQEMB3KIT8FigZI+QXwxjDzp270LSpHRISfsDF5Q7mzJkt89ojQkpKo0YiAKB+Y4QUE0rGCPmFfP36Fd2798TMmU4YOnQwPDwewNramu+wyB9GX18PNWvWoGSMkGJCt9KE/CIuXrwER8cpUFZWwfnzZ9G+fTu+QyJ/sKyXhvvyHQYhvwWqGSOkjIuLi8PYseMxaNAQNGvWDD4+XpSIEd6JxSI8f/4CKSkpfIdCyC+PkjFCyjAPD080btwUly9fwc6d/+LYsSPQ16fXFhH+iUSNkJqaiufPn/MdCiG/PErGCCmDUlNTsWjRErRv3xFVqhjBy8sDQ4YMoiErSJlRr149qKmpUb8xQooB9RkjpIx58+YtRo0ag7dv32Lp0iWYPn0qFBUV+Q6LECkqKipo2LABDf5KSDGgmjFCyojMzExs374DdnbNkZqaAlfXe5g1awYlYqTMEolE8PGhTvyEFBUlY4SUASEhIejatQdmz56LkSNHwN39Pho0sOI7LEJyJRaLEBgYiLCwcL5DIeSXRskYITw7e/YcxOImePfuHS5fvoi//16HcuXK8R0WIXkSi7MGf6UhLggpGkrGCOFJTEwMRo4cjWHDRqBVq5bw8XmI1q1b8R0WIflWpUoVGBkZUSd+QoqIOvATwgM3t/sYO3Y84uLisHfvbvTv34+elCS/JJGoEXXiJ6SIqGaMkFKUkpKCefMWwMGhC6pXrwZvb08MGNCfEjHyyxKJRHj8+AnS09P5DoWQXxYlY4SUklevXqNZsxb499+dWL58Ga5duwITExO+wyKkSMRiERISEvDmzVu+QyHkl0XJGCElLDMzE//8sxXNmtmDMYb7911p7DDy22jYsAEUFRWpqZKQIqBkjJASFBQUBAeHLpg/fwHGjRuLBw9cUb++Jd9hEVJs1NXVYWlpSZ34CSkC6sBPSAlgjOHUqdOYMWMWypcvj2vXrqBFC3u+wyKkRIjFjXD//gO+wyDkl0U1Y4QUs+joaAwfPgKjRo1Bu3Zt4e3tSYkY+a01atQI7969R0xMDN+hEPJLKvM1YykpKUhJSeH+jouL4zEaQnJ3754Lxo2bgMTERBw4sA99+/bhOyRCStz/Bn99jDZtWvMcDSG/njKfjK1evRrOzs4y09XVNaGurslDRGUXlYe00iyPpKQkzJs3D//88w9atWqFgwcPwtjYuNS2nx90fEij8pBWlPKoX78hdHV18ezZC3Tt2r34guIRHR+yqEyypKezYl+ngDFW/GstRvJqxoyNjfH1azC0tLR4jKxsUVfXRGJiPN9hlBmlWR7Pn7/AqFGj8eWLH5ydl2DSpIlQUChbPQDo+JBG5SGtOMqjR49eAIALF84VR0i8ouNDFpXJ/8TFxcHQsCpiY2OLLQ8pW78YcqiqqkJLS0vqP0LKgoyMDGzYsAn29i2hqKiEBw/c4Og4ucwlYoSUBrFYBF9fX5Tx+3tCyiT61SCkEAICAtCxowOWLFmKyZMn4f59F/z1V12+wyKENyKRCN+/R+Pz5898h0LIL4eSMUIKgDGGo0ePoXHjpggMDMKNG9ewYsUyqKqq8h0aIbxq1MgaAGi8MUIKgZIxQvLp27dvGDx4KMaNm4DOnR3g7e2JZs3s+A6LkDJBR0cH5ua1aSR+QgqhzD9NSUhZ8N9/dzB+/ESkpCTjyJFD6NmzB98hEVLmiEQi+Pj48h0GIb8cqhkjJBeJiYmYOXMWunfvib/+qgsfHy9KxAjJgVgswsuXL5GYmMh3KIT8UigZIyQHT58+hZ1dcxw8eBh//70OFy+eh5GREd9hEVJmiUQiZGRk4OnTZ3yHQsgvhZIxQn6Snp6OdevWo0WL1lBTKwd39/uYMGE8DVlBSB7q1rWAhoYGdeInpICozxgh2fj5+WH06LHw8XmEGTOmY8GCeVBRUeE7LEJ+CUpKSrC2FsLXl/qNEVIQdKtPCLKGrDh06AhsbGwRFhaOW7duwNl5CSVihBRQVid+qhkjpCAoGSN/vMjIKAwYMAgTJ05Cjx7d8fChO5o2bcJ3WIT8kkSiRggNDUVISAjfoRDyy6BkjPzRbt68CbHYBp6enjh+/Ch27txBr9wipAgaNWoEgAZ/JaQgKBkjf6SEhARMnTodvXr1RYMGVvD29kK3bl35DouQX56hYWWYmJhQMkZIAVAHfvLH8fX1xahRYxASEorNmzdi9OhREAgEfIdFyG9DLG5EI/ETUgBUM0b+GOnp6Vi1ajVatWoLLS0teHq6Y8yY0ZSIEVLMRCIRnj59hrS0NL5DIeSXQMkY+SN8+vQJbdq0w+rVa+HkNBP37t1B7dpmfIdFyG9JLBYhOTkZr1694jsUQn4JlIyR3xpjDPv3H0CTJnb49u0b7t69jUWLFkJZWZnv0Aj5bVlZWUFFRYX6jRGST5SMkd9WeHgE+vTpB0fHqejXry8ePvSAWCzmOyxCfnuqqqqoX9+SkjFC8ok68JPf0uXLlzFq1CgAwOnTJ+Hg0InniAj5s4hEIty+fZvvMAj5JVDNGPmt/PjxA5MmOaJbt24QiRrBx8eLEjFCeCAWi/D58xdERX3jOxRCyjxKxshvw9vbG02a2OL06TPYvXs3zpw5hUqVKvIdFiF/JLFYBADw9aWmSkLyQskY+eWlpaVh2bLlaNOmPfT09ODl5YExY8bQkBWE8MjU1BQGBgbUb4yQfKA+Y+SX9uHDR4waNRrPn7/A/Plz4eQ0C0pKdFgTwjeBQACxWIRHj3z5DoWQMo9qxsgviTGG3bv3oGlTO8TFxeHevf8wb95cSsQIKUNEIhF8fR8jMzOT71AIKdMoGSO/nK9fw9CjRy9Mnz4TgwcPhKenO/dyYkJI2SESNUJcXBzev//AdyiElGlUjUB+KZcuXYaj4xQoKirh3Lkz6NChPd8hEUJyYG0thEAggI/PI1hY1OE7HELKLKoZI7+EuLg4jBs3AQMHDkbTpk3h4+NFiRghZZympibq1q1LLw0nJA9UM0bKPE/Phxg9eiy+ffuGf//dgSFDBtGTkoT8IsRiET1RSUgeqGaMlFmpqalYvHgp2rXrACMjQ3h5eWDo0MGUiBHyCxGJRHj79i3i4+P5DoWQMouSMVImvX37Di1atMY//2zBkiWLcOvWDVSvXp3vsAghBSQWi5CZmYknT57yHQohZRYlY6RMyczMxI4d/8LOrjmSk5Pg6noXTk6zoKioyHdohJBCMDevDS0tLWqqJCQXlIyRMiM0NBTduvWAk9McjBgxDO7u99GwYUO+wyKEFIGCggKsra2pEz8huaBkjJQJ586dh1hsgzdv3uLixfP4++/1UFdX5zssQkgxEIsbwcfnERhjfIdCSJlEyRjhVWxsLEaNGoOhQ4ejRYsW8PF5iLZt2/AdFiGkGInFIkRGRiIgIIDvUAgpk2hoC8KbBw/cMWbMOMTExGD37p0YOHAAPSlJyG+oUSMRAMDH5xGqVavGbzCElEFUM0ZKXUpKChYsWISOHR1gYmIMb29PDBo0kBIxQn5T+vp6qFmzBr00nJAcUM0YKVWvXr3GqFFj8P79eyxb5oypUx3pSUlC/gAikYg68ROSA6oZI6UiMzMTW7ZsQ7Nm9sjIyICbmwtmzJhGiRghfwiRqBGeP3+BlJQUvkMhpMyhZIyUuODgYHTu3A3z5s3HmDGj4e7uBiur+nyHRQgpRWKxCKmpqXj+/DnfoRBS5lAyRkrU6dNn0LhxU3z8+BFXr17GunVroKamxndYhJBSVq9ePaipqdHgr4TIQckYKRHR0dEYNmwERowYhTZtWsPH5yFatmzBc1SEEL6oqKigYcMG1G+MEDmoAz8pdi4urhg3bgJ+/PiB/fv3ol+/vnyHRAgpA0QiES5evMR3GISUOVQzRopNcnIy5syZh86du6JmzZrw9vakRIwQwhGLRQgMDERYWDjfoRBSplAyRorFixcvYWdnj92792D16lW4du0yjI2N+Q6LEFKGiMVZg7/6+tJ4Y4RkR8lYMejQoROcnOYAACws6mHbtu08R1R6MjIysHHjZjRv3gIKCgp48MANU6ZMhoICHVqEEGlVqlSBoaEhdeIn5CfUZ6yY3b/vCg2NP+MF14GBgRgzZhw8PDwxZYojlixZBFVVVb7DIoSUYWIxDf5KyM+o+qKYGRjoQ139907GGGM4fvwEGjduCn//AFy/fhWrVq2gRIwQkieRSITHj58gPT2d71AIKTMoGStmPzdTamhoYd++/ejVqw/09StBKGwEb29vfP78GR06dIKBQWW0bNkaX758kVrP9es3YGvbHBUqGOCvv+pj1arVpX7xysjIwIsXL6Wmffv2DUOHDseYMePQqVNHeHt7onnzZqUaFyHk1yUWi5CQkIA3b97yHQohZQYlY6VgzZp1GDhwAB4+dEft2rUxYsRoODpOw8yZM/DggRsAYMaMWdzy//13B6NGjcGECePw+LEPtmzZjKNHj2PduvWlGvemTf/A3r4lGGMAgDt37kIsbgIXFxccPnwQ+/btgY6OTqnGRAj5tTVs2ACKiorUVElINpSMlYIhQwahV6+eMDMzw4wZ0xAQEIB+/fqibds2qFPHHBMnTsCDB+7c8uvX/40ZM6Zj8OBBqF69Olq3boVFixZg374DpRZzVNQ3bNiwEaNGjURycjJmzXJCt249YGFhAR8fL/Tq1bPUYiGE/D7U1dVhaWmJR4/oiUpCJKgDfymoV68e9++KFSv+/7S6UtOSk5MRFxcHLS0tPH36DI8fP8H69X9zy2RkZCA5Ofn/2rvzsKjK/g3g9zAIBDKgSEoKpiIqMaxzDoq75vKS+76lZvrLUguX3HI301xzyzKM3HPXcn3dF1R2hjHNLd/ccENlVBQU+P1hUhOamsBzZub+XBdXMgzDPd+LK2/Pec5zkJGRUSRr0qZOnYbc3FyEh4ejVq06OHfuf5g27Uv07fsBr5QkolciyzocOHBQdAwixWAZKwLFihXL+7NKpQIA2NrmfywnJyfvv599NhItWzbP91pFcV/H//3vf1i48DvUrl0LrVu3ga+vL6KjD6JataqF/rOJyPLpdDosXBiJ27dvc6kDEVjGFCkwMACnT59GpUqVhPz8oUOHIzc3F3v27EWzZs0QEOCPWbO+ws2bN/H11/Px+uvuQnIRkWX4c/PXBLz9dkPBaYjEYxlToOHDh6Fduw4oV64sWrduDRsbGxw7dgy//PILxo4dU6g/OyEhAVu2bM37fPPmzTh8OBre3t7w8/ODvb1dof58IrJ83t7eKFHCFXFxcSxjRGAZU6RGjd7G2rWrMWXKl5g1azaKFSsGH5/K6NmzR6H/7IoVK6J161aoV68e/P39UKlSJbi5uRX6zyUi66FSqSBJEnfiJ/qDKvfJvgVmwmg0wsXFBampF6HRaETHUQxHR2dkZNwRHUMxOA9TnIcpzsOUiHlMnjwFX3+9AOfP/y9v3axS8PcjP87kT0ajER4e5ZCenl5gPYSXxRERUZGTJAk3b97C2bNnRUchEo5ljIiICtTChd/B11eLkiXdUbNmHURHH873HJ0uBACwdOkyODlp8n2cPHnK5Pm3b9/GwIGDULFiZZQs6Y7gYB22b99RJO+HqLBxzRgRERWYtWvXYejQ4fjqq5moXr06Fi36Hq1bt0VCQiw8PT3znufq6ooqVXzw66+/AgCSkxPg7PznKR9391J5f87KykLz5i3h7u6O5cuXomzZN3Dx4iUUL1686N4YUSFiGSMiogIzd+489OjRPe+Co2nTvsTu3bvx3XeLMGHCOJPnSpKEI0eOAgDc3d2fuefYkiVLcevWLezZsytv30YvL69CegdERY+nKS1Idk4uYv93G1uOXUPs/24jO8esrs0gIjOXlZWFpKRkNGzYwOTxBg0aICYmJt/zZVnCuXPnAABhYbVRsWJlhIc3x/79B0yet2XLVsiyjIEDB+PNNytBpwvFtGnTkZ2dXXhvhqgI8ciYBWn5TTx+u3E/7/PSGjuMbOKNRtVK/cN3EREVjLS0NGRnZ+fd9u2J0qVfx65dV/M9X5Ik5OTkICLiE7Rr1xZZWZlYufJHvPNOc2zfvhW1atUE8PiuIPv3H0DHjh2wYcNanDlzFoMGDcajR48wYsTwInlvRIWJZcwC7D2ZhneCnHHtzkOTx68ZsxCx5ji+au/LQkZERebvO1Xk5uY+dfsKX99qcHJygru7O4KCAgEAoaGhuHjxEmbPnpNXxnJycuDu7o558+ZArVYjKCgIqalX8NVXs1nGyCLwNKWZy87JxYzdvz31a09OUk7ecZanLImo0Lm5uUGtVuPq1Wsmj1+7dj3f0TIAsLW1RUhIMOLiTDd/lWXJZMuLMmXKwNvbG2q1Ou+xKlV8cPXqVWRlZRXwuyAqeixjZi7hfHq+I2J/lQvgijETCefTiy4UEVklOzs7BAUFYs+ePSaP7927F6GhoU/9Hp1Ol28nfr0+BaVLl8n7vHr16vjtt9+Qk5OT99iZM2dQpkwZ2NnxFm1k/hR/mjIzMxOZmZl5nxuNRoFplOdWxkM42T/+1+KT/z7reUREhW3AgP7o3fv/EBQUjNBQGd9/H4ULFy6id+9eAIAxY8bh8uXLiIxcCAC4ceMGLl++jOjoaJQoURI//rgKGzduwooVy/Jes0+f9/HNN9/i00+Hom/fD3D27FlMmzYDH33UV8h7JCpoii9jkydPxvjx4/M97ujoDEdHZwGJlKW1zhmtdRUBADEj3xacRln4+2GK8zDFeZgqqHl0794Td+9m4MsvpyI1NRV+fn7YunUrqlZ9CwBw40YaLl9Ozft5Xl7lAQDvvNMCxYsXx1tvvYUtW7YgPDw87zV9fKrhv//9LwYOHIjQ0DCULVsWERERGDZsmMmpy4LE34/8OJPHHj0q+GU/ir835dOOjHl6evLelH/IzslF5++TsPnjugj9YhfuZZpe6q0C4O5sh019Q6C2Udb93woT76NmivMwxXmYEj2PatX80KpVS0yePElYhr8SPQ8l4kz+VBj3plT8kTF7e3vY29uLjqFYahsVPqz9+F+WGZnZuJv5KO9rT6rX5y18rKqIEZF5kWVdvkX8RNaEC/gtQP0qbgAAd+diJo+X1thzWwsiUjxJkpCUlIyHD7m2layT4o+M0Yvb1FeHhPPpuH43C+7F7RDi5cIjYkSkeLIs4cGDBzh27BiCgoJExyEqcixjFkRto4L8pqvoGEREL8Xf3x/FihVDbGwcyxhZJZ6mJCIioRwcHBAQ4J9vvzEia8EyRkREwkmSxEX8ZLVYxoiISLjHt0D6DTdupImOQlTkWMaIiEg4WZYAAPHxPDpG1ocL+Om5KlTwRkbGPZQq5Y7ixYvDwcEer732GhwcHPDJJx+jfv16ghMSkbkrX7483N3dERcXj6ZNm4qOQ1SkeGSMnqt8eS/cvXsPFy9ehIODPapUqYI33ngDTk5OsLHhrxARvTqVSgVZlriIn6wS/yal59q4cT08PDxQunRp6PUp2LlzF8LCauCHH75H3bp1RMcjIgshSTrExycgJydHdBSiIsUyRs/l6uqKyMiFuHTpEj755GM0aFAfERGDIEmh2LTpJyj89qZEZCYkSYLRaMTJk6dERyEqUixj9ELq1auLAQP6Y86cuYiI+ATR0Qfh5eWFLl26oUGDtxEdfVh0RCIycyEhwVCpVDxVSVaHZYxe2LhxY1C5cmVERAxEQIA/fvppI37+eRMyM7PQuHFTtG/fESdO/Co6JhGZKWdnZ/j6+nK/MbI6LGP0whwcHPDjj8vx3ns98x5r0KA+Dh3aj6ioRTh+/ARkuTo++qg/Ll++LC4oEZktLuIna8QyRi+lYsWK6Natq8ljNjY26NChPRIT4zBlyhfYvHkz/P2DMHbseKSnpwtKSkTmSJIknDhxAnfu3BEdhajIsIxRgbG3t0e/fh/BYNCjf/9+mD//a2i1AZg3bz4yMzNFxyMiMyBJOuTk5CAxMUl0FKIiwzJGBc7FxQXjxo1BSkoSmjdvjhEjPkNQkA6rVq3mJetE9I+qVq0CjUbDU5VkVVjGqNC88cYbmD9/LmJjj8LP7y306tUbtWrVxe7de0RHIyKFsrGxQUhICBfxk1VhGaNCV61aVaxe/SN27twBBwd7tGjRCs2bt0Rysl50NCJSIFnWITY2jnsYktVgGaMiExZWA7t378TKlctx8eJF1KxZG7169cbvv/8uOhoRKYgsS7h+/Tr/30BWg2WMipRKpUKLFs0RFxeDOXO+wr59+xEYGIJhw0YgLS1NdDwiUgCdTgIArhsjq8EyRkLY2tri/fd7wWBIxrBhn+KHHxZDqw3E9Okzcf/+fdHxiEigUqXcUKlSRcTFxYuOQlQkWMZIKCcnJwwfPgwGgx6dO3fExImfw98/CIsXL0F2drboeEQkiE6n4yJ+shosY6QIr7/ujhkzpiMxMQ41ajzexT80tAa2bt3GRbxEVkiWJej1KdyjkKwCyxgpSqVKlbBkyQ84cGAv3N1fR/v2HdGkyX8QGxsrOhoRFSFZlpCVlQW9nlddk+VjGSNFCgkJwdatP2P9+rW4fTsd9eu/ja5d38Xp06dFRyOiIuDn5wcHBwcu4ierwDJGiqVSqdCkSWMcOXII3367APHxCQgJkRERMRBXr14THY+ICpGdnR2CggK5boysAssYKZ5arUa3bl2h1ydi/PhxWLNmHbTaAEya9AVvJkxkwSRJQmwsr6gky8cyRmbDwcEBAwd+gmPH9OjTpzdmzJgFrTYQ3367EA8fPhQdj4gKmCxLOH/+PK5cuSo6ClGhYhkjs1OiRAlMmjQRen0iGjduhMGDP0VIiIT16zfwyksiCyJJOgBAfDyPjpFlYxkjs+Xp6YmFC7/BkSPRqFSpEt59twfq1WuAgwcPiY5GRAWgbNmy8PDw4CJ+sngsY2T2tFo/bNiwDlu3bkZOTg6aNg1Hs2bN8Msvx0VHI6JXoFKpIMsSF/GTxWMZI4tRt24d7N+/F4sXR+HEiROoXj0Mfft+hEuXLomORkT/kiRJSEhIxKNHj0RHISo0LGNkUWxsbNCuXVucOHEC06Z9iW3btsPfPwijRo3B7du3RccjopckyxLu3buH48dPiI5CVGhYxsgi2dnZoW/fD2AwJCMi4mN8++1C+Pn5Y/bsuXjw4IHoeET0goKCAqFWq3mqkiwayxhZNI1Gg9GjRyElJRlt2rTB6NFjEBgYghUrViInJ0d0PCJ6DkdHR2i1Wi7iJ4vGMkZWwcOjDObM+Qrx8bEIDg5Cnz4fICysNnbu3MXtMIgUTpJCuL0FWTSWMbIqPj6VsWLFMuzevRPFizuhVas2aNasJZKSkkRHI6JnkCQJv/56kus+yWKxjJFVql49FDt37sCqVSuRmnoZtWrVRc+evXDu3DnR0Yjob2RZAgDExycITkJUOFjGyGqpVCo0a/YOYmOPYv78uTh0KBpBQToMGTIU16/fEB2PiP7g7e2NEiVcuYifLBbLGFk9W1tb9OzZAykpSfjssxFYvnwFtNoATJ06Dffu3RMdj8jqqVSqP24azjJGlolljOgPjo6O+PTTITAY9Hj33W744osp8PcPQlTUD9xwkkiwJzvx84IbskQsY0R/U6qUG6ZN+xJJSfGoU6c2+vf/GLJcHZs3b+FfBESCSJKEW7du48yZM6KjEBU4ljGiZ6hQoQKiohbh0KEDeOONsujYsTMaNWqCo0djREcjsjo6XQgAIC6OW1yQ5WEZI3qOoKBAbN68CZs2bcC9exlo2LAROnfuipMnT4mORmQ1XF1dUaWKDxfxk0ViGSN6QW+/3RDR0QcQGbkQycl6SFIoBgz4BKmpV0RHI7IKjxfx88gYWR6WMaKXYGNjg86dOyEpKR6ffz4RGzduhL9/ICZMmAij0Sg6HpFFk2UJBoMBGRkZoqMQFSiWMaJ/wcHBAR9/3B8Ggx59+36A2bPnQqsNwIIF3yArK0t0PCKLJEkSsrOzkZSULDoKUYFiGSN6Ba6urpg4cTxSUpIQHh6OoUOHIzhYh7Vr1/FG5EQFzNe3GpycnLjfGFkcljGiAlC2bFksWDAfR48eRtWqVdGjx3uoW7c+9u8/IDoakcWwtbVFcHAQF/GTxWEZIypAb73li7VrV2PHjm1Qq9UID2+GVq3awGA4JjoakUWQJInbW5DFYRkjKgS1atXE3r27sXz5Upw7dw41atREnz4f4MKFC6KjEZk1WZZw+fJlXLp0SXQUogLDMkZUSFQqFVq1aon4+FjMmjUDO3fuQkBAMEaOHIWbN2+KjkdklnQ6HQBw3RhZFJYxokJWrFgx9OnTGwZDMoYMGYTIyEXQagMxc+ZXuH//vuh4RGbFw6MMvLy8WMbIorCMERURZ2dnjBw5AgaDHh06tMP48RMQGBiCpUuXIzs7W3Q8IrMhyzou4ieLwjJGVMRKl34ds2bNREJCLCRJh759P0SNGrWwffsO3oic6AVIkoSkpGTu6UcWg2WMSBBvb28sW7YE+/btRokSrmjbtj3Cw5shISFBdDQiRZMkHR48eIBjx3iVMlkGljEiwSRJwvbtW7Fu3Wpcv34DderUR/fuPXH27FnR0YgUKSAgAMWKFeMWF2QxWMaIFEClUqFp06aIiTmMBQu+xtGjMQgOljB48BBcu3ZddDwiRXFwcEBAgD8X8ZPFYBkjUhC1Wo3u3btBr0/EmDGjsXLlKmi1AZg8eQru3r0rOh6RYjze/JVljCwDyxiRAr322msYPHggDIZkvPdeT0ydOh1abSAiIxfh4cOHouMRCSfLEs6e/Q03bqSJjkL0yljGiBTMzc0NU6Z8geTkBDRoUB8REYMgSaHYtOknXnlJVk2WJQBAfDyPjpH5YxkjMgPly5fHokXfITr6IMqXL48uXbqhYcNGOHz4iOhoREKUL18e7u7uXDdGFoFljMiMBAT4Y9OmDdi8+SdkZmahUaMm6NChE06c+FV0NKIipVKpIEk6xMbyikoyfyxjRGaofv16OHhwH6KiFuGXX45DlqujX78BuHz5sthgREVIliUkJCQgJydHdBSiV6L4MpaZmQmj0WjyQUSAjY0NOnRoj8TEOEyZ8gV+/vln+PsHYezY8UhPTxcdj6jQSZIEo9GIkydPiY5C9EpUuQpfBTxu3DiMHz8+3+Pp6enQaDQCEhEpU3p6OqZNm4aZM2fC0dERo0aNwocffgh7e3vR0YgKxZ07d+Di4oLIyEj06tVLdByyEkajES4uLgXaQxRfxjIzM5GZmZn3udFohKenJ1JTL7KM/YWjozMyMu6IjqEY1jyP1NRUTJo0GYsXL4GXlxfGjBmFHj3ew4MH90RHUwxr/v14GnOehyzXgCxLmDdvToG9pjnPo7BwJn8yGo3w8ChXoGVM8acp7e3todFoTD6I6Nk8PDwwb94cxMXFwM/vLfTq1RuSJGHPnr2ioxEVOFmWeEUlmT3FlzEi+neqVq2CVatWYufOHbC3t0fz5i3RokUr6PUpoqMRFRhJknD8+HHcucOjNmS+WMaILFxYWA1ER0dj5crluHDhAsLCaqFXr974/fffRUcjemWSpENubi4SEhJFRyH611jGiKyASqVCixbNERcXg7lzZ2Pfvv0IDAzBsGEjkJbG28mQ+apatQo0Gg3i4rjfGJkvljEiK2Jra4tevd6DwZCM4cOHYvHiJdBqAzF9+kzcv39fdDyil2ZjY4OQkBDeNJzMGssYkRVycnLCsGFDYTDo0aVLJ3z++ST4+wdh8eKlyM7OFh2P6KXIsg6xsXG8XyuZLZYxIivm7l4K06dPQ2JiHMLCquOjj/ohNDQM27Zt419sZDZkWcL169e5DpLMFssYEaFixYpYvPgHHDy4D+7u7mjXriOaNg3nqR8yCzqdBADc4oLMFssYEeUJDg7G1q0/Y/36tbh16zbq1WuIrl3fxenTp0VHI3qmUqXcULFiBZYxMlssY0RkQqVSoUmTxjhy5BAWLvwG8fEJCAmRERExEFevXhMdj+ipJEnikVwyWyxjRPRUarUaXbt2gV6fiAkTxmPt2nXQagMwadIX3GCTFEeWJaSkGExun0dkLljGiOgfOTg4ICLiYxgMevTp0xszZsyCVhuIhQu/w8OHD/Oet3Dhd/D11aJkSXfUrFkH0dGHn/maBw4chJOTJt/HyZOn8p7TtGn4U5/Tpk27Qn2/ZJ5kWUJWVhb0er3oKEQvjWWMiF5IiRIlMGnSROj1iWjSpDEGDRoCnU7Ghg0bsWbNWgwdOhxDhw7B4cOHEBZWA61bt8WFCxf+8TWTkxNw9uzpvA9v70p5X1uxYpnJ1+LiYqBWq9G6devCfqtkhvz8/ODg4MB1Y2SWWMaI6KV4enri228X4OjRw6hUqRK6deuOfv36o3HjRujZsweqVq2CadO+RLlyZfHdd4v+8bXc3d1RpkzpvA+1Wp33tZIlS5p8bc+ePXB0dESbNq0K+R2SObKzs0NQUCDXjZFZYhkjon/Fz+8trF+/Fj/9tBH37mVgy5ataNu2PX755TgAoEGDBoiJifnH1wgLq42KFSsjPLw59u8/8I/PXbx4Kdq1awsnJ6cCew9kWSRJQmwsb4tE5odljIheia9vNQDA6NGf4dSpU6hePQx9+34EBwcHXL169anfU6ZMGcybNwfLly/FypXL4OPjjXfeaY5Dh6Kf+vz4+HgcP34cPXt2L7T3QeZPknQ4f/48UlOviI5C9FJsRQcgIstQv349DBo0EN9/H4XJk7/E7du34ezsjNu3b8PV1dXkuT4+leHjUznv89DQUFy8eAmzZ89BrVo187324sVL4evrC51OV7hvgsyaLD/e/DU+Ph7NmzcTnIboxfHIGBG9Ejc3N6jValy9eg12dnbo2/cDGAzJCAgIQHp6OrTaAMyZM++5Ww7IsoSzZ8/mezwjIwNr167jUTF6rrJly8LDwwNxcTxVSeaFZYyIXsmThdN79uzJe0yj0eDevbv4v//rgzZt2mDUqNEIDAzBihUrkZOT89TX0etTULp0mXyPr1u3AZmZmejUqWOhvQeyDCqVCrLMzV/J/PA0JRG9sgED+qN37/9DUFAwQkNlfP99FC5cuIhPPhkALy8vZGdnY+fOXejT5wPMmTMPkqRDo0Zvw9e3GrKyHuLHH1dh48ZNWLFiWb7XXrJkCZo3fwdubm4C3hmZG0mSMHnyFDx69Ai2tvwrjswDf1OJ6JW1a9cWN2/exJQpX+LKlSvw9fXF+vVr4eXlBQDIyspChQpvYsmSKIwaNQbffx+Vd5TMyckR1apVw7p1a9C0aROT1z19+jQOHz6Cn37aKOBdkTmSZQn37t3D8eMn4O+vFR2H6IWocnNzc0WHeBlGoxEuLi5ITb0IjUYjOo5iODo6IyODt6h5gvMwpaR55ObmYtu27RgzZixOnPgV7du3w9ixo1GhQoUiy6CkeSiBJc0jIyMDZcqUxaxZM/D++73+1WtY0jwKCmfyJ6PRCA+PckhPTy+wHsI1Y0RUpFQqFcLD/4OjRw/j66/n4dChaAQF6fDpp8Nw40aa6Hhk5hwdHeHn58ed+MmssIwRkRC2trbo0aM7UlKS8NlnI7Fs2XJotQGYNm06MjIyRMcjMybLOi7iJ7PCMkZEQjk6OuLTTwfDYNDj3Xe7YdKkydBqAxEV9QMePXokOh6ZIUmScPLkKdy+fVt0FKIXwjJGRIpQqpQbpk6dguTkBNSpUxv9+3+M0NAa2Lx5C8xsaSsJ9ufmrwmCkxC9GJYxIlKUN998E1FRi3Do0AF4eLyBjh07o1GjJjh69J/vc0n0hLe3N0qUcOWpSjIbLGNEpEhBQYHYvHlT3o3IGzZshM6du+LkyVOio5HCqVSqP24azjJG5oFljIgUrWHDBoiOPoBFi75DcrIekhSKAQM+4c2g6R892Ymfp7jJHLCMEZHi2djYoFOnjkhOTsCkSROxceNG+PsHYsKEiTAajaLjkQLpdDrcunUbZ86cER2F6LlYxojIbNjb22PAgP4wGPT48MO+mD17LrTaQCxY8A2ysrJExyMF0elCAICnKskssIwRkdlxdXXFhAnjkJKShPDw/2Do0OEICZGwdu26Z96InKxLiRIlUKWKD+Lj40VHIXouljEiMltly5bFggXzERNzBFWrVkWPHu+hbt362L//gOhopACPF/GzjJHysYwRkdnz9a2GNWtWYceObVCr1QgPb4ZWrdrAYDgmOhoJJMsSDAYD7+hAiscyRkQWo1atmti7dzeWL1+Kc+fOoUaNmujT5wNcuHBBdDQSQJIkZGdnIykpWXQUon/EMkZEFkWlUqFVq5aIj4/FrFkzsGvXbgQEBGPkyFG4efOm6HhUhHx9q8HJyYmL+EnxWMaIyCIVK1YMffr0hsGQjCFDBiEychG02kDMmjUbDx48EB2PioCtrS2Cg4O4Ez8pHssYEVm04sWLY+TIETAY9OjQoR3GjRsPHx8fLFu2HNnZ2aLjUSHjTvxkDljGiMgqlC79OmbNmomEhFhUr14dH3zwIWrUqIXt23dwl3YLJssSUlNTcenSJdFRiJ6JZYyIrIq3tzdWr16N/fv3oGTJEmjbtj3Cw5shISFBdDQqBDqdDgA3fyVlYxkjIquk0+mwbdsWrFu3Gtev30CdOvXRvXtPnD17VnQ0KkAeHmXg5eXFMkaKxjJGRFZLpVKhadOmiIk5jAULvsbRozEIDpYwePAQXLt2XXQ8KiCyrOMiflI0ljEisnpqtRrdu3eDXp+IMWNGY+XKVdBqAzB58hTcvXtXdDx6RTqdDklJybx/KSkWyxgR0R9ee+01DB48EAZDMnr1eg9Tp06HVhuIyMhFePjwoeh49C/JsoQHDx7g2DHekYGUiWWMiOhv3NzcMHnyJOj1iWjYsAEiIgZBkkKxadNPvPLSDAUEBKBYsWJcN0aKxTJGRPQMXl5eiIxciMOHD6F8+fLo0qUbGjZshMOHj4iORi/BwcEBAQH+iIvjTcNJmVjGiIiew99fi02bNmDz5p+QmZmFRo2aoEOHTjhx4lfR0egFSZLERfykWCxjREQvqH79ejh4cB+iohbhl1+OQ5aro1+/Abh8+bLYYPRcsizh7NnfcONGmugoRPmwjBERvQQbGxt06NAeiYlxmDLlC/z888/w9w/C2LHjkZ6eLjoePYMsSwCA+HgeHSPlYRkjIvoX7O3t0a/fRzAY9BgwoB/mz/8aWm0A5s2bj8zMTNHx6G/Kly+PUqVKcRE/KRLLGBHRK3BxccHYsWNgMCSjRYsWGDHiMwQF6bBq1Wrk5OSIjkd/UKlUkGUJsbFcxE/KwzJGRFQAPDw8MG/eHMTFxUCr9UOvXr1Ru3Y97NmzV3Q0+oMsS0hISGBJJsVhGSMiKkBVq1bBqlUrsXPnDtjb26F585Zo0aIV9PoU0dGsniRJMBqNOHnylOgoRCZYxoiICkFYWA3s3r0TK1cux4ULFxAWVgu9evXG77//Ljqa1QoJCYZKpeK6MVIcljEiokKiUqnQokVzxMXFYO7c2di3bz8CA0MwbNgIpKVxi4Wi5uzsDF9fX+43RorDMkZEVMhsbW3Rq9d7MBiSMXz4UCxevARabSCmT5+J+/fvi45nVR4v4mcZI2VhGSMiKiJOTk4YNmwoDAY9unTphM8/nwR//yAsXrwE2dnZouNZBUnS4fjx47hz547oKER5WMaIiIqYu3spTJ8+DYmJcQgLq46PPuqP0NAa2LZtG29EXsgkSUJubi4SEhJFRyHKwzJGRCRIxYoVsXjxDzhwYC/c3V9Hu3Yd0bRpONc0FaKqVatAo9FwxqQoLGNERIKFhIRg69afsX79Wty6dRv16jVE167v4vTp06KjWRwbGxuEhIQgLo6bv5JysIwRESmASqVCkyaNceTIISxc+A3i4xMQEiIjImIgrl69JjqeRZFlHWJj43hKmBSDZYyISEHUajW6du0CvT4REyaMx9q166DVBmDSpC+46LyAyLKE69evc883UgyWMSIiBXJwcEBExMcwGPTo06c3ZsyYBa02EN9+uxAPHz4UHc+s6XQSAHCLC1IMljEiIgUrUaIEJk2aCL0+EY0bN8LgwZ8iJETC+vUbeJrtXypVyg0VK1ZgGSPFYBkjIjIDnp6eWLjwGxw5Eo1KlSrh3Xd7oF69Bjh48JDoaGZJkiReUUmKofgylpmZCaPRaPJBRGSttFo/bNiwDlu3bkZubi6aNg1H27bt8csvx0VHMyuyLEGvT8GDBw9ERyGCKlfhx7nHjRuH8ePH53s8PT0dGo1GQCIiImXIzc3FmjVrMHLkSJw7dw49evTAhAkTUK5cOdHRFC8+Ph6SJOHw4cOoUaOG6DhkRoxGI1xcXAq0hyi+jGVmZiIzMzPvc6PRCE9PT6SmXmQZ+wtHR2dkZPBKqyc4D1OchylLm0dWVha+/z4Kkyd/ibt37+LDD/tiyJBBcHV1faHvt7R5vIisrCx4eJTD+PFj0b9/P5OvWeM8nocz+ZPRaISHR7kCLWOKP01pb28PjUZj8kFERH+ys7ND374fwGBIRkTEx/j224Xw8/PH7NlzeRruGezs7BAUFMh1Y6QIii9jRET0YjQaDUaPHoWUlGS0adMGo0ePQWBgCFasWImcnBzR8RRHp9MhNpY78ZN4LGNERBbGw6MM5sz5CvHxsQgODkKfPh8gLKw2du7cxe0w/kKWJZw/fx6pqVdERyErxzJGRGShfHwqY8WKZdizZyecnYujVas2aNasJZKSkkRHUwRZfrz5a3w8j46RWCxjREQWLjQ0FP/973asXv0jrlxJRa1addGzZy+cO3dOdDShypYtCw8PD27+SsKxjBERWQGVSoV33glHTMwRzJ8/F4cORSMoSIchQ4bi+vXrouMJoVKpIMvc/JXEYxkjIrIitra26NmzB1JSkvDZZyOxfPkKVKpUCVOnTsO9e/dExytykiQhMTEJjx49Eh2FrBjLGBGRFXJ0dMSnnw6GwaDH+++/jy++mAJ//yBERf1gVcVEliXcu3cPx4+fEB2FrBjLGBGRFStVyg2zZs1CUlI86tSpjf79P4YsV8fPP2+2iisvg4ICoVareaqShGIZIyIiVKhQAVFRi3Do0AG88UZZdOrUBY0aNcHRozGioxUqR0dH+Pn5cRE/CcUyRkREeYKCArF58yZs2rQB9+5loGHDRujcuStOnjwlOlqhkWUdj4yRUCxjRESUz9tvN0R09AFERi5EcrIekhSKAQM+scgNUiVJwsmTp3Dr1i3RUchKsYwREdFT2djYoHPnTkhOTsCkSROxceNG+PsHYsKEiTAajaLjFZg/N39NEJyErBXLGBER/SN7e3sMGNAfBoMeH37YF7Nnz4VWG4AFC75BVlaW6HivzNvbGyVKuHInfhKGZYyIiF6Iq6srJkwYh5SUJISHh2Po0OEIDtZhzZq1Zn0jcpVKBUmSuIifhGEZIyKil1K2bFksWDAfR48eRtWqVdGzZy/UqVMf+/btFx3tX5Okx4v4rWE7D1IeljEiIvpX3nrLF2vXrsaOHdtga6vGO+80R6tWbWAwHBMd7aVJkoRbt27jzJkzyM3NRXKyXnQksiIsY0RE9Epq1aqJvXt3Y/nypTh37hxq1KiJPn0+wIULF0RHe66HDx/i0aNH0OlCAACxsXHYtWsXatasjRs30gSnI2vBMkZERK9MpVKhVauWiI+PxaxZM7Br124EBARj5MhRuHnzpuh4zzR58hRUr14TarUaVar4IC4uDjt37kTp0qXh5lZSdDyyEixjRERUYIoVK4Y+fXrDYEjGkCGDEBm5CFptIGbO/Ar3798XHS+fTp064dKlS+jd+/+g0+kQGxuPvXv3om7dOlCpVKLjkZVgGSMiogJXvHhxjBw5AgaDHh06tMP48RMQGBiCpUuXIzs7W3S8PD4+lREVFYmtW7chLS0NBoMBiYmJqFu3juhoZEVYxoiIqNCULv06Zs2aiYSEWEiSDn37fogaNWph+/YdirlysWnTphg7djS2b9+BnJwc5OTkoE6d2qJjkRVhGSMiokLn7e2NZcuWYN++3ShRwhVt27ZHeHgzJCQoY9f7IUMGo2XLFgAe76dWoUIFwYnImrCMERFRkZEkCdu3b8W6datx/foN1KlTH92798TZs2eF5lKpVFi48Bu4urqiSpUqXC9GRYpljIiIipRKpULTpk0RE3MYCxZ8jaNHYxAcLGHw4CG4du26sFzFixfH+fPncPjwYWEZyDqxjBERkRBqtRrdu3eDXp+IMWNGY+XKVdBqAzB58hTcvXtXWCYbG/7VSEWLv3FERCTUa6+9hsGDB8JgSMZ77/XE1KnTodUGIjJyER4+fCg6HlGhYxkjIiJFcHNzw5QpXyA5OQENGtRHRMQgSFIoNm36STFXXhIVBpYxIiJSlPLly2PRou8QHX0Q5cuXR5cu3dCgwduIjj6M//53J95+uzHeeMMTnp7l0bZte5w6dSrvey9duoQePXqiXDkvuLuXQa1adREXF4dTp07DyUmDkydPmfysOXPmoVo1P5Y9EopljIiIFCkgwB+bNm3A5s0/ISvrIRo3boqJEz9H69atceDAXmze/DPu37+PkBAZcXHxuHv3Lpo0+Q9SU69g9epVOHo0GgMHfoKcnBz4+FRGUFAQVq1aZfIzVq9egw4d2vPqSRKKZYyIiBStfv16OHhwH6KiFuHmzVsYPnwEZs78Cu7upRAZ+R1ycnLQvXtPLF26DDdupOHHH1cgLKwGKlWqhLZt2yA0NBQA0LFje6xevSbvdU+fPo2kpCR06tRRxNsiysMyRkREimdjY4MOHdpj3brV8PfXYunSZahcuSp8ff0AAFeuXMGiRd8jIMAfJUs+/Qbf7dq1w/nzFxAbGwsAWLVqNfz9/VGtWtUiex9ET8MyRkREZqNr13fh5uaGlSuXo1ev9/K2oQgMDMSJE7/i5s2bz/xeD48yqFOnTt7RsTVr1vKoGCkCyxgREZmFtLQ0/PrrSQwbNhShoaHo06c3Jk+eBACIjY2Fra0tjh8/gZMnTz7zNTp27IC1a9cjJiYGv/12Du3bty2q+ETPpMo1s0tIjEYjXFxckJp6ERqNRnQcxXB0dEZGxh3RMRSD8zDFeZjiPEyZyzxycnLw5psV0ahRI6SkpOD48RNPfZ6zszM2bFiHMmVKQ69PgYdHmbx1Y0ajERUqeKNy5cpwc3PDli0/5ft+c5lHUeJM/mQ0GuHhUQ7p6ekF1kN4ZIyIiMyCjY0NfvghCsnJyThz5iwqVqyIadO+BAAMGTIIixdHoV+/DxEQEIA2bdpBlmtgxoyZUKvVea+h0WgQHv4fGAwGdOzYQdRbITLBI2MWgv9qMcV5mOI8THEepjgPU5xHfpzJn3hkjIiIiMjCsIwRERERCcQyRkRERCQQyxgRERGRQLaiAxARESlVdk4uEs6n4/rdLLgXt0OIlwvUNryPJRUsljEiIqKn2HniBr7YcQZXjVl5j5XW2GFkE280qlZKYDKyNDxNSURE9Dd7T6YhYs1xkyIGANeMWYhYcxw7T9wQlIwsEcsYERHR38zY/Ruetgnnk8cm7ziL7Byz2qaTFIxljIiI6G+u3Xn4zK/lArhizETC+fSiC0QWjWWMiIjoX7h+N+v5TyJ6ASxjRERE/4J7cTvREchCsIwRERH9zevOxfCsDSxUAMpo7BHi5VKUkciCsYwRERH9zeCGFQEgXyF78vmIJpW43xgVGJYxIiKiv6lfxQ1ftffF6xrTU5GlNfb4qr0v9xmjAsVNX4mIiJ6iUbVSaFDFjTvwU6FjGSMiInoGtY0K8puuomOQheNpSiIiIiKBWMaIiIiIBGIZIyIiIhKIZYyIiIhIIJYxIiIiIoFYxoiIiIgEYhkjIiIiEohljIiIiEggljEiIiIigVjGiIiIiARiGSMiIiISiGWMiIiISCDF3yg8MzMTmZmZeZ8bjUaBaYiIiIgKlio3NzdXdIh/Mm7cOIwfPz7f4+np6dBoNAISERERkbUyGo1wcXEp0B6i+DL2tCNjnp6eSE29yDL2F46OzsjIuCM6hmJwHqY4D1OchynOwxTnkR9n8iej0QgPj3IFWsYUf5rS3t4e9vb2omMQERERFQou4CciIiISiGWMiIiISCCWMSIiIiKBWMaIiIiIBGIZIyIiIhKIZYyIiIhIIJYxIiIiIoFYxoiIiIgEYhkjIiIiEohljIiIiEggljEiIiIigVjGiIiIiARiGSMiIiISiGWMiIiISCCWMSIiIiKBWMaIiIiIBGIZIyIiIhKIZYyIiIhIIJYxIiIiIoFYxoiIiIgEYhkjIiIiEohljIiIiEggljEiIiIigVjGiIiIiARiGSMiIiISiGWMiIiISCCWMSIiIiKBWMaIiIiIBGIZIyIiIhKIZYyIiIhIIJYxIiIiIoFsRQd4Wbm5uQCAO3fuCE6iLI8e5SIjgzN5gvMwxXmY4jxMcR6mOI/8OJM/PekfT/pIQTC7MpaWlgYA8PGpJjgJERERWau0tDS4uLgUyGuZXRkrWbIkAOD8+fMFNgRzZzQa4enpiQsXLkCj0YiOIxznYYrzMMV5mOI8THEe+XEmptLT0+Hl5ZXXRwqC2ZUxG5vHy9xcXFz4S/E3Go2GM/kLzsMU52GK8zDFeZjiPPLjTEw96SMF8loF9kpERERE9NJYxoiIiIgEMrsyZm9vj7Fjx8Le3l50FMXgTExxHqY4D1OchynOwxTnkR9nYqow5qHKLchrM4mIiIjopZjdkTEiIiIiS8IyRkRERCQQyxgRERGRQCxjRERERAKxjBEREREJxDJGREREJBDLGBEREZFALGNEREREAv0/9Thd2lW3W+gAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABMMAAAGbCAYAAADJDFcGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8o6BhiAAAACXBIWXMAAA9hAAAPYQGoP6dpAABqu0lEQVR4nO3dd3gU9drG8XuTkJ4QQpEeepPeBFECIoJ0VI4UqTYQVBQb0oIooCKKHiugCCgooBwEpRzaQSkGkSJN6Shw6ARCTfJ7/+DNHpZNIBt3s5vZ7+e6cmmm7TOzc89kH2Z2bMYYIwAAAAAAAMAPBHi7AAAAAAAAACCn0AwDAAAAAACA36AZBgAAAAAAAL9BMwwAAAAAAAB+g2YYAAAAAAAA/AbNMAAAAAAAAPgNmmEAAAAAAADwGzTDAAAAAAAA4DdohgEAAAAAAMBv0AwDkGtMmTJFNpst058VK1Z4u0S3KFWqlHr16uXtMjJ0+fJl9e3bV0WKFFFgYKBq1qzp7ZKc7Nu3TzabTVOmTPF2KZKk1atXKyEhQadPn3Ya16RJEzVp0iTHa7per169fKIOX5aQkCCbzebtMv6Wr776SrfeeqvCwsJks9m0ceNGb5fkFitWrMiV5wCbzaaEhAT77+nnuH379rm0nNGjR2vu3LlurS03WLVqlUJCQrR//377sCZNmqhq1ao3nO+bb75Rly5dVK5cOYWFhalUqVLq1q2b/vjjD0+XnON+//13BQcHa8OGDd4uBQB8TpC3CwAAV3322WeqVKmS0/AqVap4oRr/8uGHH+rjjz/We++9pzp16igyMtLbJfm81atXa+TIkerVq5diYmIcxn3wwQfeKQoue+SRR9SyZUtvl5Ftx44dU/fu3dWyZUt98MEHCgkJUYUKFbxdllvUrl1ba9asyfXngNatW2vNmjUqUqSIS/ONHj1aDzzwgDp06OCZwnyQMUYDBw7Uo48+qri4OJfmff3111W4cGENGTJEZcqU0cGDBzV69GjVrl1ba9eu1a233uqhqnNehQoV1K1bNz3zzDNauXKlt8sBAJ9CMwxArlO1alXVrVvX22X4pd9++01hYWEaMGCAt0uxhNz+4d0fnD9/XuHh4SpevLiKFy/u7XKy7ffff9eVK1f00EMPKT4+3i3LTN823nLlyhXZbDZFR0erQYMGXqvDXQoWLKiCBQt6u4xcYeHChdqwYYO+/PJLl+f97rvvVKhQIYdhd911l0qVKqW3335bkyZNcleZ2ZaamqqUlBSFhIT87WUNGDBAdevW1erVq3X77be7oToAsAZukwRgOTNnzpTNZtM///lPh+EjRoxQYGCglixZYh82cuRI3XbbbYqNjVV0dLRq166tyZMnyxjjMG+pUqXUpk0bzZ8/X7Vq1VJYWJgqV66s+fPnS7p6e0vlypUVERGh+vXra/369Q7z9+rVS5GRkdq6dauaNWumiIgIFSxYUAMGDND58+dvuk5JSUl67rnnVLp0aQUHB6tYsWIaOHCgkpOTHaabNWuWbrvtNuXNm1fh4eEqU6aM+vTpc9PlX7x4UYMHD3ZYfv/+/R1u7bPZbJo0aZIuXLhgvzX1Zrci/vvf/1azZs0UHR2t8PBwNWrUSEuXLrWP/+OPPxQdHa1OnTo5zLds2TIFBgZq2LBh9mHp78G3336r6tWrKzQ0VGXKlNG777570/XbtWuXevfurfLlyys8PFzFihVT27ZttWXLFofp0m+3mjFjhoYMGaKiRYsqOjpad999t3bu3Okw7ZIlS9S+fXsVL15coaGhKleunB5//HEdP37cPk1CQoKef/55SVLp0qWdbunN6DbJkydP6oknnlCxYsUUHBysMmXKaMiQIbp06ZLDdDabTQMGDNC0adNUuXJlhYeHq0aNGvZ9Mt2xY8f02GOPqUSJEgoJCVHBggXVqFEj/fvf/77pdsvIl19+qYYNGyoyMlKRkZGqWbOmJk+e7DDNp59+qho1aig0NFSxsbHq2LGjtm/f7jBNeiZ27NihFi1aKCIiQkWKFNHYsWMlSWvXrtUdd9yhiIgIVahQQZ9//rnD/Om3lC1ZskS9e/dWbGysIiIi1LZtW+3Zs8dh2qy8V9L/boXcsGGDHnjgAeXLl09ly5Z1GHetZcuWqUmTJsqfP7/CwsJUsmRJ3X///Q6Z9oX3s1evXrrjjjskSQ8++KBsNpvDfjdv3jw1bNhQ4eHhioqKUvPmzbVmzZosb5vrbdq0STabzWm/kKQffvhBNptN8+bNk+R6NqdNm6ZBgwapWLFiCgkJ0a5duzK9TTIr69WrVy+VKlXKqc6M3u/sHl+TkpL06KOPKn/+/IqMjFTLli31+++/O02X0W2Sv/76q9q0aaNChQopJCRERYsWVevWrfXnn39KurrfJCcn6/PPP7cfX9Lf22PHjumJJ55QlSpVFBkZqUKFCumuu+7SqlWrHF43/dbycePGafz48SpdurQiIyPVsGFDrV271qnOdevWqW3btsqfP79CQ0NVtmxZDRw40GGaP/74Q127drXXXblyZb3//vsO06SlpenVV19VxYoVFRYWppiYGFWvXl0TJky46Tb98MMPVa9ePVWsWPGm017v+kaYJBUtWlTFixfXwYMHbzp/+q2YiYmJuvPOO+37wtixY5WWluYw7YEDB/TQQw85bIe33nrLYbr07f/GG2/o1VdfVenSpRUSEqLly5fb98PNmzerU6dOyps3r2JjY/Xss88qJSVFO3fuVMuWLRUVFaVSpUrpjTfecKq3Tp06qly5sj766COXtxUAWJoBgFzis88+M5LM2rVrzZUrVxx+UlJSHKbt27evCQ4ONomJicYYY5YuXWoCAgLM0KFDHabr1auXmTx5slmyZIlZsmSJGTVqlAkLCzMjR450mC4uLs4UL17cVK1a1cyYMcN8//335rbbbjN58uQxw4cPN40aNTLffPON+fbbb02FChXMLbfcYs6fP2+fv2fPniY4ONiULFnSvPbaa2bx4sUmISHBBAUFmTZt2ji9Vs+ePe2/Jycnm5o1a5oCBQqY8ePHm3//+99mwoQJJm/evOauu+4yaWlpxhhjVq9ebWw2m+ncubP5/vvvzbJly8xnn31munfvfsPtmpaWZlq0aGGCgoLMsGHDzOLFi824ceNMRESEqVWrlrl48aIxxpg1a9aYVq1ambCwMLNmzRqzZs0ac/To0UyXO23aNGOz2UyHDh3MN998Y7777jvTpk0bExgYaP7973/bp5s5c6aRZCZMmGCMMebw4cPmlltuMfHx8Q7va1xcnClWrJgpWbKk+fTTT833339vunXrZiSZN9980z7d3r17jSTz2Wef2YetXLnSDBo0yMyePdusXLnSfPvtt6ZDhw4mLCzM7Nixwz7d8uXLjSRTqlQp061bN7NgwQIzY8YMU7JkSVO+fHmHej788EMzZswYM2/ePLNy5Urz+eefmxo1apiKFSuay5cvG2OMOXjwoHnyySeNJPPNN9/Yt9uZM2eMMcbEx8eb+Ph4+zIvXLhgqlevbiIiIsy4cePM4sWLzbBhw0xQUJBp1aqVw/ZNr7N+/frm66+/Nt9//71p0qSJCQoKMrt377ZP16JFC1OwYEHzySefmBUrVpi5c+ea4cOHm5kzZ2a+U2Ri2LBhRpK57777zKxZs8zixYvN+PHjzbBhw+zTjB492kgyXbp0MQsWLDBTp041ZcqUMXnz5jW///67fbr0TFSuXNlMmDDBLFmyxPTu3dtIMoMHDzYVKlQwkydPNosWLTJt2rQxksz69evt86cfD0qUKGH69OljfvjhB/PJJ5+YQoUKmRIlSphTp0659F4ZY8yIESOMJBMXF2defPFFs2TJEjN37lyHcen27t1rQkNDTfPmzc3cuXPNihUrzBdffGG6d+9uf21feT937dpl3n//fSPJjB492qxZs8Zs3brVGGPMF198YSSZe+65x8ydO9d89dVXpk6dOiY4ONisWrUqS9smI7Vq1TKNGjVyGv6Pf/zDFCpUyFy5csUY43o2ixUrZh544AEzb948M3/+fHPixAn7uOXLl9unz+p69ezZ08TFxTnVef37/XeOr02bNjUhISH2Y/+IESNMmTJljCQzYsQI+7Tp+/TevXuNMcacO3fO5M+f39StW9d8/fXXZuXKlearr74yffv2Ndu2bTPGXD0uh4WFmVatWtmPL+nv7Y4dO0y/fv3MzJkzzYoVK8z8+fPNww8/bAICAhy2Vfoxs1SpUqZly5Zm7ty5Zu7cuaZatWomX7585vTp0/ZpFy5caPLkyWOqV69upkyZYpYtW2Y+/fRT07lzZ/s0W7duNXnz5jXVqlUzU6dONYsXLzaDBg0yAQEBJiEhwT7dmDFjTGBgoBkxYoRZunSpWbhwoXnnnXccpsnIpUuXTFhYmHnhhRecxsXHx5tbb731hvNnZPfu3SYgIMA888wzN502Pj7e5M+f35QvX9589NFHZsmSJeaJJ54wksznn39un+7o0aOmWLFipmDBguajjz4yCxcuNAMGDDCSTL9+/ezTpW//YsWKmaZNm5rZs2ebxYsXm71799r3w4oVK5pRo0aZJUuWmBdeeMFIMgMGDDCVKlUy7777rsPxc86cOU419+vXzxQoUMD+9wIAwBiaYQByjfQPChn9BAYGOkx78eJFU6tWLVO6dGmzbdu2DJsr10tNTTVXrlwxr7zyismfP7/DH41xcXEmLCzM/Pnnn/ZhGzduNJJMkSJFTHJysn343LlzjSQzb948+7CePXs6NHzSvfbaa0aS+fHHHx1e69pm2JgxY0xAQIC9sZdu9uzZRpL5/vvvjTHGjBs3zkhy+OCSFQsXLjSSzBtvvOEw/KuvvjKSzCeffOKwHhERETddZnJysomNjTVt27Z1GJ6ammpq1Khh6tev7zC8X79+Jjg42KxZs8bcddddplChQubQoUMO08TFxRmbzWY2btzoMLx58+YmOjra/h5k1Ay7XkpKirl8+bIpX768w4ef9A/V1zcqvv76ayPJrFmzJsPlpaWlmStXrpj9+/cbSeZf//qXfdybb77p8AH3Wtc3wz766CMjyXz99dcO073++utGklm8eLF9mCRzyy23mKSkJPuwI0eOmICAADNmzBj7sMjISDNw4MBMt0VW7dmzxwQGBppu3bplOs2pU6fsH8yvdeDAARMSEmK6du1qH5aeiWs/uF25csUULFjQSDIbNmywDz9x4oQJDAw0zz77rH1Y+vGgY8eODq/1008/GUnm1VdfzbDGG71X6R88hw8f7jTf9c2R9Pxdvz9ey5fez/R9e9asWfZhqamppmjRoqZatWomNTXVPvzs2bOmUKFC5vbbb7cPu9G2yci7775rJJmdO3fah508edKEhISYQYMGZTrfzbLZuHHjTNctvcHjynpltRmW3ePrDz/8cMNj/42aYevXrzeSbth0NMaYiIgIh3NGZlJSUsyVK1dMs2bNHHKTfsysVq2awzny559/NpLMjBkz7MPKli1rypYtay5cuJDp67Ro0cIUL17c3vRPN2DAABMaGmpOnjxpjDGmTZs2pmbNmjet+3rr1q0zkjJsAGenGXblyhXTpEkTEx0dbQ4cOHDT6ePj440ks27dOofhVapUMS1atLD//tJLL2U4Xb9+/YzNZrNnI337ly1b1qE5b8z/9sO33nrLYXjNmjXt/8hy7XoULFjQ3HfffU41T5w40Ugy27dvv+n6AYC/4DZJALnO1KlTlZiY6PCzbt06h2lCQkL09ddf68SJE6pdu7aMMZoxY4YCAwMdplu2bJnuvvtu5c2bV4GBgcqTJ4+GDx+uEydO6OjRow7T1qxZU8WKFbP/XrlyZUlXb5m49ntz0odf+4SrdN26dXP4vWvXrpKk5cuXZ7q+8+fPV9WqVVWzZk2lpKTYf1q0aOFwa1C9evUkSf/4xz/09ddf66+//sp0mddvA0lOT7Ds1KmTIiIiHG5rzKrVq1fr5MmT6tmzp0PNaWlpatmypRITEx1u8Xz77bd16623qmnTplqxYoWmT5+e4ZdI33rrrapRo4bDsK5duyopKemGT8tKSUnR6NGjVaVKFQUHBysoKEjBwcH6448/nG7fk6R27do5/F69enVJju/p0aNH1bdvX5UoUUJBQUHKkyeP/YucM1pmVixbtkwRERF64IEHHIanvzfXvxdNmzZVVFSU/fdbbrlFhQoVcqizfv36mjJlil599VWtXbtWV65cyVZtS5YsUWpqqvr375/pNGvWrNGFCxec9qUSJUrorrvucqrfZrOpVatW9t+DgoJUrlw5FSlSRLVq1bIPj42NdVqvdNdn6vbbb1dcXJxDplx9r+6///5M1zFdzZo1FRwcrMcee0yff/65062Zkm+/n5K0c+dOHTp0SN27d1dAwP/+JIyMjNT999+vtWvXOt3GnZVtI119X0JCQhxupZ4xY4YuXbqk3r1724e5ms2svH521utmsnt8Td8PMzv230i5cuWUL18+vfjii/roo4+0bds2l2qWpI8++ki1a9dWaGiofd9funRphtu2devWDufI6497v//+u3bv3q2HH35YoaGhGb7exYsXtXTpUnXs2FHh4eEOx/9WrVrp4sWL9lsv69evr02bNumJJ57QokWLlJSUlKV1OnTokKSMb3d0lTFGDz/8sFatWqWpU6eqRIkSWZqvcOHCql+/vsOw6tWrO2R12bJlqlKlitN0vXr1kjHGfu5N165dO+XJkyfD12vTpo3D75UrV5bNZtO9995rH5Z+/MzoOJm+rbK63wKAP6AZBiDXqVy5surWrevwU6dOHafpypUrpzvvvFMXL15Ut27dnJorP//8s+655x5J0sSJE/XTTz8pMTFRQ4YMkSRduHDBYfrY2FiH34ODg284/OLFiw7Dg4KClD9/fodhhQsXliSdOHEi0/X973//q82bNytPnjwOP1FRUTLG2L/3qHHjxpo7d65SUlLUo0cPFS9eXFWrVtWMGTMyXXb6awcFBTl9cbPNZlPhwoVvWNuNapakBx54wKnu119/XcYYnTx50j59SEiIunbtqosXL6pmzZpq3rx5hstN314ZDbtRnc8++6yGDRumDh066LvvvtO6deuUmJioGjVqOL3Pkpzep/QvMU6fNi0tTffcc4+++eYbvfDCC1q6dKl+/vln+4e8jJaZFSdOnFDhwoWdvquoUKFCCgoKclrH6+tMr/Xa1//qq6/Us2dPTZo0SQ0bNlRsbKx69OihI0eOuFTbsWPHJOmGXyKfXl9GjcyiRYs61R8eHu70oTo4ONgpU+nDr8+UlPk+kf5a2XmvsvI0v7Jly+rf//63ChUqpP79+6ts2bIqW7asw/cd+fL7mV6flPn7lZaWplOnTjkMz+qTDmNjY9WuXTtNnTpVqampkq5+J1b9+vUdntbnajaz8vrZWa+b+bvH18yO/TeSN29erVy5UjVr1tTLL7+sW2+9VUWLFtWIESOy1AQdP368+vXrp9tuu01z5szR2rVrlZiYqJYtW2bruJfVY0BKSoree+89p2N/euM7/Zw1ePBgjRs3TmvXrtW9996r/Pnzq1mzZk7fuXm99Hoya8hllTFGjzzyiKZPn64pU6aoffv2WZ43K1k9ceJEpvtg+vhr3WjfzujvjMyOnxkdJ9Ony+65CQCsiKdJArCsSZMmacGCBapfv77++c9/6sEHH9Rtt91mHz9z5kzlyZNH8+fPd/iDcu7cuR6pJyUlRSdOnHD4Izr9A2xGf1inK1CggMLCwvTpp59mOj5d+/bt1b59e126dElr167VmDFj1LVrV5UqVUoNGzbMcP78+fMrJSVFx44dc2iIGWN05MgR+xURrkiv6b333sv0KW+33HKL/f9/++03DR8+XPXq1VNiYqLGjx+vZ5991mmejD7wZ2UbTp8+XT169NDo0aMdhh8/flwxMTE3XZ/r/fbbb9q0aZOmTJminj172ofv2rXL5WVdK3/+/Fq3bp2MMQ4NlKNHjyolJcXhvc6qAgUK6J133tE777yjAwcOaN68eXrppZd09OhRLVy4MMvLSd83/vzzz0yvnkh/Dw4fPuw07tChQ9mq/2Yy2yfKlSsnKXvv1fXNq8zceeeduvPOO5Wamqr169frvffe08CBA3XLLbeoc+fOPv1+Sjd/vwICApQvXz6H4VndNpLUu3dvzZo1S0uWLFHJkiWVmJioDz/80GEaV7OZldd3Zb1CQ0OdHmaQ/vrX+zvH18yO/TdTrVo1zZw5U8YYbd68WVOmTNErr7yisLAwvfTSSzecd/r06WrSpInTNj979myWXvt61x4DMpMvXz4FBgaqe/fumV5FWrp0aUlX/4Ho2Wef1bPPPqvTp0/r3//+t15++WW1aNFCBw8ezPRJpem5ufYfVFyV3gj77LPPNHnyZD300EPZXlZm8ufPn+k+KMkp/65ky1Xp28oTx2AAyK24MgyAJW3ZskVPPfWUevTooVWrVql69ep68MEHHa4GsNlsCgoKcrgt5MKFC5o2bZrH6vriiy8cfk9/LPz1TxS8Vps2bbR7927lz5/f6Yq4unXrZvgktJCQEMXHx+v111+XdPWJZJlp1qyZpKsfnK41Z84cJScn28e7olGjRoqJidG2bdsyrLlu3br2K+iSk5PVqVMnlSpVSsuXL9eAAQP00ksvOd36Kklbt27Vpk2bHIZ9+eWXioqKUu3atTOtx2azOT2ifsGCBdm+ZST9Q8v1y/z444+dpr3+6oobadasmc6dO+fUkJ06dap9/N9RsmRJDRgwQM2bN7/hbaUZueeeexQYGOj0wfpaDRs2VFhYmNO+9Oeff2rZsmV/u/6MXJ+p1atXa//+/fZMufJeZVdgYKBuu+02+9Py0retL7+fklSxYkUVK1ZMX375pcMTdJOTkzVnzhz7kxiz65577lGxYsX02Wef6bPPPlNoaKi6dOniMI27sym5tl6lSpXS0aNH7VezStLly5e1aNGiTJfvyvG1adOmkjI/9meVzWZTjRo19PbbbysmJsbh/b7+iqRr57l+227evNnpiZpZVaFCBZUtW1affvpphg1E6erVnk2bNtWvv/6q6tWrZ3jsz+gfLmJiYvTAAw+of//+OnnypMMTNa+X/lUEu3fvztZ6GGP06KOP6rPPPtPHH3/scNuuOzVr1kzbtm1zyubUqVNls9ns+0ZO2LNnjwICArL19E0AsCquDAOQ6/z2229KSUlxGl62bFkVLFhQycnJ+sc//qHSpUvrgw8+UHBwsL7++mvVrl1bvXv3tn8wbd26tcaPH6+uXbvqscce04kTJzRu3DinDw/uEhwcrLfeekvnzp1TvXr1tHr1ar366qu69957dccdd2Q638CBAzVnzhw1btxYzzzzjKpXr660tDQdOHBAixcv1qBBg3Tbbbdp+PDh+vPPP9WsWTMVL15cp0+f1oQJE5QnTx7Fx8dnuvzmzZurRYsWevHFF5WUlKRGjRpp8+bNGjFihGrVqqXu3bu7vK6RkZF677331LNnT508eVIPPPCAChUqpGPHjmnTpk06duyYvanSt29fHThwQD///LMiIiL01ltvac2aNercubN+/fVXh6tDihYtqnbt2ikhIUFFihTR9OnTtWTJEr3++us3/NDepk0bTZkyRZUqVVL16tX1yy+/6M0337zh7T43UqlSJZUtW1YvvfSSjDGKjY3Vd999pyVLljhNW61aNUnShAkT1LNnT+XJk0cVK1Z0+G6odD169ND777+vnj17at++fapWrZp+/PFHjR49Wq1atdLdd9/tUp1nzpxR06ZN1bVrV1WqVElRUVFKTEzUwoULdd9997m0rFKlSunll1/WqFGjdOHCBXXp0kV58+bVtm3bdPz4cY0cOVIxMTEaNmyYXn75ZfXo0UNdunTRiRMnNHLkSIWGhmrEiBEuvWZWrF+/Xo888og6deqkgwcPasiQISpWrJieeOIJSa69V6746KOPtGzZMrVu3VolS5bUxYsX7Vdvpr9Pvvx+SlJAQIDeeOMNdevWTW3atNHjjz+uS5cu6c0339Tp06c1duxYl5d5rcDAQPXo0UPjx49XdHS07rvvPuXNm9dhGndn09X1evDBBzV8+HB17txZzz//vC5evKh3333XfmtnuuweX++55x41btxYL7zwgpKTk1W3bl399NNPWfpHl/nz5+uDDz5Qhw4dVKZMGRlj9M033+j06dMOt5JXq1ZNK1as0HfffaciRYooKipKFStWVJs2bTRq1CiNGDFC8fHx2rlzp1555RWVLl06w3NoVrz//vtq27atGjRooGeeeUYlS5bUgQMHtGjRInvDb8KECbrjjjt05513ql+/fipVqpTOnj2rXbt26bvvvrN/V1bbtm1VtWpV1a1bVwULFtT+/fv1zjvvKC4uTuXLl8+0huLFi6tMmTJau3atnnrqKafxSUlJmj17ttPwggULKj4+Xk899ZQmT56sPn36qFq1avZbpqWrjcVrv6/w73jmmWc0depUtW7dWq+88ori4uK0YMECffDBB+rXr58qVKjgltfJirVr16pmzZpOV3oCgF/L8a/sB4BsutHTJCWZiRMnGmOMeeihh0x4eLj98fLpZs2aZSSZt99+2z7s008/NRUrVjQhISGmTJkyZsyYMWby5MlOT/+Li4szrVu3dqpJkunfv7/DsPQnQ7355pv2YelPYdy8ebNp0qSJCQsLM7GxsaZfv37m3LlzDvNf/zRJY4w5d+6cGTp0qKlYsaIJDg62P7b+mWeeMUeOHDHGGDN//nxz7733mmLFipng4GBTqFAh06pVK7Nq1aqbbtsLFy6YF1980cTFxZk8efKYIkWKmH79+plTp045TJfVp0mmW7lypWndurWJjY01efLkMcWKFTOtW7e2P9Eu/QlX1z/5cdeuXSY6Otp06NDBYbu0bt3azJ4929x6660mODjYlCpVyowfP95h3oyeJnnq1Cnz8MMPm0KFCpnw8HBzxx13mFWrVjk9zTGjJ+5ltsxt27aZ5s2bm6ioKJMvXz7TqVMnc+DAAacnxBljzODBg03RokVNQECAw1Pvrn99Y64+ObFv376mSJEiJigoyMTFxZnBgwebixcvOkyX0b6Xvp3S95+LFy+avn37murVq5vo6GgTFhZmKlasaEaMGOHwBFRXTJ061dSrV8+EhoaayMhIU6tWLaf3b9KkSaZ69er2fbV9+/ZOecxsX8rsaXDXZzD9eLB48WLTvXt3ExMTY3+S5R9//OEwb1bfq/Qntx07dszp9a9/uuCaNWtMx44dTVxcnAkJCTH58+c38fHxDk+RNcZ33s/M9m1jrj4B97bbbjOhoaEmIiLCNGvWzPz0008Zrn9G2+ZGfv/9d/sxesmSJU7j/242rx2XnitX1ssYY77//ntTs2ZNExYWZsqUKWP++c9/Or3ff+f4evr0adOnTx8TExNjwsPDTfPmzc2OHTtu+jTJHTt2mC5dupiyZcuasLAwkzdvXlO/fn0zZcoUh+Vv3LjRNGrUyISHhxtJ9u126dIl89xzz5lixYqZ0NBQU7t2bTN37lynJ2hmdM5Kl9HxbM2aNebee+81efPmNSEhIaZs2bIOT/5MX2afPn1MsWLFTJ48eUzBggXN7bff7vCU17feesvcfvvtpkCBAiY4ONiULFnSPPzww2bfvn033abDhg0z+fLlc8pR+pMeM/pJ3y5xcXGZTpPRk0Wvl9kxKqMnk+7fv9907drV5M+f3+TJk8dUrFjRvPnmmw5POb3R9s8sd64cP8+ePWvCw8OdnkgJAP7OZsw1148DADyiV69emj17ts6dO+ftUnKtUqVKqWrVqpo/f763S4EPmDJlinr37q3ExETVrVvX2+UAyEGHDh1S6dKlNXXqVD344IPeLsenTZ48WU8//bQOHjzIlWEAcA2+MwwAAABArlG0aFENHDhQr732mtLS0rxdjs9KSUnR66+/rsGDB9MIA4Dr8J1hAAAAAHKVoUOHKjw8XH/99VemT7j1dwcPHtRDDz2kQYMGebsUAPA53CYJAAAAAAAAv8FtkgAAAAAAAPAbNMMAAAAAAADgN2iGAQAAAAAAwG/QDAMAAAAAAIDfoBkGAAAAAAAAv0EzDAAAAAAAAH6DZhgAAAAAAAD8Bs0wAAAAAAAA+A2aYQAAAAAAAPAbNMMAAAAAAADgN2iGAQAAAAAAwG/QDAMAAAAAAIDfoBkGAAAAAAAAv0EzDAAAAAAAAH6DZhgAAAAAAAD8Bs0wAAAAAAAA+A2aYbnAlClTZLPZtH79+ptO26tXL5UqVSrbrzV16lR17txZFStWVEBAQJaXNWnSJNlsNkVGRmb7tQGrycnsPvLII6patapiYmIUFhamChUq6Pnnn9fx48cdptu4caNat26tkiVLKiwsTLGxsWrYsKGmT5/utMx3331XDRo0UIECBRQSEqKSJUuqc+fO2rp1a7brBHIrXz4X//jjj2rVqpXy5cunsLAwlS9fXqNGjXKYxmazZfpTqVKlbNcK5Da+mOVevXrdMKNr1651mH7Dhg26++67FRkZqZiYGN13333as2dPtusErCQnM56UlKQhQ4aoQoUKCg8PV7FixdSpUyenv5VdzThyRpC3C4BvmTZtmo4cOaL69esrLS1NV65cuek8f/31l5577jkVLVpUZ86cyYEqAVwvOTlZjz32mMqVK6fQ0FCtX79er732mr7//nv9+uuvCg4OliSdPn1aJUqUUJcuXVSsWDElJyfriy++UPfu3bVv3z4NHTrUvswTJ07o3nvvVY0aNZQvXz7t2bNHY8eO1W233aZffvlFFStW9NbqApbmyrn4yy+/VPfu3fWPf/xDU6dOVWRkpHbv3q1Dhw45TLdmzRqnedetW6eBAweqY8eObl8HAFnP8rBhw9S3b1+n4W3btlVISIjq1atnH7Zjxw41adJENWvW1Ndff62LFy9q+PDhuvPOO7Vx40YVLFjQY+sDwFHbtm21fv16JSQkqG7duvrzzz/1yiuvqGHDhtqyZYvi4uIkuZZx5ByaYXCwaNEiBQRcvWCwTZs2+u233246T9++fdW4cWPFxsZq9uzZni4RQAZmzJjh8Ptdd92lqKgoPfHEE/rxxx911113SZKaNGmiJk2aOEzbpk0b7d27V5988olDM2zkyJEO08XHx6tBgwaqUqWKvvjiC73yyiueWRnAz2X1XPzXX3/pscce0+OPP64PPvjAPrxp06ZO0zZo0MBp2McffyybzaaHH37YTZUDuFZWs1y2bFmVLVvWYdjKlSt1/PhxDR06VIGBgfbhw4cPV0hIiObPn6/o6GhJUp06dVS+fHmNGzdOr7/+uofWBsC1du3apf/85z8aOnSonn/+efvwcuXK6fbbb9c333yjZ555RpJrGUfO4TbJXGzKlCmqWLGiQkJCVLlyZU2dOvVvLzP9hJ1V06dP18qVKx3+CAdwY57IbkbS/3U4KOjm/+5RoECBLE3nyjIBf+DNc/GkSZOUnJysF1980eXXOHv2rGbNmqX4+HiVK1fO5fkBq/GFv6uvNXnyZNlsNvXp08c+LCUlRfPnz9f9999vb4RJUlxcnJo2bapvv/32b9ULWJm7M54nTx5JUt68eR2Gx8TESJJCQ0NvOH9GGUfOohmWS02ZMkW9e/dW5cqVNWfOHA0dOlSjRo3SsmXLnKZNv0d53759bq3h6NGjGjhwoMaOHavixYu7ddmAVXk6uykpKUpOTtZPP/2kYcOG6Y477lCjRo2cpktLS1NKSoqOHTumDz74QIsWLcr0A3VqaqouXbqkHTt26JFHHlGhQoXUu3fvLNcEWJW3z8X/+c9/FBsbqx07dqhmzZoKCgpSoUKF1LdvXyUlJd1w3pkzZyo5OVmPPPKI2+oBcitvZ/l6Z86c0ezZs9WsWTOVLl3aPnz37t26cOGCqlev7jRP9erVtWvXLl28eNFjdQG5lScyHhcXp/bt2+vtt9/W8uXLde7cOe3YsUNPPfWU/Xt2M5NZxpGz+Kf9XCgtLU1DhgxR7dq19e2338pms0mS7rjjDpUvX15FixZ1mD4wMFCBgYH26dzliSeeUMWKFdWvXz+3LhewKk9nd+3atWrYsKH991atWmnmzJkZXnr9xBNP6OOPP5YkBQcH691339Xjjz+e4XIjIiJ06dIlSVKFChW0YsUKlShRIks1AVblC+fiv/76S+fPn1enTp00ePBgvfPOO0pMTNSIESP022+/adWqVZm+3uTJkxUTE6P777/fbfUAuZEvZPl6M2bM0IULF5xuYT5x4oQkKTY21mme2NhYGWN06tQpFSlSxGO1AbmNJzM+a9Ys9e/f3/51JNLVxvTKlSuVL1++TOfLLOPIWVwZlgvt3LlThw4dUteuXR1CGhcXp9tvv91p+smTJyslJcX+BX7uMGfOHH333XeaOHGiR/8YAKzE09mtVq2aEhMTtXLlSk2YMEG//vqrmjdvrvPnzztN+/LLLysxMVELFixQnz59NGDAAI0bNy7D5a5evVpr1qzR9OnTFRUVpaZNm/JESfg9XzgXp6Wl6eLFi3r55Zc1ePBgNWnSRM8//7zGjBmjn376SUuXLs1wvq1bt2rdunXq1q3bTW/jAKzOF7Kc0Wvkz58/04db3Ohvb/4uBxx5MuP9+vXTnDlz9Pbbb2vlypX66quvFBwcrLvuukv79+/PdL6bZRw5g2ZYLpT+r0KFCxd2GpfRMHc7d+6c+vfvryeffFJFixbV6dOndfr0aV2+fFnS1afVJScne7wOILfxdHYjIiJUt25dNW7cWE899ZS+/fZbrVu3zn4F2LVKliypunXrqlWrVvrwww/12GOPafDgwTp27JjTtLVr11aDBg3UrVs3LV++XMYYvfzyy3+7XiA38/a5WJLy588vSWrRooXD8HvvvVeStGHDhgznmzx5siRxiyQg38jytTZv3qz169froYceUkhIiMO49Myn13ytkydPymaz2b+vCMBVnsr4woULNXnyZH388ccaOHCgGjdurH/84x9asmSJTp48qYSEhAznu1HGkbNohuVC6SfCI0eOOI3LaJi7HT9+XP/973/11ltvKV++fPafGTNmKDk5Wfny5VO3bt08XgeQ2+R0duvWrauAgAD9/vvvN522fv36SklJ0Z49e244XVRUlCpVqpSlZQJW5u1zsaQMvzdIkowxkjL+8u7Lly9r2rRpqlOnjmrWrOnJ8oBcwReyfK0bNavLli2rsLAwbdmyxWncli1bVK5cOa72BK7jqYxv3LhRklSvXj2H4TExMSpXrlymT4/lH6R8B82wXKhixYoqUqSIZsyYYf+DV5L279+v1atXe/z1CxcurOXLlzv9tGjRQqGhoVq+fLleffVVj9cB5DY5nd2VK1cqLS0tS0+KW758uQICAlSmTJkbTnf8+HH7H9yAP/P2uViS/fu+fvjhB4fh33//vSSpQYMGTvPMmzdPx48f53tKgP/nC1lOd+nSJU2fPl3169dX1apVncYHBQWpbdu2+uabb3T27Fn78AMHDmj58uW67777crJcIFfwVMbTv2ts7dq1DsNPnDih33//PcMHzN0s48hZfIF+LhQQEKBRo0bpkUceUceOHfXoo4/q9OnTSkhIyPBSz4cffliff/65du/efdN7n7dt26Zt27ZJutopP3/+vGbPni1JqlKliqpUqaLQ0FA1adLEad4pU6YoMDAww3EAPJfd+fPna+LEiWrXrp3i4uJ05coVrV+/Xu+8847KlSvn8C9Pjz32mKKjo1W/fn3dcsstOn78uGbNmqWvvvpKzz//vAoWLCjp6lNumjdvrq5du6p8+fIKCwvT77//rgkTJujSpUsaMWKE+zcQkIt4+1wsSffcc4/atm2rV155RWlpaWrQoIHWr1+vkSNHqk2bNrrjjjuclj158mSFhYWpa9euf3cTAJbgC1lON3fuXJ08efKGV4yMHDlS9erVU5s2bfTSSy/p4sWLGj58uAoUKKBBgwa5uvqA5Xkq4/fdd5+GDx+ufv366c8//1Tt2rV1+PBhvfnmmzp//ryefvppp3myknHkIAOf99lnnxlJJjEx0WH4pEmTTPny5U1wcLCpUKGC+fTTT03Pnj1NXFycw3Q9e/Y0kszevXtv+lojRowwkjL8GTFixA3n7dmzp4mIiHBx7QDryqnsbt++3TzwwAMmLi7OhIaGmtDQUFOpUiXz/PPPmxMnTjhM++mnn5o777zTFChQwAQFBZmYmBgTHx9vpk2b5jDdxYsXzSOPPGIqV65sIiMjTVBQkClevLh56KGHzNatW7O9TYDcylfPxefPnzcvvviiKVGihAkKCjIlS5Y0gwcPNhcvXnRa7oEDB0xAQIDp0aOHq6sPWIavZtkYY5o3b24iIiJMUlLSDZe7fv1606xZMxMeHm6io6NNhw4dzK5du25aD+APcjLjhw8fNgMGDDDlypUzoaGhpmjRoqZ169ZmzZo1GU6f1YwjZ9iMueZaQQAAAAAAAMDC+M4wAAAAAAAA+A2aYQAAAAAAAPAbNMMAAAAAAADgN2iGAQAAAAAAwG/QDAMAAAAAAIDfoBkGAAAAAAAAv0EzzEvS0tIUGRmpQYMGebuUmzp37pwGDhyookWLKjQ0VDVr1tTMmTOztaxJkybJZrMpMjLSaVyvXr1ks9ky/Vm7du3fXRXA7ciyc5Yl6eeff1aLFi0UFRWlyMhINW3aVD/99NPfKR/wOH/J84oVK7J8rl22bJn69OmjSpUqKSIiQsWKFVP79u31yy+/eGK1ALchzzf/2/lm53LAV5Dn/+WZz8zuE+TtAvzV1q1blZycrHr16nm7lJu67777lJiYqLFjx6pChQr68ssv1aVLF6Wlpalr165ZXs5ff/2l5557TkWLFtWZM2ecxg8bNkx9+/Z1Gt62bVuFhITkim0F/0OWnbOcmJioxo0bq379+po2bZqMMXrjjTfUrFkzLV++XA0bNnTnagFu4295Hj16tJo2beowrGrVqg6/f/jhhzpx4oSefvppValSRceOHdNbb72lBg0aaNGiRbrrrrvctk6AO5Fn5zxf62bncsCXkOf/5ZnPzG5k4BWTJk0yksyuXbu8XcoNLViwwEgyX375pcPw5s2bm6JFi5qUlJQsL6tNmzambdu2pmfPniYiIiJL86xYscJIMkOHDnWpbiCnkGXnLLdo0cLccsstJjk52T4sKSnJFChQwNx+++3ZXwnAw/wlz8uXLzeSzKxZs276Wv/973+dhp09e9bccsstplmzZq4VDuQg8nxj2fm7HPAW8nxjfGbOHm6TzAETJ05UtWrVFBoaqqpVq2rRokX6+eeflS9fPpUtW9bb5d3Qt99+q8jISHXq1MlheO/evXXo0CGtW7cuS8uZPn26Vq5cqQ8++MCl1588ebJsNpv69Onj0nyAJ5DlrGX5p59+UpMmTRQeHm4fFhUVpcaNG2v16tU6fPhw9lYCcCPynDWFChVyGhYZGakqVaro4MGDbnsd4O8gz67J7t/lQE4gz67jM3P20AzzsIEDB+qpp55Shw4d9MMPP6h///7q2bOnfvjhB9WtW9cjr2mMUUpKSpZ+bua3335T5cqVFRTkeEdt9erV7eNv5ujRoxo4cKDGjh2r4sWLZ3k9zpw5o9mzZ6tZs2YqXbp0lucDPIEsZz3Lly9fVkhIiNPw9GFbtmy56WsBnkSer+rfv7+CgoIUHR2tFi1a6Mcff8zSfGfOnNGGDRt06623Zml6wJPI81VZzXN2/y4HcgJ5vsqV8zOfmbOPZpgHzZkzRxMmTNCUKVM0atQoNW3aVP369dPTTz+tgwcP2u/n3bVrl4KCgnTx4kWH+S9duqTevXurRIkSio6OVoMGDbR69eqbvu7KlSuVJ0+eLP3s27fvhss6ceKEYmNjnYanDztx4sRN63niiSdUsWJF9evX76bTXmvGjBm6cOGCHn74YZfmA9yNLF+V1SxXqVJFa9euVVpamn1YSkqK/V/DsvJagKeQZylv3rx6+umn9fHHH2v58uWaMGGCDh48qCZNmmjRokU3XZf+/fsrOTlZQ4YMuem0gCeRZ9fznN2/ywFPI8/ZOz/zmTn7+AJ9Dxo1apTq1aunBx980GF4lSpVJMne3d68ebMqVqyo0NBQh+lSUlJUunRp/fTTTypevLimTZumdu3a6cCBAw63H12vTp06SkxMzFKNRYsWvek0NpstW+Okqwe17777Tr/++utNp73e5MmTlT9/fnXs2NGl+QB3I8uuZfnJJ5/Uww8/rAEDBmjIkCFKS0vTyJEjtX//fklSQAD/DgPvIc9SrVq1VKtWLfvvd955pzp27Khq1arphRdeUIsWLTKdd9iwYfriiy/03nvvqU6dOjetE/Ak8uxanv/O3+WAp5Hn7J2f+cycfTTDPOTIkSPatGmT3n77badxf/75pyTZu9ubNm1SjRo1nKaLiIjQ8OHD7b/37NlTzzzzjP74448Mp08XGRmpmjVrZqnO6y/hvF7+/Pkz7GCfPHlSkjLsfKc7d+6c+vfvryeffFJFixbV6dOnJV29hUqSTp8+rTx58igiIsJp3s2bN2v9+vV6+umnM7zdCsgpZNn1LPfp00fHjh3Tq6++qg8//FCS1LBhQz333HN6/fXXVaxYsSytE+Bu5DlzMTExatOmjT766CNduHBBYWFhTtOMHDlSr776ql577TUNGDDA5dcA3Ik8Zy6jPP+dv8sBTyPPmbvR+ZnPzH8P/zzvIemhLVKkiNO4L7/8UoULF7bfp79p0yb7fcQ3smPHDl24cOGmXxzozks9q1Wrpu3btzvdI53+nT83emTz8ePH9d///ldvvfWW8uXLZ/+ZMWOGkpOTlS9fPnXr1i3DeSdPnixJeuSRR25YH+BpZDl7WX7xxRd1/PhxbdmyRfv27dPq1at16tQpRUREcDUJvIY835gxRlLG/3I9cuRIJSQkKCEhQS+//HK2lg+4E3m+sevz/Hf+Lgc8jTzfWGbnZz4z/z1cGeYhBQsWlHT1S/KuvdRz9uzZWr16tdq0aWMftnnzZj3++OM3XN758+fVvXt3DR06VJGRkTec1p2Xenbs2FETJ07UnDlzHNbj888/V9GiRXXbbbdlOm/hwoW1fPlyp+Fjx47VypUr9cMPP6hAgQJO4y9duqTp06erfv362T5gAO5ClrOf5ZCQEHuGDxw4oK+++kqPPvpohlecADmBPGfu1KlTmj9/vmrWrOl068moUaOUkJCgoUOHasSIES4vG/AE8py5jPKc3XM5kBPIc+YyOz/zmdkNDDwiLS3N1KtXz0RERJgJEyaY5cuXm5EjR5rY2FgjyYwcOdIYY8yZM2eMzWYzf/31V6bLunz5smndurXp0aOHSUtLy6lVsGvevLnJly+f+eSTT8yyZcvMo48+aiSZ6dOnO0y3YsUKExgYaF+3zPTs2dNERERkOn7mzJlGkvnkk0/cUj/wd5DlzGWW5S1btpiEhAQzf/58s2TJEjNu3DhToEABU7duXXP27Fm3rhPgCvJ8VZcuXcyLL75oZs2aZZYvX24++eQTU7FiRRMUFGSWLFniMP+4ceOMJNOyZUuzZs0apx/AW8jzVa7kOSM3+7scyAnk+SpX8sxn5r+PZpgH7d2717Rs2dJERkaamJgY07ZtWzN58mQjySxYsMAYY8yqVatM/vz5M11Gamqq6dy5s2nXrp25cuVKTpXu4OzZs+app54yhQsXNsHBwaZ69epmxowZTtMtX77cSDIjRoy44fJudtJt3ry5iYiIMElJSX+3dMAtyHLGMsvyzp07TePGjU1sbKwJDg425cqVM0OHDjXnzp1z16oA2UaejRkzZoypWbOmyZs3rwkMDDQFCxY0HTt2ND///LPT/PHx8UZSpj+AN5Fn1/KcEZph8BXk2bU885n577MZ8/83oMIrPvjgA3399ddauHChfVhAQICCg4MlSY8++qj++OMPLVy40Om2BQC+gywD1kGeAesgz4B1kGe4E1+g72WbNm3SypUrFRYWZv+5//77JUn79+/XpEmTtG7dOhUoUECRkZGKjIzUqlWrvFw1gOuRZcA6yDNgHeQZsA7yDHfiyjAAAAAAAAD4Da4MAwAAAAAAgN+gGQYAAAAAAAC/QTMMAAAAAAAAfoNmGAAAAAAAAPwGzTAAAAAAAAD4jSBvFyBJaWlpOnTokKKiomSz2bxdDuBRxhidPXtWRYsWVUCA9frR5Bn+hDwD1mD1LEvkGf7D6nkmy/AnnsyzTzTDDh06pBIlSni7DCBHHTx4UMWLF/d2GW5HnuGPyDNgDVbNskSe4X+smmeyDH/kiTz7RDMsKipKkvT779vt/w/PCg+P0vnzZ71dhk/z1DY6e/asKlSobNl9nTznHHKcuZzaNuQZOY3ce4bVsyyRZ08hk1f50nawep7Jsvv50v4LR57Ms080w9Iv74yKilJ0dLSXq/EP4eFRCgristob8fQ2suplzeQ555DjzOX0tiHPyCnk3rOsmmWJPHsKmbzKF7eDVfNMlt3PF/dfOPJEnq13EzUAAAAAAACQCZphAAAAAAAA8Bs0wwAAAAAAAOA3aIYBAAAAAADAb9AMAwAAAAAAgN+gGQYAAAAAAAC/QTMMAAAAAAAAfoNmGAAAAAAAAPwGzTAAAAAAAAD4jSBvF+CK8H/FebsEawiKkjrt15iZG3TpSqq3q/FJIXkCNapPvLfLsDTy/DeR40yRX1hRwrRE9m14HOdmF3EulsR511eR5yz6/xxnV8K0RDcWAycpFz22aK4MAwAAAAAAgN+gGQYAAAAAAAC/QTMMAAAAAAAAfoNmGAAAAAAAAPwGzTAAAAAAAAD4DZphAAAAAAAA8Bs0wwAAAAAAAOA3aIYBAAAAAADAb9AMAwAAAAAAgN8I8nYBrjjffr+3S7CMcEmDO9f2dhnwY+T57yPHgP9I6F7P2yXAD3Budh3nYvgq8px14X9jXs7PnpWUlKQ3B3hm2VwZBgAAAAAAAL+Rq64MAwDgRhKmJSokT6BG9Yn3dikAAABwUfi/4nL2BYOipE5cReePuDIMAAAAAAAAfoNmGAAAAAAAAPwGzTAAAAAAAAD4DZphAAAAAAAA8Bs0wwAAAAAAAOA3aIYBAAAAAADAb9AMAwAAAAAAgN+gGQYAAAAAAAC/QTMMAAAAAAAAfiPI2wUAAOAuCd3rebsEAAAAZNP59vtz/DXDc/wV4Qu4MgwAAAAAAAB+gyvDAAAAAADZMmbmBo3qE+/tMmBB4f+K8/yLBEVJnXL+ajR4H1eGAQAAAAAAwG/QDAMAAAAAAIDfoBkGAAAAAAAAv0EzDAAAAAAAAH6DZhgAAAAAAAD8Bs0wAAAAAAAA+A2aYQAAAAAAAPAbNMMAAAAAAADgN2iGAQAAAAAAwG8EebsAAAAAAEDuNLhzbW+XAIs6335/jrxOeI68CnwNV4YBAAAAAADAb3BlGHADY2Zu4F+7AAA+YczMDRrVJ97bZQBAhvi7GZ4S/q84zy08KErqlDNXoMG3cGUYAAAAAAAA/AbNMAAAAAAAAPgNmmEAAAAAAADwGzTDAAAAAAAA4DdohgEAAAAAAMBv0AwDAAAAAACA36AZBgAAAAAAAL9BMwwAAAAAAAB+g2YYAAAAAAAA/EaQtwsAfNngzrW9XQIAAJI4JwHwbRyj4Cnn2+/36PLDPbp0+CquDAMAAAAAAIDfoBkGAAAAAAAAv8FtksB1EqYlKiRPoEb1ifd2KQD+hjEzN3DLBgAAOYTzLnxN+L/ibj5RUJTUybO3YcI3cWUYAAAAAAAA/AbNMAAAAAAAAPgNmmEAAAAAAADwGzTDAAAAAAAA4DdohgEAAAAAAMBv0AwDAAAAAACA36AZBgAAAAAAAL9BMwwAAAAAAAB+I8jbBQC+JqF7PW+XAMANBneu7e0SAADwG5x34WvOt9+fpenCPVwHfBNXhgEAAAAAAMBv0AwDAAAAAACA3+A2SeA6CdMSFZInUKP6xHu7FAAuSJiWKEnkFwAALxgzcwO3SiJXCP9X3P9+CYqSOmXtdkpYC1eGAQAAAAAAwG/QDAMAAAAAAIDfoBkGAAAAAAAAv0EzDAAAAAAAAH6DZhgAAAAAAAD8Bs0wAAAAAAAA+A2aYQAAAAAAAPAbNMMAAAAAAADgN4K8XQDgaxK61/N2CQCygewCAOA9gzvX9nYJQJacb7/f4fdwL9UB7+LKMAAAAAAAAPgNmmEAAAAAAADwG9wmCdzAmJkbdOlKKrdfAblAwrRESVJInkCN6hPv5WoAALA2zrvIzcL/FXf1f4KipE77bzwxLMnlK8M+//xzLViwwP77Cy+8oJiYGN1+++3av5+dCMhNyDNgDWQZsA7yDFgHeQZ8l8vNsNGjRyssLEyStGbNGv3zn//UG2+8oQIFCuiZZ55xe4EAPIc8A9ZAlgHrIM+AdZBnwHe5fJvkwYMHVa5cOUnS3Llz9cADD+ixxx5To0aN1KRJE3fXB8CDyDNgDWQZsA7yDFgHeQZ8l8tXhkVGRurEiROSpMWLF+vuu++WJIWGhurChQvurQ6AR5FnwBrIMmAd5BmwDvIM+C6Xrwxr3ry5HnnkEdWqVUu///67WrduLUnaunWrSpUq5e76AHgQeQasgSwD1kGeAesgz4DvcvnKsPfff18NGzbUsWPHNGfOHOXPn1+S9Msvv6hLly5uLxCA55BnwBrIMmAd5BmwDvIM+C6XrwyLiYnRP//5T6fhI0eOdEtBAHIOeQasgSwD1kGeAesgz4DvcvnKMElatWqVHnroId1+++3666+/JEnTpk3Tjz/+6NbiAHgeeQasgSwD1kGeAesgz4BvcrkZNmfOHLVo0UJhYWHasGGDLl26JEk6e/asRo8e7fYCAW8a3Lm2ErrX83YZHkOeYSUJ3espoXs9De5c29ul5DiyDFgHeUZu4c/n3awiz77rfPv9V39a/+btUuAlLjfDXn31VX300UeaOHGi8uTJYx9+++23a8OGDW4tDoBnkWfAGsgyYB3kGbAO8gz4LpebYTt37lTjxo2dhkdHR+v06dPuqAlADiHPgDWQZcA6yDNgHeQZ8F0uN8OKFCmiXbt2OQ3/8ccfVaZMGbcUBfiKMTM3KGFaorfL8BjyDKtImJZo/xkz0//+pZUs+wd/3Lf9EXlGbmX1v5uzgzz7tvB/xSl8QVVvlwEvcbkZ9vjjj+vpp5/WunXrZLPZdOjQIX3xxRd67rnn9MQTT3iiRgAeQp4BayDLgHWQZ8A6yDPgu4JcneGFF17QmTNn1LRpU128eFGNGzdWSEiInnvuOQ0YMMATNQLwEPIMWANZBqyDPAPWQZ4B3+VSMyw1NVU//vijBg0apCFDhmjbtm1KS0tTlSpVFBkZ6akaAXgAeQasgSwD1kGeAesgz4Bvc6kZFhgYqBYtWmj79u2KjY1V3bp1PVUXAA8jz4A1kGXAOsgzYB3kGfBtLn9nWLVq1bRnzx5P1AIgh5FnwBrIMmAd5BmwDvIM+C6Xm2GvvfaannvuOc2fP1+HDx9WUlKSww+A3IM8A9ZAlgHrIM+AdZBnwHe5/AX6LVu2lCS1a9dONpvNPtwYI5vNptTUVPdVB8CjyDNgDWQZsA7yDFgHeQZ8l8vNsOXLl3uiDgBeQJ4BayDLgHWQZ8A6yDPgu1xuhsXHx3uiDsAnDe5c29sleBR5hlUkdK/n7RK8iiz7B6ufk3AVeUZuxTHKGXn2befb75ckhXu5DniHy82w//znPzcc37hx42wXAyBnkWfAGsgyYB3kGbAO8gz4LpebYU2aNHEadu39z9z3DOQe5BmwBrIMWAd5BqyDPAO+y+WnSZ46dcrh5+jRo1q4cKHq1aunxYsXe6JGIEclTEvUmJkbvF1GjiDPsIqEaYn2H3/J77XIsn/wx33bH5Fn5Bb+fN7NKvLs28L/FafwBVW9XQa8xOUrw/Lmzes0rHnz5goJCdEzzzyjX375xS2FAfA88gxYA1kGrIM8A9ZBngHf5fKVYZkpWLCgdu7c6a7FAfAi8gxYA1kGrIM8A9ZBngHvc/nKsM2bNzv8bozR4cOHNXbsWNWoUcNthQHwPPIMWANZBqyDPAPWQZ4B3+VyM6xmzZqy2WwyxjgMb9CggT799FO3FQbA88gzYA1kGbAO8gxYB3kGfJfLzbC9e/c6/B4QEKCCBQsqNDTUbUUByBnkGbAGsgxYB3kGrIM8A77L5e8MW7lypQoXLqy4uDjFxcWpRIkSCg0N1eXLlzV16lRP1AjAQ8gzYA1kGbAO8gxYB3kGfJfLzbDevXvrzJkzTsPPnj2r3r17u6UoADmDPAPWQJYB6yDPgHWQZ8B3udwMM8bIZrM5Df/zzz8zfHQsAN9FngFrIMuAdZBnwDrIM+C7svydYbVq1ZLNZpPNZlOzZs0UFPS/WVNTU7V37161bNnSI0UCOSmhez1vl+Bx5BlW4w+5zQhZ9i+DO9f2dgnwIPKM3MZfz71ZQZ5zh/Pt90uSwr1cB7wjy82wDh06SJI2btyoFi1aKDIy0j4uODhYpUqV0v333+/2AgG4H3kGrIEsA9ZBngHrIM+A78tyM2zEiBGSpFKlSunBBx/kCRhALkaeAWsgy4B1kGfAOsgz4Ptc/s6wnj17EmbAIsgzYA1k2T+MmbnB2yUgB5BnwDrIs+8LX1DV2yXAS7J8ZVi61NRUvf322/r666914MABXb582WH8yZMn3VYcAM8iz4A1kGXAOsgzYB3kGfBdLl8ZNnLkSI0fP17/+Mc/dObMGT377LO67777FBAQoISEBA+UCMBTyDNgDWQZsA7yDFgHeQZ8l8vNsC+++EITJ07Uc889p6CgIHXp0kWTJk3S8OHDtXbtWk/UCMBDyDNgDWQZsA7yDFgHeQZ8l8vNsCNHjqhatWqSpMjISJ05c0aS1KZNGy1YsMC91QHwKPIMWANZBqyDPAPWQZ4B3+VyM6x48eI6fPiwJKlcuXJavHixJCkxMVEhISHurQ6AR5FnwBrIMmAd5BmwDvIM+C6Xm2EdO3bU0qVLJUlPP/20hg0bpvLly6tHjx7q06eP2wsE4DnkGbAGsgxYB3kGrIM8A77L5adJjh071v7/DzzwgIoXL67Vq1erXLlyateunVuLA+BZ5BmwBrIMWAd5BqyDPAO+y+Vm2PUaNGigBg0auKMWAF5GngFrIMuAdZBnwDrIM+A7XL5NUpKmTZumRo0aqWjRotq/f78k6Z133tG//vUvtxYHwPPIM2ANZNn6Bneu7e0SkEPIM2Ad5Nm3nW/9m7dLgJe43Az78MMP9eyzz6pVq1Y6ffq0UlNTJUkxMTF655133F0fAA8iz4A1kGXAOsgzYB3kGfBdLjfD3nvvPU2cOFFDhgxRYGCgfXjdunW1ZcsWtxYHwLPIM2ANZBmwDvIMWAd5BnyXy82wvXv3qlatWk7DQ0JClJyc7JaiAF8xZuYGJUxL9HYZHkOeYWXp+bVyhtORZf8wZuYGb5eAHECekVtZ/e/m7CDPvi98QVVvlwAvcbkZVrp0aW3cuNFp+A8//KAqVaq4oyYAOYQ8A9ZAlgHrIM+AdZBnwHe5/DTJ559/Xv3799fFixdljNHPP/+sGTNmaMyYMZo0aZInagTgIeQZsAayDFgHeQasgzwDvsvlZljv3r2VkpKiF154QefPn1fXrl1VrFgxTZgwQZ07d/ZEjQA8hDwD1kCWAesgz4B1kGfAd2XpNsl58+bpypUr9t8fffRR7d+/X0ePHtWRI0d08OBBPfzwwx4rEoD7kGfAGsgyYB3kGbAO8gzkDllqhnXs2FGnT5+WJAUGBuro0aOSpAIFCqhQoUIeKw6A+5FnwBrIMmAd5BmwDvIM5A5ZaoYVLFhQa9eulSQZY2Sz2TxaFADPIc+ANZBlwDrIM2Ad5BnIHbL0nWF9+/ZV+/btZbPZZLPZVLhw4UynTU1NdVtxANyPPAPWQJYB6yDPgHWQZyB3yFIzLCEhQZ07d9auXbvUrl07ffbZZ4qJifFwaQA8gTwD1kCWAesgz4B1kGcgd8jy0yQrVaqkSpUqacSIEerUqZPCw8M9WRcADyLPgDWQZcA6yDNgHeQZ8H02Y4zxdhFJSUnKmzevDh/+U9HR0d4uxy+Eh0fp/Pmz3i7Dp3lqGyUlJalIkeI6c+aMJfd38pxzyHHmcmrbkGfkNHLvGVbPskSePYVMXuVL28HqeSbL7udL+y8ceTLPWfoCfQAAAAAAAMAKsnybJGBlCdMSHX4PyROoUX3ivVQNAHcYM3ODLl353xfTJnSv58VqgL8nYVoi5yYAPu3a8y7nXOQW4QuqSp32e7sMeAFXhgEAAAAAAMBv0AwDAAAAAACA33BbM+y///2vXnnlFXctDoAXkWfAGsgyYB3kGbAO8gx4n9uaYUeOHNHIkSPdtTgAXkSeAWsgy4B1kGfAOsgz4H1Z/gL9zZs333D8zp07/3YxAHIGeQasgSwD1kGeAesgz4Dvy3IzrGbNmrLZbDLGOI1LH26z2dxaHADPIM+ANZBlwDrIM2Ad5BnwfVluhuXPn1+vv/66mjVrluH4rVu3qm3btm4rDIDnkGfAGsgyYB3kGbAO8gz4viw3w+rUqaNDhw4pLi4uw/GnT5/OsPMNwPeQZ8AayDJgHeQZsA7yDPi+LDfDHn/8cSUnJ2c6vmTJkvrss8/cUhQAzyLPgDWQZcA6yDNgHeQZ8H024wMt6aSkJOXNm1eHD/+p6Ohob5fjF8LDo3T+/Flvl+HTPLWNkpKSVKRIcZ05c8aS+zt5zjnkOHM5tW3IM3IaufcMq2dZIs+eQiav8qXtYPU8k2X386X9F448mecAty4NAAAAAAAA8GFZvk1Ski5cuKBffvlFsbGxqlKlisO4ixcv6uuvv1aPHj3cWiDgaQnTEp2GheQJ1Kg+8V6oJueQZ1jdmJkbdOlKqtPwhO71vFCN55Bl/5AwLdEvzk3+jjwjN7v+vGu1862ryDPg27J8Zdjvv/+uypUrq3HjxqpWrZqaNGmiw4cP28efOXNGvXv39kiRANyLPAPWQJYB6yDPgHWQZ8D3ZbkZ9uKLL6patWo6evSodu7cqejoaDVq1EgHDhzwZH0APIA8A9ZAlgHrIM+AdZBnwPdluRm2evVqjR49WgUKFFC5cuU0b9483Xvvvbrzzju1Z88eT9YIwM3IM2ANZBmwDvIMWAd5Bnxflr8z7MKFCwoKcpz8/fffV0BAgOLj4/Xll1+6vTgAnkGeAWsgy4B1kGfAOsgz4Puy3AyrVKmS1q9fr8qVKzsMf++992SMUbt27dxeHADPIM+ANZBlwDrIM2Ad5BnwfVm+TbJjx46aMWNGhuP++c9/qkuXLjLGuK0wAJ5DngFrIMuAdZBnwDrIM+D7stwMGzx4sL7//vtMx3/wwQdKS0tzS1EAPIs8A9ZAlgHrIM+AdZBnwPdluRkGAAAAAAAA5HY0wwAAAAAAAOA3svwF+oBVJXSv5+0SAHjA4M61vV0C4DacqwD4Os67AHITrgwDAAAAAACA3+DKMPilhGmJNxwfkidQo/rE51A1AFx1owyTX1hRwrRE9m0APuH6czDHJgC5UbaaYTt37tR7772n7du3y2azqVKlSnryySdVsWJFd9cHwMPIM2ANZBmwDvIMWAd5BnyTy7dJzp49W1WrVtUvv/yiGjVqqHr16tqwYYOqVq2qWbNmeaJGAB5CngFrIMuAdZBnwDrIM+C7XL4y7IUXXtDgwYP1yiuvOAwfMWKEXnzxRXXq1MltxQHwLPIMWANZBqyDPAPWQZ4B3+XylWFHjhxRjx49nIY/9NBDOnLkiFuKApAzyDNgDWQZsA7yDFgHeQZ8l8vNsCZNmmjVqlVOw3/88UfdeeedbikKQM4gz4A1kGXAOsgzYB3kGfBdLt8m2a5dO7344ov65Zdf1KBBA0nS2rVrNWvWLI0cOVLz5s1zmBaA7yLPgDWQZcA6yDNgHeQZ8F02Y4xxZYaAgKxdTGaz2ZSampqlaZOSkpQ3b14dPvynoqOjXSkH2RQeHqXz5896uwyvuf6R0NdLf0S0J7ZRUlKSihQprjNnznh9fyfPuZs/5/hGGfZkfq/nK3n2RJYl8uxLEqYl5ui+7W98JcsSec5t/PFcfP052NeOTVbPM1l2P3/McW7hyTy7fGVYWlqaWwsA4D3kGbAGsgxYB3kGrIM8A77L5e8MAwAAAAAAAHIrl68Mk6SVK1dq3Lhx2r59u2w2mypXrqznn3+eLwFErpHQvZ63S/AZ5Bm5ERl2RpatjX3ev5Bn+DKOR64hz4BvcvnKsOnTp+vuu+9WeHi4nnrqKQ0YMEBhYWFq1qyZvvzyS0/UCMBDyDNgDWQZsA7yDFgHeQZ8l8tfoF+5cmU99thjeuaZZxyGjx8/XhMnTtT27dtdLoIvAcx5/volgTf74vx0/vIF+uQ5d/PHHGclw/74BfqeyLJEnn1ReHiUhn26UoM71/Z2KZbiK1mWyHNu44/n4oykH5suXfnfl8B76woyq+eZLLsfOfZdnsyzy1eG7dmzR23btnUa3q5dO+3du9ctRQHIGeQZsAayDFgHeQasgzwDvsvlZliJEiW0dOlSp+FLly5ViRIl3FIUgJxBngFrIMuAdZBnwDrIM+C7svwF+n369NGECRM0aNAgPfXUU9q4caNuv/122Ww2/fjjj5oyZYomTJjgyVoBuAl5BqyBLAPWQZ4B6yDPgO/LcjPs888/19ixY9WvXz8VLlxYb731lr7++mtJV++F/uqrr9S+fXuPFQrAfcgzYA1kGbAO8gxYB3kGfF+Wm2HXfs9+x44d1bFjR48UBMDzyDNgDWQZsA7yDFgHeQZ8n0vfGWaz2TxVB4AcRp4BayDLgHWQZ8A6yDPg27J8ZZgkVahQ4aahPnny5N8qCEDOIM+ANZBlwDrIM2Ad5BnwbS41w0aOHKm8efN6qhYAOYg8A9ZAlgHrIM+AdZBnwLe51Azr3LmzChUq5KlaAOQg8gxYA1kGrIM8A9ZBngHfluVmGPc8wwoSutfzdgk+gTwjtyLDjsiyfxrcuba3S4AHkGfkdhyb/oc8A74vy1+gf+0TMQDkbuQZsAayDFgHeQasgzwDvi/LV4alpaV5sg7A4xKmJWZ52pA8gRrVJ96D1XgXeUZulZUcWz2/1yLL1nb9/u5P+7Y/Is/IDTI6D3NsckaeAd+X5SvDAAAAAAAAgNyOZhgAAAAAAAD8Bs0wAAAAAAAA+A2aYQAAAAAAAPAbNMMAAAAAAADgN2iGAQAAAAAAwG/QDAMAAAAAAIDfoBkGAAAAAAAAv0EzDAAAAAAAAH4jyNsFADkloXs9b5cA4G8ix/An7O8AfA3HJQBWwZVhAAAAAAAA8BtcGQa/kTAtMcvThuQJ1Kg+8R6sBkBWuZJdifzC+sbM3KBLV1IzHc+VGwCyw9XzbTrOuwByI64MAwAAAAAAgN+gGQYAAAAAAAC/QTMMAAAAAAAAfoNmGAAAAAAAAPwGzTAAAAAAAAD4DZphAAAAAAAA8Bs0wwAAAAAAAOA3aIYBAAAAAADAb9AMAwAAAAAAgN8I8nYBQE5J6F7P2yUAyAayCzga3Lm2t0sAYEGcbwH4E64MAwAAAAAAgN/gyjDgBsbM3KBLV1Jdmod/VQN8Q3byez3yDF/k6r7NfgwgJ7jjvHstjl0APIkrwwAAAAAAAOA3aIYBAAAAAADAb9AMAwAAAAAAgN+gGQYAAAAAAAC/QTMMAAAAAAAAfoNmGAAAAAAAAPwGzTAAAAAAAAD4DZphAAAAAAAA8Bs0wwAAAAAAAOA3grxdAODLBneu7e0SAGQT+YVVsW8D8EUcmwDkJlwZBgAAAAAAAL/BlWHItRKmJXps2SF5AjWqT7zHlg/4M09mVyK/AAB4w5iZG3TpSmqOvFZC93o58joArIsrwwAAAAAAAOA3aIYBAAAAAADAb9AMAwAAAAAAgN+gGQYAAAAAAAC/QTMMAAAAAAAAfoNmGAAAAAAAAPwGzTAAAAAAAAD4DZphAAAAAAAA8Bs0wwAAAAAAAOA3grxdAJBdCd3rebsEANlAdgEAsJ7BnWt7uwQAyDKuDAMAAAAAAIDf4Mow4P8lTEu0/39InkCN6hPvxWoA/F1jZm7QpSup9t+5Ii37whc1UHhwsrfLcHC+/X5vlwAAfou/mwHkdlwZBgAAAAAAAL9BMwwAAAAAAAB+g2YYAAAAAAAA/AbNMAAAAAAAAPgNmmEAAAAAAADwGzTDAAAAAAAA4DdohgEAAAAAAMBv0AwDAAAAAACA36AZBgAAAAAAAL8R5O0CAF+R0L2et0sA4EaDO9f2dgmWcb7FWgVFR3u7DACAj+DvZgC5HVeGAQAAAAAAwG/QDAMAAAAAAIDf4DZJAABwQ+GLGig8ONnbZfic8+33e+V1x8zcoEtXUr3y2rkVt3QBAG4kfEFVKeVslqb11vkf7sWVYQAAAAAAAPAbNMMAAAAAAADgN2iGAQAAAAAAwG/QDAMAAAAAAIDfoBkGAAAAAAAAv0EzDAAAAAAAAH6DZhgAAAAAAAD8Bs0wAAAAAAAA+I0gbxcAAAB82/kWaxUUHe3tMvD/Bneu7e0SAACwlPOtf/N2CchhXBkGAAAAAAAAv0EzDAAAAAAAAH6DZhgAAAAAAAD8Bs0wAAAAAAAA+A2aYQAAAAAAAPAbNMMAAAAAAADgN2iGAQAAAAAAwG/QDAMAAAAAAIDfoBkGAAAAAAAAv0EzDAAAAAAAAH6DZhgAAAAAAAD8RpC3C5AkY4wk6ezZs16uxH+kpBidP8/2vhFPbaP0/Tx9v7ca8pxzyHHmcmrbkGfkNHLvGVbPskSePYVMXuVL28HqeSbL7udL+y8ceTLPPtEMS1/BChUqe7kSIOecPXtWefPm9XYZbkee4Y+smucTJ05IIs/wH1bNssT5Gf7Hqnkmy/BHJ06ccHuebcYHWuZpaWk6dOiQoqKiZLPZvF2O5SUlJalEiRI6ePCgoqOjvV2OT/LkNjLG6OzZsypatKgCAqx3pzJ5zhnkOHM5uW2snufTp08rX758OnDggCU/UOQ25N5zrJ5lifOzJ5DJq3xtO1g9z2TZvXxt/4WjM2fOqGTJkjp16pRiYmLcumyfuDIsICBAxYsX93YZfic6OprA34SntpGVP1SS55xFjjOXU9vG6nmWrq4j+5nvIPeeYeUsS5yfPYlMXuVL28HKeSbLnuFL+y+ceaKxbb1WOQAAAAAAAJAJmmEAAAAAAADwGzTD/FBISIhGjBihkJAQb5fis9hG8HXso5lj27gP29K38H4AvoVMXsV2QG7G/uvbPPn++MQX6AMAAAAAAAA5gSvDAAAAAAAA4DdohgEAAAAAAMBv0AwDAAAAAACA36AZBr/QpEkTDRw4UJJUqlQpvfPOO16tB0DWkF1YFfs2AF/F8QlW0qtXL3Xo0MHbZcAHBXm7ACCnJSYmKiIiwttlAHAR2YVVsW8D8FUcnwBYFc0w+J2CBQt6uwQA2UB2YVXs2wB8FccnAFbFbZIWsnDhQt1xxx2KiYlR/vz51aZNG+3evds+/s8//1Tnzp0VGxuriIgI1a1bV+vWrdPOnTtls9m0Y8cOh+WNHz9epUqVkjEmp1fFo66/3Ntms+njjz9WmzZtFB4ersqVK2vNmjXatWuXmjRpooiICDVs2NBhW0rSd999pzp16ig0NFRlypTRyJEjlZKSksNrA6shx5kju+7FvuY72LcB38Mx8iqOT8gtZs+erWrVqiksLEz58+fX3XffreTkZPv4cePGqUiRIsqfP7/69++vK1eu2MdNnz5ddevWVVRUlAoXLqyuXbvq6NGj9vErVqyQzWbTggULVKNGDYWGhuq2227Tli1bcnQdrcbbx1maYRaSnJysZ599VomJiVq6dKkCAgLUsWNHpaWl6dy5c4qPj9ehQ4c0b948bdq0SS+88ILS0tJUsWJF1alTR1988YXD8r788kt17dpVNpvNS2uUc0aNGqUePXpo48aNqlSpkrp27arHH39cgwcP1vr16yVJAwYMsE+/aNEiPfTQQ3rqqae0bds2ffzxx5oyZYpee+01b60CLIIcu4bsZh/7mm9j3wa8i2Nk5jg+wdccPnxYXbp0UZ8+fbR9+3atWLFC9913n70psnz5cu3evVvLly/X559/rilTpmjKlCn2+S9fvqxRo0Zp06ZNmjt3rvbu3atevXo5vc7zzz+vcePGKTExUYUKFVK7du0cmmpwjdePswaWdfToUSPJbNmyxXz88ccmKirKnDhxIsNpx48fb8qUKWP/fefOnUaS2bp1a06V61Hx8fHm6aefNsYYExcXZ95++237OElm6NCh9t/XrFljJJnJkyfbh82YMcOEhobaf7/zzjvN6NGjHV5j2rRppkiRIp5ZAfgtf88x2c05/r6v5TT2bSB38adjJMcn5Da//PKLkWT27dvnNK5nz54mLi7OpKSk2Id16tTJPPjgg5ku7+effzaSzNmzZ40xxixfvtxIMjNnzrRPc+LECRMWFma++uorN66Jf8vp4yxXhlnI7t271bVrV5UpU0bR0dEqXbq0JOnAgQPauHGjatWqpdjY2Azn7dy5s/bv36+1a9dKkr744gvVrFlTVapUybH6val69er2/7/lllskSdWqVXMYdvHiRSUlJUmSfvnlF73yyiuKjIy0/zz66KM6fPiwzp8/n7PFw1LIsWvIbvaxr/k29m3AuzhGZo7jE3xNjRo11KxZM1WrVk2dOnXSxIkTderUKfv4W2+9VYGBgfbfixQp4nAb5K+//qr27dsrLi5OUVFRatKkiaSreb9Ww4YN7f8fGxurihUravv27R5aK+vz9nGWL9C3kLZt26pEiRKaOHGiihYtqrS0NFWtWlWXL19WWFjYDectUqSImjZtqi+//FINGjTQjBkz9Pjjj+dQ5d6XJ08e+/+nX1aZ0bC0tDT7f0eOHKn77rvPaVmhoaGeLBUWR45dQ3azj33Nt7FvA97FMTJzHJ/gawIDA7VkyRKtXr1aixcv1nvvvachQ4Zo3bp1khz3T+nqPpq+fyYnJ+uee+7RPffco+nTp6tgwYI6cOCAWrRoocuXL9/0ta1w67O3ePs4SzPMIk6cOKHt27fr448/1p133ilJ+vHHH+3jq1evrkmTJunkyZOZdle7deumF198UV26dNHu3bvVuXPnHKk9N6pdu7Z27typcuXKebsUWAg59jyyexX7mvWwbwPuwzHSvTg+ISfYbDY1atRIjRo10vDhwxUXF6dvv/32pvPt2LFDx48f19ixY1WiRAlJsn/33fXWrl2rkiVLSpJOnTql33//XZUqVXLfSvgRXzjOcpukReTLl0/58+fXJ598ol27dmnZsmV69tln7eO7dOmiwoULq0OHDvrpp5+0Z88ezZkzR2vWrLFPc9999ykpKUn9+vVT06ZNVaxYMW+sSq4wfPhwTZ06VQkJCdq6dau2b9+ur776SkOHDvV2acjFyLHnkd2r2Nesh30bcB+Oke7F8Qmetm7dOo0ePVrr16/XgQMH9M033+jYsWOqXLnyTectWbKkgoOD9d5772nPnj2aN2+eRo0aleG0r7zyipYuXarffvtNvXr1UoECBdShQwc3r41/8IXjLM0wiwgICNDMmTP1yy+/qGrVqnrmmWf05ptv2scHBwdr8eLFKlSokFq1aqVq1app7NixDvdOR0dHq23bttq0aZO6devmjdXINVq0aKH58+dryZIlqlevnho0aKDx48crLi7O26UhFyPHnkd2r2Jfsx72bcB9OEa6F8cneFp0dLT+85//qFWrVqpQoYKGDh2qt956S/fee+9N5y1YsKCmTJmiWbNmqUqVKho7dqzGjRuX4bRjx47V008/rTp16ujw4cOaN2+egoOD3b06fsEXjrM2Y/7/eaMAAAAAAACwW7FihZo2bapTp04pJibG2+XATbgyDAAAAAAAAH6DZhgAAAAAAAD8BrdJAgAAAAAAwG9wZRgAAAAAAAD8Bs0wAAAAAAAA+A2aYQAAAAAAAPAbNMMAAAAAAADgN2iGWVxCQoJq1qxp/71Xr17q0KFDjrwWAPciz4B1kGfAGsgyYB3k2b/QDHOzI0eO6Mknn1SZMmUUEhKiEiVKqG3btlq6dKnbXqNJkyYaOHBglqZ97rnn3Pra6Ww2m+bOnZsjrwV4C3kmz7AO8kyeYQ1kmSzDOsgzefamIG8XYCX79u1To0aNFBMTozfeeEPVq1fXlStXtGjRIvXv3187duzIsVqMMUpNTVVkZKQiIyNz5DVz8rUATyPP5BnWQZ7JM6yBLJNlWAd5Js9eZ+A29957rylWrJg5d+6c07hTp04ZY4zZv3+/adeunYmIiDBRUVGmU6dO5siRI/bpRowYYWrUqGGmTp1q4uLiTHR0tHnwwQdNUlKSMcaYnj17GkkOP3v37jXLly83kszChQtNnTp1TJ48ecyyZcvsy0vXs2dP0759e5OQkGAKFixooqKizGOPPWYuXbpknyYuLs68/fbbDvXXqFHDjBgxwj7+2tePi4tzqD1damqqGTlypClWrJgJDg42NWrUMD/88IN9/N69e40kM2fOHNOkSRMTFhZmqlevblavXm2fZt++faZNmzYmJibGhIeHmypVqpgFCxa48rYA2UKeyTOsgzyTZ1gDWSbLsA7yTJ69jdsk3eTkyZNauHCh+vfvr4iICKfxMTExMsaoQ4cOOnnypFauXKklS5Zo9+7devDBBx2m3b17t+bOnav58+dr/vz5WrlypcaOHStJmjBhgho2bKhHH31Uhw8f1uHDh1WiRAn7vC+88ILGjBmj7du3q3r16hnWunTpUm3fvl3Lly/XjBkz9O2332rkyJFZXtfExERJ0meffabDhw/bf7/ehAkT9NZbb2ncuHHavHmzWrRooXbt2umPP/5wmG7IkCF67rnntHHjRlWoUEFdunRRSkqKJKl///66dOmS/vOf/2jLli16/fXX6aDD48izM/KM3Io8OyPPyI3IsjOyjNyKPDsjz17g1Vachaxbt85IMt98802m0yxevNgEBgaaAwcO2Idt3brVSDI///yzMeZqhzg8PNzezTbGmOeff97cdttt9t/j4+PN008/7bDs9O723LlzHYZn1N2OjY01ycnJ9mEffvihiYyMNKmpqcaYm3e3jTFGkvn2229v+FpFixY1r732msM09erVM0888YQx5n/d7UmTJjltj+3btxtjjKlWrZpJSEgwQE4iz+QZ1kGeyTOsgSyTZVgHeSbPvoArw9zEGCPp6pfjZWb79u0qUaKEQze6SpUqiomJ0fbt2+3DSpUqpaioKPvvRYoU0dGjR7NUR926dW86TY0aNRQeHm7/vWHDhjp37pwOHjyYpdfIiqSkJB06dEiNGjVyGN6oUSOHdZXk0IUvUqSIJNnX96mnntKrr76qRo0aacSIEdq8ebPbagQyQ54dkWfkZuTZEXlGbkWWHZFl5Gbk2RF59g6aYW5Svnx52Ww2p531WsaYDAN//fA8efI4jLfZbEpLS8tSHRldZppV6TUEBATYD1Dprly58reWmS6jbXDt+qaPS1/fRx55RHv27FH37t21ZcsW1a1bV++99162agGyijzfeJnpyDNyA/J842WmI8/wdWT5xstMR5aRG5DnGy8zHXn2LJphbhIbG6sWLVro/fffV3JystP406dPq0qVKjpw4IBDF3nbtm06c+aMKleunOXXCg4OVmpqarZr3bRpky5cuGD/fe3atYqMjFTx4sUlSQULFtThw4ft45OSkrR3716HZeTJk+eGNURHR6to0aL68ccfHYavXr3apXWVpBIlSqhv37765ptvNGjQIE2cONGl+QFXkWdH5Bm5GXl2RJ6RW5FlR2QZuRl5dkSevYNmmBt98MEHSk1NVf369TVnzhz98ccf2r59u9599101bNhQd999t6pXr65u3bppw4YN+vnnn9WjRw/Fx8dn6RLNdKVKldK6deu0b98+HT9+PMud73SXL1/Www8/rG3btumHH37QiBEjNGDAAAUEXN0d7rrrLk2bNk2rVq3Sb7/9pp49eyowMNCphqVLl+rIkSM6depUhq/z/PPP6/XXX9dXX32lnTt36qWXXtLGjRv19NNPZ7nWgQMHatGiRdq7d682bNigZcuWuXxAALKDPDsiz8jNyLMj8ozciiw7IsvIzcizI/Kc84K8XYCVlC5dWhs2bNBrr72mQYMG6fDhwypYsKDq1KmjDz/8UDabTXPnztWTTz6pxo0bKyAgQC1btnT50sXnnntOPXv2VJUqVXThwgWnzvPNNGvWTOXLl1fjxo116dIlde7cWQkJCfbxgwcP1p49e9SmTRvlzZtXo0aNcnqNt956S88++6wmTpyoYsWKad++fU6v89RTTykpKUmDBg3S0aNHVaVKFc2bN0/ly5fPcq2pqanq37+//vzzT0VHR6tly5Z6++23XVpfIDvIsyPyjNyMPDsiz8ityLIjsozcjDw7Is85z2auv8EVAAAAAAAAsChukwQAAAAAAIDfoBkGAAAAAAAAv0EzDAAAAAAAAH6DZhgAAAAAAAD8Bs0wAAAAAAAA+A2aYQAAAAAAAPAbNMMAAAAAAADgN2iGAQAAAAAAwG/QDAMAAAAAAIDfoBkGAAAAAAAAv0EzDAAAAAAAAH6DZhgAAAAAAAD8xv8By4dOd1Mr0OwAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1500x400 with 5 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cns.consistency_plot(max_features=21)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Int64Index([167, 307, 333, 378,   1, 305,  87, 280, 287,  83, 121, 337,  92,\n",
+       "            220, 104, 246, 321, 326, 317, 273, 327, 145, 353, 258, 334, 103,\n",
+       "            306, 127,  24, 291, 233, 372,  32, 373, 352, 232,  94, 183, 113,\n",
+       "            312, 304,  12, 349, 332, 106, 135,   0, 208, 154, 169, 272, 132,\n",
+       "             52, 268, 209, 322,  20, 324, 370, 155, 228, 340, 299, 308,  36,\n",
+       "            139, 184, 345, 193, 245,  91, 165, 170, 163,  18,  46,  25, 359,\n",
+       "             51,  72,  14, 253, 186, 277, 316, 240, 270, 239,  47,  50,  73,\n",
+       "            124, 380, 187, 250, 138,   4, 112,  23, 384],\n",
+       "           dtype='int64')"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cns.index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmMAAAJfCAYAAAAzcNGrAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8o6BhiAAAACXBIWXMAAA9hAAAPYQGoP6dpAAC4NklEQVR4nOzddVwU2/sH8M/SDUooSliIeFV0UURBWcTG7u6+F7v1qtit17p2d+u1g1BRsMVOGiVUQjrO7w9+O99dd4GlHMDn/Xrd15WZ2ZlnZmdmnznnzDkCxhgDIYQQQgjhhRLfARBCCCGE/M4oGSOEEEII4RElY4QQQgghPKJkjBBCCCGER5SMEUIIIYTwiJIxQgghhBAeUTJGCCGEEMIjSsYIIYQQQnhEyRghucjIyOA7BEJIEaBrmZRkKnwHQGS9fPkSN2/eREBAAIKDg5GQkABlZWXo6+ujZs2asLe3R7t27VCuXDm+Q+WFnZ0dAMDU1BQXLlwolm3Ex8dj06ZNqFevHjp06FAs2yBFJzw8HHv37oW/vz9iYmIAAAYGBhgyZAh69erFc3T8efjwIUaPHg0A6NChAzw8PHiO6NfL61oeNWoUHj16BAD477//UKlSpV8dIiGUjJUkz549w/r16xEQECAzLz09HSkpKYiMjMTt27exadMmDB06FEOHDoWKCn2NRenBgweYPXs2vn37hjp16vAdDslDaGgoBg0ahPj4eKnpkZGR0NDQ4CkqUhLQtUxKC/oVLyG2bt2KnTt3QjxUqLKyMho0aABra2sYGBggIyMDwcHB8PPzQ2xsLFJTU7F161Y8e/YMq1atgqamJs97UHY8fvwY37594zsMoqAdO3ZwiZiBgQHatGkDIyMjJCQkQCgU8hwd4RNdy6S0oGSsBFi/fj0OHDjA/d2lSxeMHTsWRkZGMsump6fjwIED2Lp1KzIzM3Hv3j3MmzcPq1at+pUh80pcpUAIALx794779+rVq9GgQQMeoyGlzfbt2/kOgRBqwM+3GzducImYQCDA/Pnz8ffff8tNxABAVVUVw4YNw8KFC7lpnp6euHLlyi+Jl5CSJikpifv3H3/8wWMkhBBSMJSM8Sg1NRWrV6/m/h4yZAg6deqk0Gfbtm2L9u3bc39v3bqVq+Ik5HeSlZXF/VtNTY3HSAghpGAEjH7BeXP69GksWbIEQHZbl4sXL+arwXFwcDC6desGALC0tMTGjRtRuXJluct++vQJp06dwqNHj/D582ekpaXBwMAA1tbWEIlEcHNzg6qqqtzPRkREoGPHjgCAv/76C0OHDkVoaChOnDiBu3fvIjIyEgKBAKampmjWrBn69OmTY8me2N27d3HlyhU8e/YM0dHRAIBy5crB2toaTk5OcHNzg7q6utzPKvI2ZUHWP3/+/Fzfzpw/f77cZPnLly84ffo07t27h/DwcCQlJXHHtkWLFnBzc8vxJYviOLZAdqP206dPw9/fH6GhoUhLS4O+vj5sbGzQpk0btGnTBsrKytzyGzZswL59+wAo9tZdcnIyWrduze3rlStXcjx/cpOZmQlPT09cv34dL1++xPfv36GiogJjY2PY2dmhY8eOqFu3rszntm3blmf1Uk7flyKeP3+O//77Dw8fPkRMTAwyMjJgZGSE+vXro3379nBwcJD7uZUrV+LYsWMAAC0tLZw4cQIVK1aUu6zkPhgaGuLYsWPcG9LiN/zE5/iPHz9w+PBh3LhxAxEREWCMwcLCAk5OTujTpw8MDQ3lbkPRtykZY/Dx8cHt27fx/PlzxMTE4MePH9DS0kK5cuVQt25dtGrVCs2aNZP7+eI6j+/fvw9vb288ffoU0dHRiI+Ph7q6OgwMDGBjYwMXFxe0atVK6lwG8nctK/o2ZWJiIs6dO4c7d+7gw4cPiIuLg7a2NipXrgwHBwd07949x+9acjuWlpY4ffo00tPTcebMGVy/fh1BQUH48eMHypUrhwYNGqBLly5o1KhRrscmIiICZ8+ehZ+fH4KDg5GSkgI9PT1UqlQJ9vb26Ny5M8zMzHL8fIcOHfD582cuNvF5QvhBbcZ4JFm12KZNm3y/+WVpaYktW7bAysoK5cuXl7tMSkoK1q1bh1OnTsmUnEVFRSEqKgq3b9/G7t27sXz5ctSuXTvP7V64cAHLli1DSkqK1PQPHz7gw4cPOH78OFauXCn3Bys5ORmzZ8/GrVu3ZOZ9+fIFX758gY+PD3bs2IG1a9fCxsYmz3h+5fp/duDAAfz7779ITU2Vmh4dHY3o6GjcuXMH+/btw6pVq1C9evU811eYYwtklxJt3rwZBw4cQGZmptS8r1+/4s6dO7hz5w6OHTuGtWvXcj/ibm5uXDLm5eWF2bNn55gMA8CtW7e46sE2bdoUKBH78OED5s6di/fv30tNT01NRWJiIoKCgnDq1Cm0adMGf//99y95SSU1NRVLlizBxYsXZeaFh4cjPDwcFy9ehKOjI5YsWQJdXV2pZdzd3XHv3j2EhIQgKSkJK1euxNq1a2XW9fr1a+zatYv7e968eTl2VRMaGgp3d3eEhoZKTX/37h3evXuHY8eOYdWqVWjcuHFBdhmBgYGYMWMGPn78KDMvISEBCQkJCAkJwcWLF9G0aVOsWLECWlpaua6zsOdxdHQ0Zs6ciadPn8rMy8jIQGJiIsLDw3Hjxg0cPHgQ//zzT44JaVHw9PTE4sWLERcXJzU9Li4OcXFxePXqFQ4ePIhRo0Zh6NChea4vPDwckydPxocPH6SmR0ZG4sqVK7hy5Qq6d++OWbNmQSAQyHz+7NmzWL58OdLT06Wmf/v2Dd++fcOLFy+wb98+jBw5EiNHjizAHpNfjZIxnqSkpEjdaPJ6CspJbjfgjIwMTJs2DXfv3uWm/fHHH2jYsCG0tLQQEhICHx8f/PjxA+Hh4RgxYgQ2bdqU6xtod+/exdOnT5GVlYXq1aujSZMm0NPTQ3BwMG7evImUlBQkJiZi+vTpOHfunMwPzKpVq7hESVtbG82aNYOlpSUEAgHCw8Ph6emJxMREREVF4c8//8TZs2ehp6en8PEozPrbtGmD6tWrw8/PD/7+/gCA1q1bcwnbz+2RJEuTAMDW1hYNGjSAtrY2Pn/+jFu3biEmJgbBwcEYOnQodu3aBSsrq2I7tgCwaNEinD9/nvu7Ro0acHBwgLa2NoKCguDp6Yn09HS8ePEC48aNw/79+6Guro7q1aujVq1aePPmDRITE+Hr64sWLVrkGOvly5e5f0tWlyvqw4cPGDFiBBISEgAAGhoaaNasGapXr4709HQ8e/YMDx8+BABcvXoVYWFh2L59O/fA4uDgwCVne/bs4d6mnDBhAreN/LYfS09Px7hx47jrUkVFBY6OjrC2toZAIEBgYCBu376N5ORk+Pr6YsSIEdizZ49UYqKpqYkFCxZgxIgRyMrKgo+PDzw9PaWOZWpqKubNm8cly7169YKTk5PcmFJTUzFp0iSEhoZCTU0NLi4uqFatGr59+wZPT09ER0cjMTEREyZMwLp169CkSZN87XNUVBSGDx/OJRlGRkZwcnKCqakplJSU8OXLF9y9e5crQbl79y42btyIGTNm5LjOwp7HycnJGDFiBMLCwgAAenp6cHJygrm5OVRVVRETEwN/f38EBgYCyE5sFy5ciH/++YdbR36v5dxcunQJ8+bN4x5mDQ0N4ezsDFNTU8TGxuLevXv49OkT0tLSsGnTJkRFReV6fJKTk+Hu7o7g4GDo6upCJBLB3Nwc8fHx8PHx4ZLuU6dOwdraGt27d5f6/OPHj7F48WIuHqFQiHr16kFHRwcxMTF48OABPn78iMzMTGzduhUVK1bkSi1JCcYIL169esWEQiH337dv34p8G1u2bOHW7+TkxDw9PWWW+fbtG3N3d+eWa9WqFfv+/bvUMuHh4VKxNmrUiJ05c0ZmXSEhIaxdu3bccrt27ZKa//nzZ9awYUNuO2FhYXLj6dmzZ47rYIxx89zc3Ipl/Vu3buXmnzt3TmY+Y4x5e3tzy7i4uDA/Pz+ZZVJSUtiKFSu45bp27crS0tKklimqY8sYY9evX5daz6lTp2SWCQoKYm3atOGW27lzJzfv0KFD3PRp06bJ3W/GGPv+/Tuzt7fn9im/0tLSWMeOHbltDRkyhH358kVmuYcPH7IWLVpwyy1cuFDu+tzc3LhlCmPNmjXcevr27ctCQ0NllomKimLDhw/nlps/f77cda1fv55bpk2bNiwhIUHudrp168aSk5NlPj9y5Eip86Jjx47s06dPUsskJSWxadOmSS2TmpoqtcyDBw+4+fPmzZPZzt9//83NnzBhAktJSZFZJj09na1cuVLqXvLzckV5Hv/777/c/IEDB7K4uDiZZRhjbN++fVLblHcOKXItSx7r8PBwqXmfPn3iznWhUMgWL17MkpKSpJbJyspiR44cYY0aNeKWu3jxYq7bEQqFbNKkSSw+Pl5qmfT0dKnvpEuXLjLrGTt2LDf/xIkTMvOzsrLYhg0bcl0HKXmoAT9PIiMjuX+rqKgUeW/6379/x+HDh7m/Fy9eDBcXF5nlypUrhzVr1qBWrVoAsquyJD8nz5AhQ9ClSxeZ6ebm5hgzZgz39/3796Xmv3r1imts3bp1a7nt28qVK4epU6dyf79+/TrXWH7l+sUYY9i8eTOA7Ddg16xZI7eEUl1dHdOnT+dKK4KDg6VKlOQp6LEFIFVK5+7uzrUnlGRpaYlFixZxf586dYr7d7t27bi2N3fu3EFiYqLcGK9fv84NLVOQUrHz588jPDwcAFCpUiVs3LgRFSpUkFnOzs4O69ev52I6f/48goOD8709RURFRXFtvQwNDbFlyxa57W2MjY2xbt06rlnAxYsXZaoPAWDs2LGoVq0agOwqty1btgAAnjx5giNHjgDIvu6XLFmSZ/MEDQ0NbN68GVWrVpWarqmpiaVLl8La2hpAdtXX2bNnFd7n5ORk3LhxA0D2uTpv3jy5VdMqKiqYOHEiVyWblJSU5/dQmPNYsq3X33//nWPJ+KBBg7hjDBTsWs7Ljh07uHO9RYsWmDNnjkx1uUAgQJ8+feDu7s5N+/fff3Mdfsnc3BzLli2TqeZWUVHBzJkzudLWkJAQfPnyRWqZFy9eAAB0dXXRo0cPmXULBAL89ddfXPu16OhoblQKUnJRMsYTydfxDQwMinz9t2/f5rZhZ2cHZ2fnHJdVVVWVqt45d+5cruvu2bNnjvMkq1u/fv0qNU+yke2rV69yvFnZ2dnh6NGjuHPnTr76Tyvu9YsFBARw7Wvs7Ozy7NdqxIgR3L/ltUWSVNBjGxkZiVevXgHIPp/69OmT63oaNWqExo0bo3nz5khOTgaQnag2bdoUQHb1mJeXl9zPixNKgUCAdu3a5bo/8ki2lRw5ciR0dHRyXLZu3bpo06YNgOz2cP/991++t6eICxcucOdLjx49cr0mdXV1ueOblZUlN8FWU1ODh4cHd06eOHECT58+hYeHB/fAMHbsWO4hKDe9evWCubm53HkqKipSbYI8PT3zXJ9YRkYGpk6diiFDhmDUqFE5tjsFsu8RVapU4f7+8eNHrusu6Hmcnp6OUaNGYcSIERg8eHCu1foApObnFVN+paSkcNeAQCCQukfK079/f5iamgLIblz/4MGDHJft1KlTjm0ytbS0pNqy5nQfTUpKkmlzJiYQCLB161ZcvXoVd+7cUehlCcIvSsZ4Ipk4/NwIsyhI3ghya/sjZm9vD319fQBATEwMQkJC5C5XoUIFGBsb57geyR+xnxu1161bl2vo/ezZMwwbNgz//fef3JuNlZVVvhtsF/f6xSQ7nVXkBYDatWtzcT1//jzHJLEwx1bcLgbIbkeYV4P6rVu3YsuWLZg5c6bUcZAcu+/q1asyn4uIiOCG66pfv36Ob+/mJCUlBc+fPweQ/YMhr7T2Z61ateL+/fjx43xtT1H5/U5tbW25f8trZA5kf+9DhgwBkJ20jRs3jitFs7Ozw6BBgxSKrXXr1rnOd3R05N7Wffz4sUyj+Zzo6uqiW7ducHd35+LMSUREhNQDZG6lPoU5j1VVVdGpUyeMHTsW48ePzzWmr1+/IjY2VqGYCiIgIABpaWkAAGtr61zfTAQAJSUlqXttbudqXkMzSdaUiGMQE7fpzczMxMiRI7F9+3a8efNG5gUtc3NzSsJKEWrAzxPJ4un4+HhkZmbKvJ5dGOJqIABcNUZeatasySVxYWFhsLCwkFkmr4tb8of955tD+fLlMXjwYOzcuRNA9oDoL1++hEAgQM2aNeHg4ABHR0fY2toWaLzN4l6/mLjhMJD9NqXk6Al5SU1Nxffv3+X+WBXm2EpWeyvy1mZOmjdvDj09PcTHx8Pf3x/fv3+X+mG4cuUKt+2CVFFGR0dzDx+VKlWSqaaRp2bNmty/xY26i5rkdzpx4sR8ffbnaiRJI0eOxO3bt/Hu3Tsu8dDR0YGHhweUlPJ+FlZRUcmzdEhNTQ1mZmYICgpCZmYmoqOjcyxJy0tUVBRCQkIQFhaG0NBQBAYG4s2bN1LnFyB7/kkqzHksz7dv3xAcHIywsDCEhYUhMDAQb9++lTkXFFlXfhTkHiq5nOTnf5bXMZKsupbsRw8AxowZA39/fyQnJyM+Ph7btm3Dtm3bUL58eTg4OKBJkyZwdHTkHq5J6UDJGE8kb5aMMXz79i3Xp8n8knwFW9G3ESUv3p8HXRbLT/cb8m6OY8aMgaamJrZv3879ODHG8PbtW7x9+xb79u2DgYEBWrdujcGDB+fab488xb1+ADKvt+dXQkKC3O+6MMdWcvw9RRKcnKipqaFVq1Y4deoUMjMzcePGDakqJ3GVnHi5/JIsyVD0x0KR87KwCvOd5haTqqoqpk2bJlWV2LVrV646Ky96enoKPThIXuPfvn3LVzL27ds37Nu3D1euXMm1bZGysrJMdynyFPYeAWT36XX48GH8999/uSY1isZUEIW9h+Z2ThXmGFlZWeHff/+Fh4eH1EPEt2/fcOnSJVy6dAnKysqwt7dH37594ejoqPC2CH8oGeNJ5cqVuRIIILuqoyA/bs+fP0d6erpUFR0gfQHL66dGHsknMEWe2gtCIBBgyJAh6Nq1K27cuAEfHx88fPhQqroiNjYWx48fx/nz57Fq1SquHVNJWD8AqZt/x44dpRoRK6KoX9YAUKQ/SG5ublzD/itXrnDJ2Nu3b/Hp0ycAQLNmzQqV9AEl67yUPH5jx47NV0/+ufXHBki/JAFkd/bcu3dvhRIyRUtwJePPT59vT58+xeTJk2USBzU1NZibm8PKygp169aFg4MDli5d+kvGhQ0MDIS7uzvXnYaYsrIyzMzMUKNGDdSpUwf29vY4cuRIrp27FkZJvYcC2U0yjh8/Dn9/f3h6esLX11eq9FI8bvG9e/fQpUsXzJ07V+F9IPygZIwnSkpKaNSoEW7evAkA8PPzK1Aytm3bNty7dw8aGhoYMWIE1+Gg5BOaZGlEbiSXy61RdVHQ19dH9+7d0b17d6SlpSEgIAD379/HnTt38PbtWwDZ7Ytmz56NCxcu5Due4ly/5FNyvXr15L61+KtJxl/Yhsy2trYwNzdHaGgonj17hqioKJiYmEi1IXNzcyvQuiWPXUk6L/X09Li2ha1atYKlpWWRrFdy3FiBQADGGBITE7Fw4UJs2bIlzx9IRb9LydI5RdsJxcbGYtq0aVwiZm1tjT59+qBevXowNzeXaTahaFu0wkhPT8e0adO4RMzMzAz9+/dHgwYNUKVKFZlEszhjKuw9tLAPK3lRUlJCkyZNuLe1AwMD8eDBA/j5+cHPz497AD179iyEQmGBr1nya1ADfh61bduW+7eXlxf3VpuiPn/+zL0anpKSIvUDIllN8e7duzzXxRiT6gk9r8aqRUlNTQ0NGzbEuHHjcPjwYezYsQPa2toAsqv0bt++XaLWL9loXfyaeV4UvZkXlOT3FRQUlOfy//33HxYvXow9e/bI7aZA3B6MMcYdH3Fnuvr6+vkuTRSrWLEi94MaERHBdfqaG3HyDBTfeSn5nb58+TLP5dPT03Ps+kPs+/fvWLZsGff3woULue3cv38fJ06cyHM7SUlJMu21fpacnMxV5WlpaeX6VqSks2fPctXbtWrVwt69e9GpUydUqVJFbvvV79+/c/8u6vZZYl5eXlzVW4UKFXDgwAH06tULVlZWckv8ijMmyXNNkXsoIH2u5vfllsKqWrUqevXqhbVr1+Ly5ctSb63m9RY34R8lYzxq3rw5d8HHxcVJDY+iiH///ZernhCP+SZWv3597t/i0rfc+Pv7cz+M5cqVK3AD4Nzs2bMHI0aMgKurK549e5bjckKhkOvOAMhuVPwr159XaYXkCAXe3t55JtFv376Fq6srnJycMHDgwCJ/6wuQfrvP398/z2rLS5cu4cyZM9i0aZNUezOxDh06cMfBx8cH4eHh3I9kQYc/ArKr9MRDbjHGcuw+Q5Lk+Su5n0VJsnsSya43cnLixAk0b94cLVq0wNKlS+Uus3z5cu7Yurq6on379pg1axY3f8OGDQq9kODr65vr/Nu3b3PVY5JvVuZF/FYrkP1951Y1GxERgYiICO7vnxuVFxXJmFq2bJlrW62UlBSphyF5yVhhqubq1q3LHcu3b9/K7U9OUlZWltT5XBzn6rNnzzBp0iR07tw5x/MOyH5gGjduHPe3ovdQwh9KxnikoqIi9fr2vn37cOnSJYU+e/z4camnnTFjxkj9QLZs2ZJ7a+nx48fw8fHJcV3p6enYtGkT93ebNm2KpX3B169f8eTJE8TGxubZ+alkgqDoiw1FtX7Jth7yfnQaNWrEdVIaFxeHHTt25Lot8bFNTk5GpUqVCvUmZ06qV6/OvckVExOTa19xgYGBXNsfQ0NDua/ZV6pUiUtQHj58iGvXrnHzCvIWpSTJ7jN27NiRa1Xcy5cvcf36de5vySS6KEkmn76+vrkmQPHx8di7dy+A7O+/Ro0aMstcu3aN61BVR0cH06ZNAwA0adKEKxFPTk6Gh4dHniU6Bw4cyLE6Lj09nXt7GMi7G4yfPyuWV8ntz+NrFscDBSDdjUNeMW3ZskWqLai8mPK6lnOjqakJV1dXANmJ3saNG3Nd/siRI1wpZrly5WBvb5+v7SlCQ0MDt27dQlhYGLy9vXMtnZW8x5mYmBR5LKRoUTLGM1dXV66n6qysLPz9999YunQpoqOj5S4fGxuL5cuXY8WKFdy01q1bS/3AAdltYPr168f9PXfuXHh7e8usLy4uDtOmTeN6rzY0NMTw4cMLuVfyde7cmfv3yZMnce7cObk/RDdv3uSqxDQ1NRWuEiuq9YurMAFIlQaIqaqqSnXkum/fPmzfvl3mxyA1NRWrVq3ixgZVVlaW+lxRk1z36tWr5XYA+vnzZ8yYMYMrORswYECOpVziNiapqanYs2cPgOwe/OvWrVuoON3c3LgS4YiICLi7u8utinvy5AkmTpzIxdqpUyeFOkktiGrVqkklMrNmzZL7ABMTE4MpU6Zw7csqVqwodd4B2Q8Fy5cv5/6eMGGCVMI/depUrj3S48ePuR75cxISEoLp06fLVOkmJCRg2rRpUh0QK9Jvm5hklxknT56UW/ITGxuLmTNnypRgFldbLcluTG7cuCFVUiaWnJyMlStX4tChQ3nGlNe1nJdhw4ZxJYY3b97EkiVLZErCGWM4efKk1NiYEydOzNdLIIqytrbmHrq+fv2KuXPnyq3q//r1q1Q8ivQ1SfhFDfhLgNmzZyMlJYWrHjl16hTX6LJ27drQ1dVFUlIS3r17hwcPHkg9DYpEInh4eMhd76hRo7gBl5OSkjBlyhTUqVNHZqBw8cWspqaGRYsWKdzmJL+srKzQvXt3nDp1CowxLFy4EEePHoWtrS1MTEyQnJyMgIAAboBoILvET9ERCopq/ZJtPQ4ePIj09HTo6OhAKBRypUXdunXDkydPuJLMbdu24cKFC2jWrBnKly+PyMhI3Lp1Syqpdnd3z7PPqMJo0aIFevTogZMnTyI1NRXTpk2Dra0t7OzsoKmpicDAQHh6enI/WkKhUCph/1nLli2xcuVKpKamck/ghS0VA7KrKleuXImRI0ciMTERAQEB6NatG5o3b45q1aohIyMDAQEBePDgAZdMW1lZYfr06YXedm5mz56N9+/f49OnT0hMTMTkyZO560VdXR3BwcHw8vLirj91dXUsWbJE5m3KJUuWcI3iGzRogK5du0rNL1euHCZOnMhdt5s2bYKjo2OOLw2oqKjA19cXXbp0gaurKypWrIgvX77g5s2bXOlR+fLlMWfOnHyVaHfr1g1HjhxBamoqYmNj0atXL7Ro0QKWlpZIS0tDUFAQfH19udIqFRUV7oGjsN275KR169bYunUrvn37htTUVAwfPpw7LwQCAUJDQ6WG6sorJkWu5dzUqFED06dPx5IlS8AYw+nTp+Hj4wORSISKFSsiPj4ed+/e5RJiIPuh8OeH46I0bdo0jB49GpmZmbh16xY6duyI5s2bc6XuISEhUqVmtWvXRqdOnWTW06FDB+5FiVGjRmH06NHFFjPJGyVjJYCysjKWLFkCOzs7bN26FV+/fkVmZiYePHiQ45Aa2traGDNmDPr06ZPjK9QqKirYuHEjli9fjvPnz4MxhhcvXshtdG5hYYHly5cr3LlhQU2bNg2pqanc6+jv3r2T2zhWTU0NI0eOxIABA375+u3t7WFmZoawsDCkpqZi//79AIA+ffpI3cA9PDxQsWJF7N+/HxkZGQgPD8fRo0dl1qeuro7x48fnOkRRUZk5cyb09fWxd+9eZGZm4tmzZ3Lbzzk7O2PhwoW5Vpnq6OhAJBJxb1EWdPgjeaytrbF7927MnDkTgYGBSElJkaoKldShQweZkQKKg46ODnbv3o158+ZxJac5XS8VKlTAokWLpNpmAtkNpcUlampqajkmSJ06dcLFixe5blcWLFiAXbt2yb2WFyxYgFWrViE2Nlammwwgu4p6/fr1qFSpUr72t3Llyli8eDHmzp2L1NRUpKWlyW0vJxAI0LVrV9jY2GDJkiUAimccSCD7DcTVq1dj0qRJiIuLQ2ZmJry8vOS2LXRxcYGbmxs31qy8mBS9lnPTtWtX6OjoYNmyZYiLi8PXr1/lfg+qqqpwd3dH//7987PL+dagQQMsW7YMHh4eSExMREJCQo4N9O3t7bF06dJiKaUjRYuSsRKkW7duaNeuHXx8fODr64t3794hKioKiYmJUFVVRbly5WBtbQ0HBwe0a9dOodf81dTUMG/ePPTu3Rvnzp3Dw4cPERkZieTkZBgYGKBWrVpo2bIl2rVrV+BG2fmhqqoKDw8PdOnSBRcuXMDz58/x5csXpKSkQE9PD6ampmjatCk6duxYoDfnimL9Ghoa2LFjBzZt2gR/f3/ExcVBT09PZtgqJSUl/Pnnn+jcuTPOnDmD+/fvIzw8HD9+/ICWlhYsLCzg4OCQr04+C0sgEGDcuHFo3749Tp8+DX9/f27/y5cvj7p166Jz584KdwTZvn17LhkryPBHualRowaOHTuGq1evwsvLCy9fvkRsbCwYYzA1NYWdnR06depU6GrR/NDV1cW6deu4Us/Hjx8jOjoaqamp0NPTg5WVFZydndGxY0duMGex6OhoqbFOhw0bJjO4t6Q5c+agT58+SE1NRUBAAA4ePCh3iCRbW1ucOHECBw4cgLe3NyIjI6Gurg5ra2u0a9cObm5uBb52W7RogWPHjuHw4cO4f/8+Pn/+jMzMTGhra8PMzAx16tRB586dYW1tjejoaCgpKSErKwve3t6YNm1asSTItra2OHbsGI4cOYK7d+8iPDwcqamp0NbWhqmpKWxsbODm5gahUIi0tDTo6uoiISEBjx49QmRkpNSg84pey3lp1aoVHBwccObMGfj6+iIwMBBxcXFQV1eHhYUFmjRpgm7duv2y69zV1RW2trY4d+4c/Pz8EBgYiISEBKipqcHIyAj16tVDq1at4OTk9EviIYUnYMX1jjIhpNQ7f/48V502d+5cmSo3UjxGjRrFvWTx33//5bvUixBSulADfkJIjsRt4jQ0NArUKTEhhJC8UTJGCJErMDCQe9mhZcuWxT4qAyGE/K4oGSOEAMju7V3caiEwMBAzZszg/v4VLx8QQsjvihrwE0IAZLcP27RpE9TU1KS6CWjVqhVsbGx4jIwQQso2SsYIIQDA9cUm2amlhYUFZsyYwWNUhBBS9lE1JSEEQHZ/VTVq1ICamhqMjY3RrVs37Nq1C+XKleM7NEIIKdOoawtCCCGEEB5RyRghhBBCCI8oGSOEEEII4RElY4QQQgghPKJkjBBCCCGER5SMEUIIIYTwiJIxQgghhBAeUTJGCCGEEMIjSsYIIYQQQnhEyRghhBBCCI8oGSOEEEII4VG+kzE7OzvY2dnh/PnzeS57/vx5bvmyTLyP/v7+xbqdbdu2wc7ODsOGDZOa3qFDB9jZ2eHMmTPFun3ya82fPx92dnaYO3cu36EUWHJyMiIiIqSmie8L7dq14ymq4pGeno4tW7agY8eOcHBwQMuWLbFt2za+w/plIiIiuHthaGgoNz237zsmJgZz585Fq1at4ODggLZt2+Lu3bsAgAsXLqBv375o2rQpnJ2d8ddff/2yfflVMjIyEBwczHcYhRIXF4eYmBipaTn9VvGlqO85SUlJ2L17N/r3749mzZqhSZMm6NSpExYuXIiPHz8WaJ1UMkYIKRaXL19Gt27div0hpaRYt24ddu3ahYiICFSqVAkmJiYwNTXlO6wSKysrC+7u7rh8+TLi4uJQrVo16OrqwtTUFDdv3sT8+fPx7t076OrqwsLCApUrV+Y75CJ179499OrVCxcvXuQ7lAI7fPgwunTpUuAEpDSKiorCgAEDsHnzZrx58wa6urowNzfHly9fcO7cOfTv379A36lKMcT62zl58iQAoGLFisW6nV69eqF169bQ0NAo1u0QUhQ2b96MqKgomekuLi6oW7cuVFTK1u3n+vXrAIAhQ4bA3d2d52hKjpy+7+DgYLx79w4AsH79ejRt2pSbJy5RrF+/PrZt21bmzhUA2LNnT6kvFVuzZg3fIfxys2bNQnBwMIyNjbF06VIIhUIAwPfv37Fo0SL4+PjAw8MD1apVg42NjcLrpZKxIlC1alVUrVoVmpqaxbqdcuXKoWrVqvS0TUo1XV1dVK1aFebm5nyHUqRiY2MBoMw3y8ivnL5v8fECgIYNG8qdV79+/TKZiJHS6fHjx3j69CmA7GYk4kQMyP59Xr58OapXr47MzEwcOHAgX+umZIwQQopAVlYWAEBNTY3nSEqHzMxM7t8/HzM6lqQk8vX1BQBUrlwZTZo0kZmvpqaG1q1bAwDevHmTr3Xz+sgRFRWFw4cP486dO4iIiICSkhLMzc3h4uKCvn37QldXFwDAGEP79u0RFRWFxYsXyzTCu3TpEv7++28AwLFjx1CjRg2p+WvXrsWhQ4fQu3dvTJ8+Pc+4AgMDsX//frx48QIRERFQVlaGmZkZHB0d0bdvX5QvX15qefGT8JYtW9C4cWMA2Q0GPTw80K5dO8ycORO7d+/GjRs3EB0djXLlysHZ2Rl//vkndHR08O7dO+zcuROPHj1CYmIiKleujG7duqFfv34QCATcdrZt24bt27fD1tYWu3fvVugYv337FidOnMCTJ08QHR2N1NRU6OnpwcbGBp06dULLli2llhfH3bp1a/Tu3RsrVqxAYGAg9PX1MWjQIPTv3z/PbUZHR+P48ePw9/dHaGgoEhMToa2tjSpVqqBFixbo2bOnVFVrREQEOnbsCENDQxw6dAiLFi3Cw4cPoa6ujiZNmmDp0qXcso8fP8bRo0fx9OlTxMXFQU9PD3Xr1kWfPn1gb2+v0DH5mbe3N06fPo1Xr14hISEB5cqVg1AoxMCBA6WKmRljGDt2LB48eABDQ0OcOHEC+vr6UuuaP38+Lly4AGNjYxw5cgTlypXjvre+ffti8ODB2LhxI+7du4fExERUqlQJrVu3ljrfFVGYY3z16lWcO3cOp0+fRmBgIACgevXq6NatGzp27Ch1zonl5zwS76/Y4sWLsXjxYowaNQqjR4/mzjETExNcvnxZZlv379/HiRMn8OzZM8TFxUFHRwe1a9dG165d0aJFC5nlO3TogM+fP+PkyZP49u0b9u3bhxcvXiA5ORmVKlVCq1atMGjQIGhpaUl9LjMzE6dPn8b169cRHByMuLg46Ovro06dOujcuTOaN2+u0Hch3r7Y6NGjAWTfF7Zv384dj8GDB6Nu3brYuHEjIiIiYGRkBHd3d7Rp0wYAkJKSglOnTuHatWsIDAxEeno6jI2N4eDggAEDBsDCwkJquw8fPsTo0aNha2uLbdu24cCBA7h48SIiIiKgq6sLBwcHuLu7w9jYGBEREdi2bRvu3buH+Ph4mJiYoG3bthgxYkS+E543b95g//79ePr0KWJjY2FmZoYePXpIVTNK+vn7Fp+LksT30A4dOuDChQvc9O3bt3Pn0qNHj7jpP378wJEjR+Dl5YXQ0FBkZWWhcuXKaNGiBfr37y9zLSl6X8vMzMSlS5dw4cIFvHv3DsnJyTA2Nkbjxo0xaNAgme+gINeVOBaxXbt2YdeuXejQoYPUdHmK8zv/+vUrDh48iNu3b3O/e1WqVEHr1q3Rq1cvqKurc8uK73Ni48aN46Z36tRJar3fv3/Hnj174OPjg8jISOjp6aF+/foYMmQIateuLXc/g4ODcejQIfj7+yMyMhJqamqoWrUqWrduje7du+fYVMfT0xPHjx/Hu3fvkJ6eDhsbGwwdOjTXY/r8+XMcPnwYb9++xZcvX6CmpgZLS0uIRCL06tUL2tra3LJdu3ZF3bp1c20qJJ6nqqqa63Z/xlsydv/+fUybNg0/fvyAiooKqlevjoyMDHz48AHv3r3D2bNn8c8//8DKygoCgQDNmjXDqVOncO/ePZlkTLKB8IMHD2SSsdu3bwMAnJ2d84wrICAA48aNQ3JyMnR1dWFpaYm0tDR8+PABb9++xYULF7Bnzx6F24d9//4dAwcOREhICKpUqYKKFSsiJCQEx48fx5s3bzBkyBDMmDEDSkpKsLS0RExMDIKCgrB27Vp8+/atUG1PTpw4gZUrVyIrKwt6enowMzNDamoqIiIi4OvrC19fXwwbNgx//vmnzGeDgoLg7u4OJSUlVKtWDUFBQahWrVqe23z+/Dnc3d2RkJAAdXV1mJmZwdTUFOHh4QgICEBAQAB8fHywbds2KCsrS302LS0Nf/75J4KDg1G9enV8+fIFlSpV4uZv2LAB+/btAwDo6enBysoKUVFR8PHxgY+PDwYPHozx48crfHwyMjKwYMECLiEoX748atasifDwcFy9ehU3btzAlClT0Lt3bwCAQCCAh4cH+vTpg69fv2LVqlVYvHgxt75r167hwoULUFJSwsKFC1GuXDmp7UVFRWHgwIGIjo6GhYUFDA0N8fHjR2zbtg3Xrl3D5s2bUaFChWI9xowxzJ8/HxcvXuQaRoeHh+P58+d4/vw5goKCZI5hfs+jihUrwtbWFq9fv0ZaWhrMzc1Rvnx5ha6ZlStX4tixYwAAfX19WFtbIyoqCnfv3sXdu3fRqlUrLFq0SO6N7syZMzh8+DDU1NRgYWGB+Ph4BAUFYceOHbh//z527NjBHQ/GGGbNmoWbN28CAMzNzWFiYoLPnz/D29sb3t7eGDFiBMaOHZtnzLVr14aJiQmePXsGIPsHWEdHR+Y+9PjxYxw8eBB6enqoWrUqPn36BGtrawBAZGQkxo0bh6CgIACApaUltLS08OnTJ5w6dQoXLlzAggULuKduSampqRg9ejSePXuGypUrw8zMDMHBwbh48SKePn2KBQsWYOLEiUhNTYWlpSVUVFQQHh6OXbt2ISwsTOphJy+XLl2Ch4cHMjIyoKenh+rVqyMiIgIrVqxQuHpWTU0Ntra2+PHjB9fw29bWlttvW1tbfPjwAYmJiahQoYLMeRMYGIjx48dzCUPlypWhoaGBjx8/YseOHbhw4QI2btyIqlWrymw7t/taUlISpk6dyv2emJiYoHLlyggJCcGZM2dw6dIlLF68WO4DQX6uK0NDQ7n7aGlpqeC3UPTf+dOnTzF58mTExcVBRUUFlpaWYIzh9evXePXqFS5duoSNGzfCyMhI6nv6+Zw3NDSUWm9MTAz69++PyMhImJmZwcLCAsHBwbh58yZ8fHywceNGmYfoS5cuYdGiRUhLS4O6ujpq1KiBpKQkvHjxAi9evMD58+exYcMGmXvl8uXLceLECQBAhQoVUKlSJbx48QJ//fVXjuemp6cnZs6ciczMTBgYGKBatWpITEzEy5cv8eLFC1y+fBl79uzhEjIzMzOYmZnl+L2kpaXhv//+A1CA5gosn4RCIRMKhezcuXN5Lnvu3DlueUkRERHMycmJCYVCNmnSJBYTE8PNCw0NZUOGDGFCoZC1b9+excfHM8YYu3PnDhMKhax169Yy22nTpg23nUmTJknNCw4OZkKhkDk7O7O0tLQ8Yx40aBATCoVs5cqVLDU1VSquLl26MKFQyJYsWSL3mPj5+cnd99atW7MXL17IndewYUM2e/ZslpCQwBhjLD09nXl4eDChUMiaNGnCkpOTuc9t3bqVCYVCNnToUKntu7m5MaFQyE6fPi213/b29kwoFLKdO3dK7XtsbCybMWMGEwqFzN7ensXFxcmNbfDgwdzx//79O8vKysr12GVkZLBOnToxoVDIJk+eLLXetLQ0tmfPHm7dt27d4uaFh4dz011cXNjHjx+5z4iPy8mTJ7nv8eLFi9xns7Ky2NWrV5mjoyMTCoXszJkzucYoacOGDUwoFLJ27doxX19fqf04cuQIa9SoEbOzs2P37t2T+tzVq1dl9uPz58/M2dmZCYVCtnnzZqnlxd+bUChkIpGI+fv7c/M+ffrEunbtyoRCIfvzzz+lPjdv3jwmFArZnDlzivQYN2rUiB0+fJhlZGQwxhhLSUlhc+fO5eZ9+/aN+1xBzyPG5J+XjP3vHGvbtq3U9P3793MxHDt2jGVmZnLzrl27xt0zVq5cKXc7QqGQLViwgDtns7Ky2LFjx7h5np6e3Gd8fX2ZUChkrq6u7N27d1LHd9euXVwcX758YYoSb+fBgwdS0yW//ylTpnD3FfFxzsjIYH379mVCoZB17dqVvX37lvtsQkICW7hwIXeMAwICuHkPHjzg1tusWTN2584dbp6/vz+zs7Pj7jFjx45lUVFR3HGRjCk8PFyh/QsNDWVNmjRhQqGQrVmzhjsXMjIy2O7du7n1CYVCFhISwn0up+9bMv6fjRw5kgmFQrZ161ap6UlJSaxz587cvV68T4wxFh0dzcaPH8+EQiHr0qWL1L1TkfvarFmzmFAoZD179mTPnz/nPpuSksI2bdrE3ZPfv3/PzSvodSW5jz/fL3JTHN95ZGQkc3FxYUKhkC1atIg7NowxFhISwv0mDh8+XCYeeb99jEmf8x06dJA6nmFhYdw9b+DAgVKfCwgIYI0aNeJiEd//GWPszZs33Of69evH0tPTuXkXL15kQqGQNW7cmF26dImbHh8fz6ZPn87FInkOZmZmstatWzOhUMj27dvHfW+MMfbq1Svm6urKhEIh2717dy7fyP+kpaWxKVOmMKFQyJo3b84iIiIU+pxYgduMeXh4cH3K5PRfTkWue/bsQVJSEqpXr44VK1ZIZdNmZmb4559/YGhoiC9fvnBPyY0aNYKWlhZiYmLw/v17bvmPHz8iOjoa9evXh5KSEh4/fsy1NwD+Vyrm5OSkULGheN2dOnWSKso1MzPDpEmT0KxZs3y/NTllyhT88ccf3N8dO3aEsbExAMDU1BQLFy6Ejo4OAEBFRQUjR44EkP30I35Szi8/Pz8oKyvDxsYGw4cPl9p3fX19TJw4EUDu/dyMGzeOK+43MDCQW30l6d27d4iLi4Oamhr+/vtv6OnpcfNUVVUxZMgQ7vX0Dx8+yF1Hz549uSdVVVVV6OjoID09nXu7at68eWjfvj23vEAgQOvWrTFhwgQA2VVkGRkZucYJAN++fcPhw4cBZL8RJFnFoqysjD59+mDAgAFgjGHLli1Sn23dujUXw7Jly5CQkIB58+YhISEBtra2GDVqVI7b9fDwkHoSrFq1KtasWQMlJSXcu3cPz58/zzXuojjGPXr0QN++fblSInV1dUyZMgUCgQCZmZl48eIFt2xRnEeKSE1Nxa5duwAAY8aMQa9evaCk9L/bU6tWrbj+1k6cOCHTdxkA1KxZE/PmzePOWYFAgF69esHKygoAuKd4ANxbfPXq1ePmA9nf/bBhw9CyZUu0bdsW8fHxBd4neSZOnMjdV8Qlpzdu3MDbt2+hrq6ODRs2oGbNmtzyOjo6+Pvvv9G0aVNkZGTInItiw4YNg6OjI/e3vb096tatCwDQ1NTEihUruHuOQCDAsGHDuO9S0bYt+/fvR2pqKuzs7DB58mTu88rKyhg6dKhM9VRxOHPmDEJDQ1GrVi2sWrWK2ycAMDIywooVK2BqaoqQkBCuhOJn8u5r7969w9WrV6GhoYFNmzahTp063PLq6ur4888/0apVK6SmpmLnzp1y15uf66ooFNV3fuDAAcTFxcHZ2Rlz586VquI1NzfH2rVroa2tjSdPnnBtpvJj8eLFUsezcuXK3G/cq1evkJqays3btm0bMjMz4eDggLlz53K/iwBgbW2NjRs3Ql1dHW/evMG1a9e4eeJ7x7Bhw6RqznR1dbF48WK5pY7fv3/n+kfr2rWrVC2CjY0Nxo0bB5FIJNMURZ6UlBRMmTIFXl5eUFdXx6pVq/L9ol2BkzELCwvY2trm+t/P9eti4gSpZ8+echMkPT09dO7cGUB2ex4gu2jbwcEBQHb/LGLiImUXFxdUr14dCQkJePv2LTf/zp07ABSrogTAvfGzdOlS3L9/H+np6dy85s2bY/369fnqyE4gEMi0pRAIBNwX5eDgIFOVJC4KBoDExESFtyWpV69euHv3bo43Dsk67+TkZJn5SkpKqFevXr62aWNjA29vb3h5ecHAwEBmflpaGndip6SkyF1H/fr1ZaY9e/YMX79+hba2NkQikdzPtWvXDkpKSoiKilLox+XOnTtIS0vL9fVjccL18uVLfPv2TWrejBkzYGpqisjISAwZMgSPHj2Crq4ulixZkuPbX+bm5nLbIVWtWpV7K0d8vuekKI6xvBgMDAy45CAhIYGbXtjzSFFPnjxBQkIClJWV0atXL7nLtG7dGiYmJsjMzOTuIZKcnJzkPjBUqVIFgPR+ie9Nd+7cwe7du/Hlyxepz6xYsQILFy6UStQKy9DQUG4Vx61btwBkfy85VYGI2zQ9evRIaj/EnJycZKaJ7zG2trYybahUVVW580fRe4z4Xvpzey+xHj16KLSewhBfH23atJG5bwLZ56OrqysAyD1HcrqveXl5AciuWjIxMZG7bfH94O7du1IvH4jl57oqCkX1nYv3PacOUQ0NDbnfXvG5qihxlezPxNcVYwxxcXEAsu8fDx8+BAD069dP7voqV64MFxcXAP87F8LCwrhCC3nnpqqqKrp06SIz3cDAgHuYnTNnDgICAqQKcrp164Y1a9agW7duue4jYwwzZsyAr68vtLS08M8//xSo/XKB24wp8iT0c0NFIPskEPc9lFsfHOJ5kk/bzZs3h6enJ/z8/DBo0CAA2U/uQPZTQXh4ON6/f48HDx7AxsYGiYmJePLkCdTU1KSeIHIzYcIETJw4ES9evMDYsWOhpaWFBg0awMHBAU5OTjkmmDnR0dGRyu7FxEnoz+2KJOcB2V90Yairq+PFixf4+PEjwsLCEBYWhg8fPkiVuMnbhq6uboH7M9PQ0EBISAhevXqFsLAwhIeH4+PHj/jw4QP3FJTTfkkmomLidiXp6ekYMWJEjttVUlJCVlYWgoKCpJ7E5BGvMzIyMsfkWjLGoKAgqRc3dHR0sGjRIowaNYo7lnPmzMn1aUiydPRnVlZWePjwIUJCQnKNW6wwxzinHxtxA115PzQFPY8UJV6PhYWF3OsFyH6IqVWrFqKiouSWwkmWkvwcOyC9X82bN4ednR0ePXqEzZs3Y/PmzahSpQoaN26MJk2awN7eXqrBclHIKT7xvityP8zMzERYWJjMsvLaGuZ2jwHAPTQo8r2lpKQgMjISAGTawonVrFkTAoGg0Pes3IhLe8+cOZPjg8vXr18BQG6tQk73NfH94PXr1zneD8TXlfg37OdrvSDXVWEUxXeelJTEvXyyY8cOHDlyRO7nxMvkt6Ymp2Mi+TKN+LiGhYVxhR95XQtXrlzhYhHfC7S1tXO8/0qWNospKyvD3d0dS5Ys4dq+6unpoWHDhtzvvSJteM+cOYM7d+5AQ0MDW7Zs4Uon8+uXN+CXzMhzuukC4BrMJSUlgTHGNeJXVlbG06dPkZKSAmVlZTx+/BgGBgawsrJCo0aNcPz4cTx48ACDBg3CvXv3kJ6eDkdHR5k3qXLStGlTHDhwAPv27cOdO3eQmJjIfVFr1qxB/fr1MWfOHIUaswPIs+8xyaqYonbp0iXs2LFD5ge+cuXK6Ny5c67DJxX0h+j58+fYuHGj1JtPQPZTiKOjI96+fYvw8PAcPy/vRvnjxw8A2aU+klVNOVHkCVS8zsTExAKv08bGBsbGxoiMjISKikqe50Ruxd3i81OR2At7jPOqrv/5x7Qw55GixPeF3O4JwP/uC/JKc/KzXyoqKti8eTOOHTuG//77j0ssg4KCcOzYMWhra2Pw4MEYNmxYntXzisrpmlJk3yXf6JK377ndZ4oifsnzMqdtqaqqQkNDo1AlpHkRX7chISF5PrjIu5Zy+g7E6/327ZtMKXhuy0vK73VVWEXxnUvuhyK96Oe3dC8/b+oWJDcAwDUlyK3wQLI5h6Ru3brBwsKCe3MzPj4enp6e8PT0hEAggJOTE2bNmpVrUiYeGrJ///4FTsQAHpIxyaRI3gktJj7AWlpa3IllYGCAevXq4cmTJ3j8+DHU1NSQnJzMVU80atSIS9YyMjK4YvWcqrZyYm1tjaVLlyI9PR0vXrzAw4cP4e/vj2fPnuHp06cYO3Yszp49W+ydvBbGf//9hwULFgDITjDF1bhVq1aFnp4e0tPTi3wsy8DAQIwePRqpqamoVq0aOnXqhJo1a6Jq1arcE9KwYcNyTRTkER9nGxsbHDx4sEhiFa/T1dUVK1euLNA61q9fj8jISCgpKSEjIwN///039u3bl+NNObcfKfG18HO3KT8rrmOck191HonvC7ndE4D/3Rckk5OCUlVVxYABAzBgwABERkbi4cOHePjwIXx9ffH161ds2bIF6urqGDBgQKG3lRtF9l3yR7Ao9j2/JB8kcqrWZIwhLS2tWOPQ1NTEjx8/sG7dOoW7HlGE+Id8wIABmDRpUpGtt6ST/A2T1y3UryR5Xv/48SPHe6H4WhBfN+JzU5ycySPZLu1nDRs2RMOGDZGSksLlFvfu3cPr169x+/ZtREZG4vDhwzkmuJ8+fQKQ/zzjZ7+801cdHR2uuP7169c5Liee93OvzeIL0M/Pj6tfFtfP6urqolatWkhKSsLz58/h6+sLgUCg8EWbmZmJ0NBQPH78GED2zbpBgwYYOXIkdu7ciZ07d0IgECAmJqbEj7e3Z88eAICbmxs2btyIbt26wdbWlntCkDdMTWEdOXIEqampqFKlCvbv34+BAweicePGUkXV4qqO/BA3vgwJCcmxcT5jDA8ePEBISIhUO7+81pnb02BycjIePXqEsLAwmSqGu3fv4sSJE1BSUsL69ethZGSEt2/f4t9//81xfbltS9zOMa/SteI6xjn5VeeRuF1XSEhIjklJVlYWd5wK23t/fHw8nj9/zrUVq1ChAtzc3LjuCcT3jEuXLhVqO4oQ73tu98NXr14ByC7xyO3V+uKipqbGVQFJtsmVFBQUVORVcT8TX7fiH0B5xNX3379/V3i94u8gt/XGxsbi6dOn+Pz5c7FWxf5Kurq63At0ue37+/fv8fbt2yJ/oUWSmZkZV42qyLUgbjIk/u6Sk5NzfIlI3r03PT0dgYGB3EtTGhoaaNKkCf78808cPHiQ6/7j3bt3Ui8N/kxDQwOGhoZy2/DmBy898Ddr1gxA9ltR8n444+PjuQ7lfm7rJc4+/fz8uGoaycZy4k5X9+7di2/fvqFu3bpy2yHJ8/HjR3Tp0gVjxoyRGYUeyH7zSpyNSzb0K4nEb5vlVPd+9uxZ7t9FdQMVl8bkNDSUn58f9+OnyBuPYkKhEDo6OkhMTOSKhH92+fJljBkzBt27d5dpjC2Pk5MTlJWVERQUxLU7/Nnhw4cxatQo9OvXT6pU6/v371xpUf/+/eHo6IiZM2cCyH4zSZzM/+zVq1dyL+r3799zVaXixsc5Ka5jnJPCnEfiKnhFfrjq168PPT09ZGZm4vjx43KXuXr1KmJiYuS+FJNfHh4eGDJkCNdvnSRVVVXuhYriTi6A/z1g3rp1K8cSTfGbv/Xq1ctX58BFSdy/1unTp+Uel6IuaZdHfKzOnj0r9wWVjIwMTJ48GQMHDsS6desUXq/4N8nf35/rsPVnGzduxPDhwzF69Ogiuf+LS1r4TuzELwIcO3ZM7n4lJCRgzJgx6NevH3ceihXlPmhqanLDYv28HbGwsDDuJQLxPaBSpUqoVasWgP+NEy0pKytL7u+Gr68vevTogQkTJsgt0RXnEkDu94Fr167h2rVrUn1iFgQvydjgwYOhra2Njx8/YsaMGVJ19OHh4ZgwYQK+fv0KExMTmbcqLCwsYGlpiY8fPyIgIACVKlWSelJs1KgRgPy/RQlkN/KrUaMGMjMzMXv2bKkShvT0dGzevBmJiYnQ1NREgwYNCrTvv4r4aeH06dNSpRc/fvzAtm3bsHfvXm5aTm/dFXSbfn5+ePLkCTc9IyMDV65cwaxZswq0TU1NTa4X5dWrV+P8+fNSNw1vb28sW7YMQHYXCIqUmpiamnJv2MyePVvqLaGsrCycOXOG606jZ8+eUm0YlixZgq9fv8LS0pLrFNTFxQVt2rRBVlYW5s2bJ7d0hzGGadOmST2lvX//HlOmTAFjDB06dJDbUaWk4jrGeW2vIOeROFlUJDmW/I63bt2K48ePS33HN2/e5J5Uu3Xrlq8OMuVxc3MDAJw6dQoXL16U+jH5+PEjjh49CkD2YbA4tGzZElZWVkhNTYW7uzvX7QaQXSW4ePFirosRPgcgHzRoEPT19fH69Wt4eHhw1ZWMMZw4cYI7ZsWpV69eMDIyQmhoKCZPniw18sH3798xc+ZMBAYGQlVVFQMHDlR4vQ0aNEDTpk2RmZmJ8ePHS7UjTUtLw86dO7kHj8GDB8t9kzO/xA/2kvvAh6FDh0JLSwtPnz7F3LlzpUoUP3/+jAkTJiA2NhY6OjoybzoX9T6MHj0aysrK8PPzw+LFi6WqxN+9e4fx48cjNTUVNWvWRIcOHbh5f/31FwDg6NGjOHz4MHfvSE5OxuLFi/Hy5UuZbTk6OsLAwABxcXGYP38+91YnkF3lKU7mK1SokGP1rbh0LTAwsNBvy/LSA7+ZmRlWrFiBGTNmwMfHB76+vlwP/IGBgcjKykLFihWxevVquW+FODs7Y//+/cjIyOCSL7H69etDXV2dqyPObz3usmXLMHToUDx69AidOnXieneOiIjgXr2fM2dOjm+rlBTjxo3DlClT8OnTJ3Tq1In78QoNDUVqaioqV64MgUCAsLCwIqvWGjBgAK5cuYLY2FiMGDECFhYW0NbWRnh4OOLj46GlpYV69eohICAg39VbgwcPRlhYGM6cOQMPDw/8888/qFy5MqKiohAdHQ0g+3Vu8bBYipgyZQqioqJw+/ZtTJo0CcbGxjAxMUFERAR3Q3J1deWG+gCyn8i9vLygpKSEBQsWSDUInjZtGh48eIDPnz9j5cqVWLhwodT2KlSogNjYWPTu3Zurjvz06RMYY2jUqBGmTp2aZ8zFeYzlKcx5ZG1tjQ8fPmDv3r24c+cOWrRokevbsAMHDkR4eDhOnjyJFStWYNu2bTLfsaurK6ZMmVLo/WrRogW6du2KM2fOYN68eVi3bh0qVqyIHz9+ICwsDIwx/PHHHxg+fHiht5UXFRUVrF27Fu7u7ggKCkLfvn2leuBPTU2Furo6Zs+ezetDoJGREZYvX46pU6fi4sWL8PT0RLVq1RAZGYmYmBg4Ozvjzp07xVqaqKenh3Xr1mHixInw9/dHp06dULVqVSgpKSE4OBhpaWlQVlbG0qVL890tyaJFizBhwgS8ePECw4YNQ+XKlaGnp4ewsDDuh7Zfv37o3r17keyLtbU1bt26hcuXL+P9+/do0KABV8L+K5mbm2P58uWYNWsWrl69ips3b6J69epIT09HcHAwMjMzoampiQ0bNsi047K2tsbjx4+xcuVKnDp1Cj179uS6pSqIevXqYd68eVi8eDE36kG1atWQlJTEVUHWqFEDq1evlno5oEmTJhg/fjw2btyINWvWYO/evahYsSKCgoKQmJgIFxcXrgsPMVVVVaxYsQJ//fUXrl27Bh8fH5iZmUFJSQlhYWFITk6GhoYGPDw8cmwHHB0dzXXpIm8oqPzgbaDwJk2a4MSJE+jfvz8qV66MoKAgREZGwtraGn/99ReOHj2aY9WIZGnXz/15qKmpcX1VValShXuyV1S1atVw6NAh9OjRA5UrV8aXL18QGBjI9X125MiRHPtjKUmaN2+O/fv3QyQSwdDQEIGBgfjy5Qtq1KjBHV/xfsjrj6cgTE1NcfToUfTo0QOWlpaIjIxEUFAQDA0N0bt3bxw9epRLbB4+fJivt64EAgHmzp2LTZs2wcXFBcrKynjz5g2SkpJQt25dTJs2Ddu2bcvXSxXq6upYt24dli1bhqZNmyI9PR1v3rxBZmYmGjZsCA8PDyxfvpx7Cg4LC8OaNWsAAH379pXpr6hcuXLc2KcXL16U6pQQyB4maP/+/WjZsiWio6Px5csX1K5dG7Nnz8amTZsUqn4qzmMsT2HOo0mTJsHV1RWampoICgrKsfpHTCAQYNasWdi0aRNEIhGUlZW59knNmzfHmjVrsHLlyiLrcmL27NmYP38+GjZsiKysLK5D3fr162PGjBnYtWvXL2ssX6lSJRw8eBATJkzAH3/8gZiYGHz69AkVK1ZE3759cfToUamSAL7Y29vj0KFD6NatGwwMDPD+/XtoaGhg9OjRWLFixS+JoXbt2jh+/DhGjhwJKysrfP78GYGBgShfvjzc3Nxw6NAhuUMW5cXAwAA7d+7EnDlzYGdnh4SEBLx79w4qKipwdHTE2rVri+RBQGzw4MHo0qUL9PX1ERISkmu7pOLm6OiI48ePo3///jA3N0dQUBBCQ0NRqVIl9OzZE8eOHZPbX9i8efPQuHFjrslHYTp+FuvQoQOOHDmCrl27wsjICB8/fkRsbCxsbW0xY8YM7N+/n+vYWtLgwYOxbds2rir7w4cPsLS0xNKlS3McU7lhw4bYt28f3NzcYGRkhJCQEISGhsLExAS9e/fGyZMnZQp8iouA8V1hTUgZV5AB3gkhhPw+eCsZI4QQQgghlIwRQgghhPCKkjFCCCGEEB5RMkYIIYQQwiNqwE8IIYQQwiMqGSOEEEII4RElY4QQQgghPKJkjBBCCCGER5SMEUIIIYTwiJIxQgghhBAeUTJGCCGEEMIjSsYIIYQQQnhEyRghhBBCCI8oGSOEEEII4RElY4QQQgghPKJkjBBCCCGER5SMEUIIIYTwiJIxQgghhBAeUTJGCCGEEMIjSsYIIYQQQnhEyRghhBBCCI8oGSOEEEII4RElY4QQQgghPKJkjBBCCCGER5SMEUIIIYTwiJIxQgghhBAeUTJGCCGEEMIjSsYIIYQQQnhEyRghhBBCCI8oGSOEEEII4RElY4QQQgghPKJkjBBCCCGER5SMEUIIIYTwiJIxQgghhBAeUTJGCCGEEMIjSsYIIYQQQnhEyRghhBBCCI8oGSOEEEII4RElY4QQQgghPKJkjBBCCCGER5SMEQJAIBBAJBJJTRsyZAgEAgGCgoJ4iams2rt3LwQCAfbu3ct3KL+1BQsWQCAQwNvbm+9QeFUWjgNdU6UfJWMl3KBBgyAQCFCxYkVkZGTwHQ5RUFBQEAQCAYYMGcJ3KL8lecn174bOwbKDvsuyj5KxEiw+Ph6nTp2CQCBAZGQkLl68yHdIv5Vly5bh9evXqFy5Mt+hEEJIjrp27YrXr1+ja9eufIdCCoiSsRLsyJEjSEpKwpQpUyAQCLBr1y6+Q/qtmJqaolatWlBVVeU7FEIIyZG+vj5q1aoFfX19vkMhBUTJWAm2a9cuqKmpYdasWXB0dMSlS5fw+fNnbn5wcDCUlJTg6uoq9/MpKSnQ19dHjRo1pKanpaVh7dq1EAqF0NbWhq6uLpo1a4bz58/LrEPcburTp09Yt24d/vjjD6irq3PF5REREZg/fz4cHBxgYmICdXV1VKlSBePGjUNUVJTcuIKCgtC7d2+UL18eOjo6cHZ2xq1bt3Jtu3Hr1i107NgRRkZGUFdXh5WVFebOnYukpCQFj2a2nTt3ok6dOtDQ0IC5uTmmT5+OlJQUucvm1Gbs1KlTcHZ2homJCbeetm3b4uzZswCy229UrVoVALBv3z4IBALuP/G+5fe4ScayZcsW2NjYQENDA5aWlvDw8EBWVpbcfTh//jzatGkDQ0NDaGhooEqVKhg4cCBevHghtVx+zom4uDjMmzcPtWvXho6ODvdDMHToUISGhuZ2+GWcOXMGjRo1gpaWFipWrIixY8fi+/fvcpcNDAzEiBEjYGFhAXV1dZiammLIkCEIDg7mlvH29oZAIAAA+Pj4SB37vXv34unTpxAIBJg4caLUuk+cOAGBQABtbW2kpaVJzatYsSJsbGykpjHGsHv3bjg6OkJPTw9aWlpo2LAhdu/eLTf2/CwveR0cP34cQqEQmpqaMDU1xfjx45GcnJzncVXkHJSUn+0U1bUYEBCAPn36wNTUFGpqarC0tIS7uzu+fv3KLRMdHQ1TU1Po6+vj06dPUp+PiopChQoVYGBgIHUOiKuoQ0ND0bt3bxgaGkJbWxsikQh3795VOL7du3ejc+fOqFKlCjQ0NFC+fHm0adMGXl5eMsuKz7sFCxbg8ePHaNOmDXR1daGvr4+uXbvKbXd65swZ9O3bFzVq1ICWlhb09fXRrFkznDp1Smo5Rb7L3NqM3b17F25ubihfvjw0NDRQq1YtLFiwQO73JT520dHRGDZsGExMTKCpqQkHBwe5583nz58xYcIEWFlZQVNTE+XLl0fdunUxbtw4xMfH532Qyf8wUiIFBAQwAKxr166MMca2b9/OALBly5ZJLde8eXOmpKTEwsLCZNZx9OhRBoDNnz+fm5aSksJEIhEDwBo0aMDc3d3ZmDFjmLm5OQPANm7cKLWOwYMHMwCsffv2rHz58mzgwIFs+vTpbM2aNYwxxo4cOcK0tbVZp06d2Pjx49mUKVNYixYtGABWrVo1FhsbK7W+sLAwZmpqyq1z1qxZrFu3bkxdXZ21bduWAWBeXl5Sn/n333+ZQCBg5cuXZ4MHD2ZTp05lzs7ODABr2rQpS01NVeiYLly4kAFgFSpUYH/99RebNGkSs7CwYB06dGAAmLOzs9x9DwwM5KZt2bKFAWCmpqZs1KhRbNasWWzIkCGsdu3abPDgwYwxxp48ecImTJjAADBbW1s2f/587j/xuvJ73MSx9OjRgxkZGbEhQ4aw8ePHMwsLCwaAzZ49W2Z/p02bxgCw8uXLs2HDhrGZM2ey/v37s4oVK7J169Zxy+XnnMjKymKNGzdmAJijoyObNGkSmzJlCuvevTvT19eX+e7k2bNnDwPA3NzcmJqaGuvfvz+bOXMma9KkCXfMkpKSpD7j5+fH9PX1mYqKCuvatSubNm0a69mzJ1NRUWEmJibs48ePjDHGAgMD2fz58xkAZmlpKXXsnzx5wrKyslj58uVZvXr1pNY/btw4BoABYLdu3eKmv3r1igFgY8eOlToG/fr1YwBYzZo12ejRo5m7uzurVasWA8CmTJkite78Li+Ov0ePHkxbW5v169ePTZo0idnY2DAArF+/fnkeY0XOwYJsp6iuxXPnzjF1dXWmpaXF+vTpw6ZNm8bc3NwYAGZlZcW+ffvGLXvt2jUmEAhY48aNWXp6OndM27VrxwCwI0eOSK0bAKtXrx4zNzdn9vb2bObMmWzgwIFMTU2NqampyZyj4uPw83QNDQ3WuHFjNnz4cG4durq6TElJiZ09e1ZqWS8vL+6c1tLSYu3bt5e6pqtXr86Sk5OlPmNtbc3q1q3LBg8ezGbOnMmGDx/OjI2NGQC2YcOGfH2X4mtqz549Uts4efIkU1FRYVpaWmzo0KFsxowZzM7OjgFgTZo0YSkpKTLHztbWlllZWTE7Ozs2ceJE1q9fP6asrMzU1NTY8+fPuWUTExNZ1apVmUAgYG3atGHTpk1jEyZMYB07dmSamppS902SN0rGSijxxXf69GnGGGOxsbFMQ0ODWVlZSS23Y8cOBoCtXLlSZh3iJOP9+/fctNmzZzMAbMGCBSwrK4ubHh8fzxo2bMjU1NRYeHg4N12cBJiZmbHg4GCZbURGRrKEhASZ6fv27WMA2OLFi6WmDxgwgAFgq1atkpouvpn8fFN8+fIlU1FRYQ0aNGBfv36V+syyZcsYALZ69WqZ7f/s/fv3TEVFhVWuXJlFRkZy0+Pi4pi1tbXCyZhQKGRqamosKipKZhsxMTHcvwMDAxkALkH7WX6PmziWqlWrsoiICG56dHQ0MzAwYLq6ulI/hBcvXmQAWN26daXiYoyx9PR09uXLF+7v/JwTPz8kSEpJSZG7Tz+T/K5v3LghNW/o0KEMAFu4cCE3LS0tjVWpUoXp6uqyp0+fSi1/+/ZtpqyszDp06CA1Xd73Kda1a1cmEAhYdHQ0N83GxoaJRCKmrKzMPDw8uOmbN29mANjx48e5aeIHo+HDh3PJAWOMpaamso4dOzIA7OHDhwVeXpwc6Ovrszdv3nDTk5KSWM2aNZlAIJC6RnOS1zmY3+0U1bUYExPD9PT05N5TDh8+zACwv/76S2r61KlTpR461q9fn+O+ic+tgQMHSp3P3t7eTCAQsBo1arDMzEyZ4/BzMvbp0yeZdUdERLBKlSrJ3IfFyRgAdvToUal5AwcOlJs0ih8gJCUkJLC6desyfX19lpiYyE3P67uUl4zFx8czAwMDpq6uzp49e8ZNl3w4WLRokdR6xPswbtw4qWO0c+dOBoCNHj2am3b+/HkGgE2aNEkmnvj4eIUTc5KNkrESKDU1lRkaGrJy5cpJndC9e/dmAJiPjw83LTY2lqmrq8s86UdHRzNVVVXm4ODATcvMzGTlypVjNWrUkLpJiYkvLsmSEHES8M8//+RrH7Kyspienh4TiUTctJSUFKaurs4qVKggc6FmZWVxJQWSN8Xx48czAOz27dsy28jMzGTGxsbMzs4uz3g8PDwYAK5ET9KBAwfylYxpa2uz79+/57q9vG6eOZF33CRj2b17t8xnxPMCAgK4ae3bt2cAmKenZ67by+85IU7GFCmdyYn4h6NVq1Yy88LDw5mqqiqrXr06N+306dNyfzjEunXrxpSUlFhcXBw3Lbdk7J9//mEA2IkTJxhjjH358oUBYOvWrWP29vZSn+vRowcDIJXA16tXj2lra8uUdDD2v+MjWdqV3+XFycG8efNklhfPO3/+vNx9k6RoMqbodorqWly7di0DwA4cOCB3vlAoZEZGRlLTUlNTmVAoZEpKSmzDhg1MXV2dVa9encXHx8t8HgBTVlZmISEhMvPEpW+S+5BTMpYTd3d3BoAFBQVx08TJWPPmzWWWF8+bPHmyQutfs2YNA8C8vb25aQVJxvbv3y9TqisWEhLCVFRUpK4zxrKPnba2tsxDVXp6OlNRUWFCoZCbJr43yCuVJ/mnAlLinD17Fl+/fsWYMWOgpqbGTR80aBCOHTuG3bt3o3nz5gCyG2527NgRJ0+exPPnz1G3bl0AwNGjR5Geno6BAwdyn3/79i2+f/+OSpUqwcPDQ2a70dHRAIA3b97IzLO3t88x3tOnT2Pbtm14/Pgxvn//jszMTG5eRESE1PZTU1PRsGFDqf0CstsqNGnSRGbbfn5+AIArV67gxo0bMttWVVWVG+/Pnj17BgBo1qyZzDx503LSq1cvzJw5E3Xq1EGfPn0gEong5OQEAwMDhdchpuhxkyQUCmWmmZmZAQBiY2O5affv34e6ujqcnZ1zjSG/54SNjQ3q1q2Lw4cPIzQ0FF26dEGzZs0gFAqhrKyc+w7/RN5xr1SpEqpXr443b94gISEBurq63Dnw5s0bLFiwQOYzX758QVZWFt69e4eGDRvmuV0XFxcAgJeXF3r06MG1AXJxccGXL1+wfv16pKSkQF1dHT4+Pvjjjz9gYmICAEhKSsLz589RqVIlLF++XGbd6enpXKwFWV6Sot91YSm6naK6FsXr8fPzw4cPH2Tmp6SkICYmBjExMTAyMgIAqKmp4ciRIxAKhRg/fjxUVFRw+PBh6Orqyt2GpaUlzM3NZaY3a9YMFy9exNOnT+Hk5JRrnJ8+fcKyZcvg6emJ8PBwpKamSs2PiIiApaWl1LT8fGdRUVFYvnw5Ll++jODgYJk2ejndAxT15MkTAJDbxYu5uTmqV6+Ot2/fcteZmJWVFXR0dKSWV1FRQYUKFaT2oXnz5qhYsSKWLVuGp0+fws3NDU5OTqhbty7XbpMojpKxEkjcqFcykQKANm3aoGLFijhx4gQ2bNgAPT09brmTJ0/i0KFD3A3/4MGDUFVVRe/evbnPf/v2DQDw8uVLvHz5MsftJyYmykyrUKGC3GXXrFmDqVOnwtjYGK1bt4aZmRk0NTUBAOvXr5e6gYkbdBobG8tdl7xtiGNesmRJjvEqIi4uDgC4H9W8tpuT6dOnw9DQEFu3bsXatWuxZs0aqKiooH379li/fj3X0DYv+TlukuS9LaWikn0ZSyZzsbGxqFy5MpSUcn9HJ7/nhIqKCjw9PbFgwQKcPn0aU6ZMAQAYGRnB3d0dc+bMUTgpk/ddANnfx5s3bxAfHw9dXV0uxkOHDuW6PnnnrTx16tSBsbExl4R5eXnB0NAQ9erVw5cvX7BixQrcvXsXxsbGiI6OlrqGvn//DsYYwsPD5SavP8eS3+UlKfpdF5ai2ymqa1G8ns2bN+e6XGJiIpeMAdlJQt26deHn5wd7e/tcHxBzO7eA/90PcvLhwwfY29sjPj4eLi4u6NixI/T09KCkpARvb2/4+PjIvUbzcywbNWqEkJAQODo6omXLljAwMICysjKePn2Kc+fO5XgPUJT4fpvT/a1ixYp4+/Ytd53ltg/i/ZDcB319fdy7dw/z58/Hf//9h0uXLgHITj5nzZqFcePGFSr+3w0lYyVMaGgorl+/DgBwdHTMcbmjR49i1KhRAIB27drByMgIhw8fxrJly/Dx40f4+/ujc+fOMDQ05D4jTt66d++OkydP5isueU86GRkZWLRoESpVqoSnT59KJVmMMaxcuVJqefH2xaUtP4uMjJSZJv7MzzeM/BLfYKKiomSeZuVtNycCgQAjRozAiBEj8PXrV9y+fRtHjhzB8ePH8f79ezx//jzPZCS/x60gDAwMuBKj3BKygpwTRkZG2LRpEzZu3Ig3b97A09MTGzduxPz586GqqopZs2YptJ6c3rYVfx/i2MT//++//9ChQweF1p0bgUAAZ2dnnDx5El++fIG3tzecnZ0hEAjg5OQEVVVVeHl5cT/o4pI0yVjs7Ozw8OHDPLeV3+VLsqK6FsXref78OerUqaPw51atWgU/Pz8YGhri7t272LFjB0aOHCl32bzOrby6gFi3bh2+f/+OgwcPon///lLzxowZAx8fH4XjlmfXrl0ICQnB4sWLMWfOHKl5y5cvx7lz5wq1fuB/xzmn+9vP11lBVKlSBfv27UNmZiaeP3+Oa9euYcOGDfjzzz9Rrlw59O3bt8Dr/t1Q1xYlzJ49e5CVlQUnJycMHz5c5j9xaZlkn2Oqqqro1asXQkND4ePjg4MHDwIABgwYILVuGxsb6Onp4eHDh1z1SGHExMQgLi4ODg4OMqVdDx8+lCl2t7a2hrq6Oh49eiTTfQBjjKu+kNS4cWMAkDsvP2xtbQEAt2/flpknb5oiDA0N0aVLFxw7dgwtWrTA69evuWoXcUImrwQjv8etIOzt7ZGamprnj0ZhzgmBQAAbGxv8+eef3AOEvK4wciLvuEdERODjx4+oXr0694MvPgfu3bun8LqVlJRyLT0SV90cOnQI7969Q4sWLQAA2trasLe3h6enJ7y8vLjETUxXVxc2NjZ4/fq1QlWF+V2+KOV2DhZEUV2LBfk+Hz16hLlz58LGxgbPnz+HpaUlJk6ciLdv38pdPjg4WG43K+Jzrn79+rlu7+PHjwCATp06SU3PysqCr6+vwnHnd/2SMUoqyHfZoEEDAJDbJUV4eDg+fvyIatWqFSqxloyvfv36mD59Oo4cOQIgf/cCQslYicIYw549eyAQCLB//37s3LlT5r/9+/ejQYMGuH//vlRfUeIk7eDBgzh06BAMDAzQsWNHqfWrqKhg7NixCA4OxtSpU+X++L548SLHp8qfifugefz4sVSfNd+/f4e7u7vM8urq6ujRowe+fPmCDRs2SM3bv38/Xr9+LfOZcePGQUVFBe7u7nJvrrGxsVzbiNz069cPysrKWLt2rdT+xcfHY/HixXl+Xuzq1asyw1Klp6dzVS/iqsZy5cpBIBAgLCxMZh35PW4F8eeffwIAJkyYwMUmlpGRwT0V5/ecCAwMxKtXr2SWEa9PvP+KuH79Om7evCk1be7cuUhPT8fgwYO5aZ07d4aFhQXWrl2LW7duyawnPT0dd+7ckZpWvnx5ucdeTFzatWLFCqm/xf9+8OABvLy8ULduXanSZQAYP348kpKSMHLkSLnVi4GBgVL9SuV3+aKS2zlYEEV1LQ4dOhS6urqYM2eO3KrxpKQkqYQvMTER/fr1g0AgwOHDh2FqaoqDBw8iNTUV/fr1k3mwA7KTljlz5oAxxk3z8fHBpUuXUKNGDTRt2jTXGMWl5z+fVytWrJDpo68gclr/4cOHueo+SQX5Ljt37gx9fX3s2bNH6jgzxjBr1iykp6cXanilFy9eSPXvJlaQewGhasoS5ebNmwgKCoKLi0uubY+GDh2KJ0+eYNeuXVi3bh0AwMHBAVZWVti/fz/S09MxcuRIqKury3zWw8MDjx8/xoYNG3Dx4kU4OzvD2NgY4eHheP78OZ49e4Z79+7l2OZCkpKSEsaNG4c1a9bA1tYWHTt2RHx8PC5fvgxLS0tUqlRJ5jPLli3DjRs3MG3aNHh5eaF+/fp4+/YtLly4gLZt2+LKlStS1Wp16tTBli1bMHbsWFhbW6N9+/aoXr064uPj8enTJ/j4+GDIkCHYunVrrrHWqFED8+bNw/z581GvXj306tULKioqOHXqFOrWrZvjE/bPevfuDS0tLTg5OcHS0hLp6em4fv06Xr16hd69e8PCwgIAoKOjg0aNGuHWrVsYOnQorKysoKSkhH79+sHCwiLfxy2/2rdvj6lTp2L16tWwsrJC165dYWJigvDwcNy8eRNTp07lOj7Nzznx7NkzdO3aFY0aNUKdOnVQsWJFhIeH4+zZs1BWVubakCnCzc0N7du3R8+ePWFubg4fHx/cu3cPtra2mDp1Krecuro6Tp48iXbt2sHZ2Rmurq5c9VZISAhu374NQ0NDqcbjLVq0wPHjx9GjRw80aNAAysrKcHNz415wqV27NipUqIDIyEhUqFABtWvX5j7r4uKCxYsXIzY2ViopFBs9ejT8/Pywb98++Pr6omXLlqhUqRIiIyPx5s0b+Pv74/Dhw6hSpUqBli8qeZ2D+VVU16KxsTGOHDmCnj17wtbWFm3btkWtWrWQkpKC4OBg+Pj4oGnTprhy5QqA7GT23bt3WLt2LVei5eTkhNmzZ2PRokWYPXs2Vq9eLbWNevXqwdvbGw4ODmjRogUiIiJw9OhRqKqqYseOHXm2pRwzZgz27NmDbt26cR3H+vn54fHjx3Bzcyv00HQDBw7EihUr4O7uDi8vL1haWiIgIAA3btxAt27dcPr0aanlC/Jd6unpYceOHejbty8aN26M3r17w9jYGDdv3sTDhw9hb2+PadOmFXgfbty4gSlTpsDR0RG1atWCoaEhPn36hPPnz0NTUxN//fVXgdf9W+LvRU7ysz59+uT6yrdYTEwMU1NTY0ZGRlJdRIi7b8BP3V/8LCMjg23bto05OjoyPT09pq6uziwsLFjbtm3Zv//+y378+MEtK697B0lpaWlsyZIlzMrKilvP5MmTWUJCArO0tGSWlpYyn/n06RPr2bMn09fXZ1paWqxZs2bMx8eH/fXXXwwAe/Lkicxn7t+/z/r06cMqVarEVFVVmZGRERMKhWzmzJns9evXuR4vSTt27GC1a9dmampqzMzMjE2dOpUlJSUp3LXFli1bWKdOnZilpSXT0NBghoaGrHHjxmzbtm1SfUgxxtjbt29Z+/btmYGBARMIBFKvz+f3uOX2PeT2av6pU6eYi4sL09fXZ+rq6qxKlSps4MCB7MWLF1LLKXpOhIaGspkzZzIHBwdmYmLC1NTUmIWFBevRowfz9/dX6DuQfA3/9OnTzM7OjmloaDATExM2evRomT6sxMLCwtiECRO4Y6anp8dsbGzYiBEj2M2bN6WW/fz5M+vVqxczMjJiSkpKcjvEFHcV07t3b6npycnJTF1dnQFgZ86cyXE/jh07xlq2bMnKlSvHVFVVWeXKlZlIJGJr1qyR6sMsv8vn9n3m1LlnTnI7Bwu6naK6Ft+8ecOGDx/OLC0tmZqaGitXrhyrW7cuGz9+PLt//z5jjLETJ05w3aD83PVKeno6c3BwYAKBgF27do2bLr6Wg4ODWc+ePVm5cuWYpqYma968Obtz545MHDkdBy8vL+bo6Mh0dXWZgYEBa9++PXv06JHc5cXdV0h2sC2WU7cUT58+Za1bt2blypVjurq6zNnZmd24cSPHY5/bd5nb93Xr1i3Wrl07ZmBgwNTU1FjNmjXZ33//LXWf//nYyfPzfenVq1dswoQJrEGDBszQ0JCpq6uzatWqsSFDhrBXr17JXQfJmYAxiXJcQnjk5OSEe/fuIS4uTubVakIIUYS4nZ+8tlKElFTUZoz8cpLja4odOnSIq8KhRIwQQsjvhNqMkV+uTp06aNCgAWrXrs31q+Pt7Q1dXV2Zth+EEEJIWUfJWAFkZWUhIiICurq61NNwAQwdOhRXrlzBw4cPuY4de/bsienTp8PS0pLrrJAQQgoiMzOT7iNlFGMMCQkJqFSpUp4vYpQm1GasAMLCwuQOtUEIIYSQ4hcaGsoNNVUWUMlYAYg7yXv37nWRdJj3O9LS0kVSUgLfYZRadPwKh45f4dDxKxw6fgWXkJCAmjVtytxvLyVjBSCumtTV1S3UUBK/My0tXaioUBVvQdHxKxw6foVDx69w6PgVXllrIlR2KlwJIYQQQkohSsYIIYQQQnhEyRghhBBCCI8oGSOEEEII4RElY4QQQgghPKJkjBBCCCGER5SMEUIIIYTwiJIxQgghhBAeUTJGCCGEEMIjSsYIIYQQQnhEyRghhBBCCI8oGSOEEEII4RElY4QQQgghPKJkjBBCCCGER5SMEUIIIYTwiJIxQgj5f6NGjUHv3n35DoMQ8puhZIwQQgghhEeUjBFCCCGE8IiSMULIb+fkyZNo1MgBhoYmMDe3hJtbJyQmJnLz16/fgGrVrGBubolJkyYjPT2dm3fkyFE4OTmjQoVKqFq1BoYMGYaoqGhu/q1bt6GtrYcrV66gceOmKF/eGM7OLnjx4uUv3UdCSOlByRgh5Lfy+fMX9O3bF4MGDcDjxw9w+fIldO7cEYwxANnJVGBgIC5fvojt27fi4MHDOHjwEPf5tLR0/P33HPj5+eLYscMIDg7G6NFjZLYzZ87fWLp0MW7d8oaxsTF69eojldQRQoiYCt8BEELIr/TlyxdkZGSgc+dOsLCwAADUqfMHN9/AwABr166GsrIyrK1rom3bNvD29sbQoUMAAIMHD+SWrVq1KlavXonmzV3w48cP6OjocPNmzZoJV9cWAIDt27eiZk0bnD//H7p37/YL9pIQUppQyRgh5LdSr15duLq6wt6+CQYMGIQ9e/bi+/fv3Hwbm1pQVlbm/q5QoQKiomK4v58+fYZevfqgVq0/UKFCJbRt6wYACA0Nk9pO48b23L/Lly8PKysrvH37trh2ixBSilEyRgj5rSgrK+P69es4c+YUatWyxr//bkP9+nYICgoCAKiqqkotLxAIwFgWACAxMRGdO3eBtrY2du3agVu3vHHkSHYVZlpaWp7bFggERbszhJAygZIxQshvRyAQoEkTB8ydOwf37t2Bmpoazp+/kOfn3r17h5iYr1i0yAOOjk1hbV0T0dHRcpe9f/8B9+/v37/jw4cPqFmzZpHtAyGk7KA2Y4SQ38qDBw/g6+uH5s0dYWxsjAcPHiImJgbW1jXx4sWLXD9rZmYONTU1/PvvNowYMQyvXr3GihUr5S67bNkKlC9fHiYmJvDwWAhDQ0N07NihOHaJEFLKUckYIeS3oqurh1u3bqFr1x6wtRVi4cJFWLZsCdq0aZ3nZ42NjbBt2784c+Ys7OzssWbNWixdukTusosWLcC0aTPg5NQcX758wfHjR6GmplbUu0MIKQMETPw+N1FYfHw89PX18flzGPT09PgOp1TS0tJFUlIC32GUWnT8Cqc4j9+tW7fRrp0bwsNDYGBgUCzb4Budf4VDx6/g4uPjYWpqhri4uDL1+0slY4QQQgghPKJkjBBCCCGER9SAnxBCilDz5s2QmBjPdxiEkFKESsYIIYQQQnhEJWOEEMKzzCyGRyFxiP6RBmMdNdhZ6ENZiTqIJeR3QckYIYTw6PrrGCy9+gGR8f/rwb+Cnhpmt6mBVjZGPEZGCPlVqJqSEEJ4cv11DCaeeCWViAFAVHwaJp54heuvY3L4JCGkLKFkjBBCeJCZxbD06gfI6+hRPG3Z1Y/IzKKuIAkp6ygZI4QQHjwKiZMpEZPEAHyJT8WjkLhfFxQhhBeUjBFCCA+if+SciBVkOUJI6UXJGCGE8MBYR7FxKhVdjhBSelEyRgghPLCz0EcFPTXk1IGFAEBFPXXYWej/yrAIITygZIwQQnigrCTA7DY1AEAmIRP/PatNdepvjJDfACVjhBDCk1Y2RljfszZM9KSrIivoqWN9z9rUzxghvwnq9JUQQnjUysYILawNqQd+Qn5jlIwRQgjPlJUEsK9iwHcYhBCeUDUlIYQQQgiPKBkjhBBCCOERJWOEEEIIITyiZIwQQopQeno6fvz4wXcYhJBShBrwE0JIIaSkpODRo8fw9fWFl5c3fH3vQlNTA5GRn/kOjRBSSlAyRgghBRAQ8BzTp8/A/fsPkJqaCh0dHTDGkJmZCWdnZ77DI4SUIlRNSQghBZCWlgpTU1MsWuSBbdv+hbq6OrS0NAEACxd68BwdIaQ0oWSMEEIKoGHDhtizZxeMjIwwfvxE1KxpBVPTSnB1bYFataz5Do8QUopQMkYIIQXAGMOSJUsxbNgIdO/eDQsWzEdAQADGjRvDd2iEkFKG2owRQkg+paSkYMyYcThx4iQWLJiHqVOnYOjQ4ahWrSpat27Nd3iEkFKGkjFCCMmHyMgo9OnTFwEBz3Hw4H507doFAJCUlITZs2dBSYkqHAgh+UPJGCGEKOjly1fo0aMXUlNTce3aZdjZ2XHzjh8/ymNkhJDSjB7hCCFEAdeuXYerayvo6enBx8dTKhEjhJDCoGSMEELysHXrNnTv3hNOTo64ceMqzM3N+Q6JEFKGUDJGCCE5yMjIwOTJUzBlyjSMGzcWx44dga6uLt9hEULKGErGCCFEjri4OPTo0Qs7d+7Ghg3rsWLFMigrK//yOL5//45OnbogMjLyl2+bEPJrUDJGCCE/CQ4Ohqtra9y//wBnz57G8OHDeIvlzJmzuHnTEx07dkZqaipvcRBCig8lY4QQIsHf3x/Nm7sgJSUZnp430KKFC6/xBAYGQSAQ4M2btxgzZhyysrJ4jYcQUvQoGSOEkP93/PgJtGvXATVrWsHb26tEDGv06NFjWFiYo2LFCjh+/AQWLFjId0iEkCJGyRgh5LfHGMPSpcswdOhwdOvWFRcunIeRkSHfYSErKwuPHz9Go0aNEB4egZkzZ2DNmrXYuXMX36ERQooQJWOEkN9aSkoKhg4djiVLlmHBgnnYsWMb1NXV+Q4LAPDu3XskJCRwvfzXqFEdY8eOxqRJUxAUFMRrbISQokM98CsgNTVVquFsfHw8j9EQQopKZGQU+vbth2fPAnDgwD5069aV75CkPHz4EADg4iJCnTp14ONzC5s3b4RIJELlypV5jY0QUnQoGVPAsmXL4OHhITNdS0sXWlrU51BB0bErHDp+hfPpUzA6dOiAlJQU+Pj4wN7enu+QZNSoUROjR4+GqakZWrVqhZMnT0JHRx+9evXhOzQ6/wqJjl/BZGQwvkMoFgLGWNncsyIkr2TM3Nwcnz+HQU9Pj8fISi8tLV0kJSXwHUapRcevcG7d8kWvXr1gaWmJkyePlYoe9a9cuYLu3Xvh2bPHqFGjBq+x0PlXOHT8Ci4+Ph6mpmaIi4srU7+/1GZMAerq6tDT05P6jxBSOm3dug1ubm5wdGxaqoY2cnR0hIqKCry9ffgOhRBSxCgZI4T8FjIyMjBlylRMmTINEyZMwPHjR0vV0Ea6urpo1KghJWOElEGUjBFCyrz4+Hj06NELO3bswj//rMPatWt5GdqosEQiZ/j4+FDHr4SUMZSMEULKtODgYLRo0Qr37z/AmTOnMGLEcL5DKjCRSIRv377j2bMAvkMhhBQhSsYIIWWWv78/nJ1bIDk5e2gjV9cWfIdUKPb2jaClpUVVlYSUMZSMEULKJPHQRlZWNeDt7VkihjYqLDU1NTg6NoW3tzffoRBCihAlY4SQMkVyaKOuXbvgwoXzMDY24jusIiMSiXD37j2p7nYIIaUbJWOEkDJDcmij+fP/xs6d20vM0EZFRSRyRlJSEu7ff8B3KISQIkLJGCGkTIiKikb79h3w338XsH//XkyfPg0CgYDvsIpcvXp1YWhYnqoqCSlDKBkjhJR6L1++gkjUAoGBQbh69RK6d+/Gd0jFRklJCc2bN6dG/ISUIZSMEUJKtWvXrsPVtRV0dHRw65YXGjZsyHdIxc7FRYSHDx8hIYGG1CGkLKBkjBBSam3bth3du/eEo2NT3Lx5rdQMbVRYIpEzMjIy4Ovry3cohJAiQMkYIaTUEQ9tNHnyVIwdO6bUDW1UWNWqVYO5uTk8Pb35DoUQUgRU+A6AEELyIz4+HoMHD8XNm5745591pbpH/YISCAQQiZyp3RghZQSVjBFCSg3x0Eb+/vdL/dBGheXiIsLLly8RFRXNdyiEkEKiZIwQUipIDm108+b1Uj+0UWE5OzsDAHx8qHSMkNKOkjFCSIl34sRJtGvXATVqVIe3tydsbGrxHRLvKlasABsbG3h5efMdCiGkkCgZI4SUWOKhjYYMGYauXbvg4sX/ytTQRoVF7cYIKRsoGSOElEgpKSkYNmwElixZhnnz5pbJoY0Ky8VFhODgYAQGBvIdCiGkEOhtSkJIiRMVFY0+ffri2bMA7N+/t0z3qF8YTk6OUFZWhre3D6pWrcp3OISQAqKSMUJIifLq1WtuaKMrVy5SIpYLfX192NkJqd0YIaUcJWOEkBLj+vUb3NBGPj6eaNSoEd8hlXgikTN8fHyQlZXFdyiEkAKiZIwQUiJs27Yd3br1QNOmTXDz5jVYWFjwHVKpIBKJEBPzFS9evOQ7FEJIAVEyRgjhVUZGBqZOnfbbDm1UWI0b20NTU5PeqiSkFKNkjBDCm/j4ePTs2Rvbt+/EP/+sw8qVy6GsrMx3WKWKhoYGmjRxgLe3N9+hEEIKiJIxQggvgoOD4eraGn5+/jh9+uRvPbRRYYlEIty544u0tDS+QyGEFAAlY4SQX+7+/ftwdm6BpKQkeHreQMuWrnyHVKq5uDgjMTERDx8+4jsUQkgBUDJGCPmlTpw4ibZt3WhooyJka2sLAwMDqqokpJSiZIwQ8kswxrBs2XIa2qgYKCsrw9m5OTXiJ6SUomSMEFLsxEMbLV68lIY2KiYikTP8/e/jx48ffIdCCMknSsYIIcUqKioabm4dcf78f9i/fy9mzJgOgUDAd1hljkgkQkZGBnx97/IdCiEknygZI4QUG/HQRp8+BdLQRsXMyqoGKlWqRFWVhJRClIwRQooFDW30awkEAri4iCgZI6QUomSMEFLktm/fge7de6JJEwfcuHGVhjb6RUQiZwQEBCA6OobvUAgh+UDJGCGkyIiHNpo0aQpGjx6FEyeOQU9Pj++wfhsuLiIAwK1bt/gMgxCST5SMEUKKhOTQRuvXr8WqVStoaKNfzNTUFNbWNamqkpBSRoXvAAghpV9ISAi6d++FsLAwnD59knrU55FI5Izr12/wHQYhJB+oZIwQUij3799H8+YuNLRRCeHi4oJPnwIRHBzMdyiEEAVRMkYIKTDx0EbVq1ejoY1KiGbNnKCkpERVlYSUIpSMEULyTXJooy5dOtPQRiWIgYEBGjSoDy8vb75DIYQoiJIxQki+pKSkYPjwkVi8eCn+/nsOdu3aAQ0NDb7DIhJEIhF8fG6BMcZ3KIQQBVAyRghRmHhoo7Nnz2Hfvj2YOXMGDW1UArm4iBAVFYVXr17zHQohRAGUjBFCFPL69RuIRC3w8eMnXLlyET16dOc7JJIDB4fGUFdXh5eXF9+hEEIUQMkYISRP16/fQIsWLaGtrY1bt7xgb2/Pd0gkF5qamnBwcKBG/ISUEpSMEUJyJR7ayMGhMW7evEZDG5USLi7OuHPHFxkZGXyHQgjJAyVjhBC5soc2mo5Jk6Zg1KiRNLRRKePiIkJCQgIePXrEdyiEkDxQMkYIkfG/oY12YN26NVi9eiVUVGjAjtKkQYMG0NfXpy4uCCkFKBkjhEgJCQmBq2tr+Pn549SpExg1aiTfIZECUFZWRrNmTtRujJBSgJIxQghHPLRRYmIibt68jlatWvIdEikEkcgZ/v73kZSUxHcohJBcUDJGCAEAnDx5ihvayMfHC7Vr2/AdEikkkUiEtLQ03L17j+9QCCG5oGSMkFJk+/YdqF27LjQ0NODo2By+vndzXPbu3XtwdW0Fc3NLGBqaoEEDO2zcuElqmQMHDkFbWw/a2noYPHgoUlNT4efnD11dneLeFfIL1KpljYoVK1JVJSElHCVjhJQSJ0+ewvTpMzF9+lQ8efIETZs2Qdeu3REaGip3eS0tLYwePQpXr17B48cPMH36NCxcuBi7d+/hlklPT4eqqioAYNKkCfj48R0+fnxPwxuVEQKBACKRMzXiJ6SEEzAavCzf4uPjoa+vj8+fw+hV/wLS0tJFUlIC32GUKs7OLqhfvz7++Wcdd/yEwobo0KEDFi5coNA6+vbtDy0tLezatQPR0TFo0aIlPn36hL17d6Nnzx7FGX6J8judfwcOHMLYseMQEhKI8uXLF8k6f6fjVxzo+BVcfHw8TE3NEBcXV6Z+f6lkjJBSIC0tDU+ePIWrawup6S1atIC/v79C63j69Bn8/PzRrJkTN7RRdHQ0lJSU8Pff82FlVQvdu/fE06fPimMXCE9cXJzBGMOtW7f5DoUQkgNKxggpBb5+/YrMzEyYmJhITa9QwQSRkZG5ftbKqhbKlTNCs2bOGD16JMzMzNCiRUtoaWlh+/at2L59K44fP4q9e3dDQ0MDLVu2xocPH4pzd8gvZGZmBiurGvD29uY7FEJIDqgXR0JKEYFA+m/GGAQ/T/zJ9etX8ONHIh48eIDp02ciOTkZrVq1xL59e2SK+Zs0cUDTps2wdes2rF69qqjDJzyhdmOElGxUMkZIKWBoaAhlZWVERkZJTY+KipYpLftZlSpVYGNTCy9fvkJSUhL09PRyHNpISUkJdnZCfPjwsUjjJ/wSiUT48OEjwsLC+A6FECIHJWOElAJqampo0KA+PD09paZ7eXmhcePGuX5Wcmijdu3aQl9fP8ehjRhjCAgIQMWKFYssdsK/5s2bQSAQwMuLurggpCSiZIyQUsLd/S/s3bsf+/YdwOvXrzF9+kyEhoZhxIhhAIB58xZgxIhR3PLbtm3Hvn374eTkjDt3fDFu3Bj4+t5Fnz69uGWWLl2G69dvIDAwEM+eBWDs2D8REPCcWycpG8qXLw9bW1tqN0ZICUVtxggpJXr06I5v375h+fIVmDhxEmrXro3Tp0/CwsICAPDlyxepaqigoCBs3vwvsrKyoKWlhVu37mDhwgUYPvx/iVZsbBzc3ScgMjISenp6sLWth2vXLqNhw4a/eO9IcXNxEeHw4SMKtTMkhPxa1M9YAVA/Y4VH/ewUTl7H7+TJUxg1agzq17fF0aNHYGJi/AujK/l+x/Pvxo2b6Ny5Kx4+vA8bm1qFWtfvePyKEh2/gqN+xgghJR5jDMuXr8DgwUPRuXMnXLp0gRIxAgBo2rQJ1NTUqKqSkBKIkjFCyoiUlBQMHz4SixYtwdy5s7F7904a1ohwtLS00LixPY1TSUgJRG3GCCkDoqNj0LdvPzx+/OS3G9qIKM7FRYR//tmIjIyMHN+oJYT8elQyRkgpJx7a6MOHj7hy5SIlYiRHIpEz4uLi8OTJE75DIYRIoGSMkFLs5k1PbmgjHx9P2Nvb8x0SKcHs7Oygq6tLVZWElDCUjBFSSu3YsRNdu3aHg0Nj3Lx5DZaWlnyHREo4FRUVODk5UuevhJQwlIwRUspkZmZi4sSJmDhxMkaNGpHj0EaEyCMSOcPPzw/Jycl8h0II+X+UjBFSiiQkJKBXrz7YtGkT1q5djdWrV1FDbJIvLi4uSE1Nxb17fnyHQgj5f5SMEVJKhIaGwtW1Ne7evYeLFy9i9OhReX+IkJ/Urm0DExMTajdGSAlCyRghpcCDBw/QvLkLfvz4gZs3r6NNmzZ8h0RKKYFAAGfn5tT5KyElCCVjhJRwp06dRtu2bqhatQq8vT1Ru7YN3yGRUs7FRYQnT57i+/fvfIdCCAElY4SUWIwxrFixEoMGDUHHjh1oaCNSZFxcRMjKysLt23f4DoUQAkrGCCmRUlNTMWLEKCxcuBhz587Gnj27aGgjUmQsLCxQrVpVqqokpISg17AIKWFoaCPyK4hEImrET0gJQSVjhJQgkkMbXb58gRIxUmxEIme8ffsOERERfIdCyG+PkjFCSoibNz3h6toKmpqa8PHxROPGjfkOiZRhzZs3BwAqHSOkBKBkTAGpqamIj4+X+o+QorRz5y507dod9vaN4Ol5nYY2IsXO2NgI9erVg5eXN9+hEPLbozZjCli2bBk8PDxkpmtp6UJLS5eHiMoGOnbZQxtNnToV69evx19//YV169Yp3KM+Hb/CoeMHtGrVCkePHoWmpg4EAkG+PkvHr3Do+BVMRgbjO4RiIWCMlc09K0KpqalITU3l/o6Pj4e5uTk+fw6jMQELSEtLF0lJCXyHwauEhAQMGTIM165dx6pVKzBmzGiFP0vHr3Do+GW7evUaunXrgSdPHqFmTSuFP0fHr3Do+BVcfHw8TE3NEBcXV6Z+f6lkTAHq6upQV1fnOwxShoSGhqJ7914ICQnBqVMn0Lp1K75DIr8hR8emUFFRgbe3d76SMUJI0aI2Y4T8Yg8fPpQa2ogSMcIXHR0dNG5sT+3GCOEZJWOE/EKnTp1GmzbtuaGN/vijNt8hkd+cSOSMW7duIzMzk+9QCPltUTJGyC9AQxuRkkokEiE2NhbPnj3jOxRCfluUjBFSzCSHNpozZxYNbURKlIYN7aCtrQ0vL+pvjBC+UDJGSDGKjo6Bm1tHnDlzFnv27MLs2bPy3YUAIcVJTU0Njo5Nqd0YITyiZIyQYvLmzVu4uLTA+/cfcPnyBfTq1ZPvkAiRy8XFBffu3UNKSgrfoRDyW6JkjJBicPOmJ1q0aAkNDU3cuuVFQxuREk0kckZKSgr8/e/zHQohvyVKxggpYjS0ESlt6tT5A0ZGhvD29uY7FEJ+S5SMEVJEMjMzMX36TEyYMAkjRw7HyZPHy1QP0aTsUlJSgrOzMw0aTghPKBkjpAgkJCSgV68++PffrVizZhXWrFmt8BiThJQELi4iPHz4CHFxcXyHQshvh5IxQgopNDQULVu2ga/vXZw6dSJfY0wSUlKIRM7IysrCnTu+fIdCyG+HkjFCCkE8tFF8fDwNbURKtapVq8LS0pK6uCCEB5SMEVJAp0+fQZs27VGliiUNbUTKBJGI2o0RwgdKxgjJJ8YYVq5chYEDB6Njxw64fPkiKlQw4TssQgpNJHLG69ev8fnzF75DIeS3QskYIfmQmpqKkSNHw8NjEQ1tRMocZ2dnAICPD5WOEfIrUTJGiIJiYr6iQ4dOOH36DA1tRMqkChVM8Mcff1BVJSG/GL17T4gC3rx5ix49eiIh4QcuXboABwfqUZ+UTSKRM86dOw/GGD1sEPKLUMkYIXn4eWgjSsRIWebi4oywsDB8/PiR71AI+W1QMkZILiSHNrp58xoNbUTKPCcnJygrK1NVJSG/ECVjhMghb2gjfX19vsMipNjp6uqiUaOGlIwR8gtRMkbITxISEtC7d18a2oj8tkQiZ9y6dQtZWVl8h0LIb4GSMUIkhIWFoWXLNrhzxxcnTx6noY3Ib0kkEuHr128ICHjOdyiE/BYoGSPk//08tFGbNq35DokQXtjbN4KmpiYNjUTIL0LJGCEAzpw5izZt2sPS0oKGNiK/PXV1dTg6NoW3tzffoRDyW6BkjPzWGGNYtWo1BgwYhA4d3HDp0gUa2ogQZFdV3r17D2lpaXyHQkiZR8kY+W2lpqZi1KgxWLBgIWbPnom9e3dDU1OT77AIKRFEImckJSXh/v0HfIdCSJlHyRj5LYmHNjp58hR2796JOXNmU2/jhEiwta2H8uXLwcvLi+9QCCnzKBkjv523b99BJHLBu3fvcfnyRfTu3YvvkAgpcZSUlODs7Ez9jRHyC1AyRn4rnp5ecHFxhYaGBnx8PGloI0JyIRI54+HDR0hISOA7FELKNErGyG9j167d6NKlGxo1aoibN6+jSpUqfIdESIkmEjkjIyMDvr6+fIdCSJlGyRgp8zIzMzFjxiyMHz8RI0YMw6lTJ2hoI0IUUL16dZiZmcHT05vvUAgp02iMF1KmJSQkYOjQ4bh69RpWr16JsWPH8B0SIaWGQCCASETtxggpblQyRsqssLAwtGrVFnfu+OLEiWOUiBFSAC4uIrx8+RJRUdF8h0JImUXJGCmTHj16hObNXRAXF4cbN66hbds2fIdESKnk7OwMAPDxodIxQooLJWOkzDlz5ixat24HCwtzeHt7ok6dP/gOiZBSy9S0ImxsalFVJSHFiJIxUmb8PLTR5csXaWgjQoqASORMg4YTUowoGSNlguTQRrNmzaChjQgpQi4uLggODkZgYCDfoRBSJtHblKTUi4n5in79+uPBg4fYtWsH+vTpzXdIhJQpTk6OUFJSgre3D6pWrcp3OISUOVQyRkq1t2/fwcWlBd6+fYfLly9SIkZIMdDX14ednRDe3t58h0JImUTJGCm1xEMbqaur09BGhBQzkUgEb28fZGVl8R0KIWUOJWOkVNq9ew+6dOmGhg3taGgjQn4BFxcRYmK+4sWLl3yHQkiZQ8kYKVXEQxu5u0/A8OFDcfr0SRraiJBfoHFje2hoaFAXF4QUA0rGSKnx48cP9OnTD1u2/IvVq1di3bq1UFGhd1AI+RU0NDTQpEkTajdGSDGgZIyUCmFhYWjZsg1u375DQxsRwhORyBl37vgiLS2N71AIKVMoGSMlnnhoo9jYWBraiBAeubg4IzExEffv3+c7FELKFErGSIl25sxZtGnTHhYW5vDx8aKhjQjhUf369WFgYICbN2/yHQohZQolY6REyh7aaA0GDBgEN7d2NLQRISWAsrIymjdvRskYIUWMkjFS4qSmpmL06LFYsMADs2bNwJ49NLQRISWFSOQMPz8//Pjxg+9QCCkzKBkjJUpMzFd07NgZJ06cxK5dOzB37hwoKdFpSkhJIRKJkJ6eDl/fu3yHQkiZQb9ypUDbtu0xbdoMAICNTR1s2rSZ54iKh+TQRpcuXaChjQgpgWrWtELlypWpvzFCihB10lTK3LrlDW1tLb7DKHJeXt4YMGAQTE0rwsfnHPWoT0gJJRAI4OrqSskYIUWISsZKGWNjI2hpla1kbPfuPejcuSvs7IQ0tBEhpYCrqysCAgIQE/OV71AIKRMoGStlfq6m1NbWw65du9G9e08YGVWAUNgQ/v7++PjxI9q2bQ9j44pwcXHFp0+fpNZz6dJlODo2R/nyxvjjj3pYunQZMjIyij3+v/4aj1Wr1gDIHtpo5szZNLQRIaWMq6srAMDHh0rHCCkKlIyVAcuXr0S/fn1x794d1KxZE0OHjoC7+0RMmTIZt29n3ywnT57KLX/9+g0MHz4SY8eOxqNH97Fhw3ocPHgYK1euKtY4g4KCsHfvPhgbG3FDG23evAWrV6/E2rVraGgjQkqJypUro2ZNK6qqJKSIUDJWBgwc2B/du3eDlZUVJk+eiODgYPTu3QutWrVErVrWGDduLG7fvsMtv2rVakyePAkDBvRH1apV4eraAn//PQe7du0p1ji3bdsBAwN9ODo2hZOTE27dus0NbSQQCIp124SQouXiIqJxKgkpIlQUUQbUqVOH+7eJicn/T6stNS0lJQXx8fHQ09PDkydP8ejRY6xatZpbJjMzEykpKUhKSiqWNmmJiYnYv/8A2rdvh7Zt3aCmpoabN69Tj/qElFIikQjbtu1AcHAwLC0t+Q6HkFKNSsbKAFVVVe7f4hImFRXZaVlZWdz/58yZjXv37nD/3b9/DwEBT6ChoVEsMR49egxxcXE4deo0KlUyxcqVK3H69GkMGjQEX79SI2BCSptmzZygpKREVZWEFAEqGfsN1a9vi/fv36N69eq/ZHuMMSxatASMMWhrayEg4Dn69OkDIyNDiEQiaitGSClUrlw51K9vCy8vbwwePIjvcAgp1ehX8Dc0c+YM9OjRC2ZmldG1a1coKSnhxYsXePnyJebPn1fk24uMjER0dDR0dHTg6uoKJydHtGzZGpaWZtRWjJBSzMXFBQcOHARjjK5lQgqBkrHfUKtWLXHy5HEsX74C69b9A1VVVdSsaYUhQwYXy/YqVqyIyMgIaGtrczdsLS1dJCUlFMv2CCG/hkjkjDVr1uLVq9f444/aeX+AECKXgDHG+A6itImPj4e+vj4+fw6Dnp4e3+GUSpSMFQ4dv8Kh41c44uOXnJyMypUtsHDhAvz11598h1Vq0PlXcPHx8TA1NUNcXFyZ+v2lBvyEEEIKRFNTE40bN6ZG/IQUEiVjhBBCCszFxRl37vj+khE8CCmrKBkjhBBSYC4uIiQkJODRo0d8h0JIqUXJGCGEkAJr0KAB9PT0qKqSkEKgZIwoJDOL4X5QLC6+iML9oFhkZtF7H4QQQEVFBc2aOcHLy5vvUAgptahrC5Kn669jsPTqB0TGp3HTKuipYXabGmhlY8RjZISQkkAkcsacOX8X23BqhJR1VDJGcnX9dQwmnngllYgBQFR8GiaeeIXrr2N4iowQUlK4uLggLS0Nd+/e4zsUQkolSsZIjjKzGJZe/QB5FZLiacuufqQqS0J+c7VqWaNixYrUboyQAqJkjOToUUicTImYJAbgS3wqHoXE/bqgCCEljkAggLNzc2o3RkgBUTJGchT9I+dErCDLEUJKp+3bd6B27booX94Yjo7Ncfv2bZllRCIRnj17hosXL0JbW0/mv7dv30ktf/bsOdjZNUK5ckaws2uE8+f/+1W7Q0iJQ8kYyZGxjlqRLkcIKX1OnjyF6dNnYvr0qbh79w6aNm2Cdu3aITQ0VGo5FxdnMMbw7NlzAMDTp4/w8eN77r8aNapzy/r7+2PQoCHo06cP/Pzuok+fPhg4cDAePHjwS/eNkJKCxqYsgN9lbMrMLIaWG/wRFZ8mt92YAEAFPXVcH28PZSVBvtZNY7MVDh2/wqHjpzhnZxfUr18f//yzjptmZ2cPN7f2WLhwgdSytrYNYG1tjYsXLyE8PAQGBgZy1zlo0BDEx8fj7NnT3LTOnbvCwMAA+/btKfqdKGHo/Cs4GpuS/HaUlQSY3aYGgOzES5L471ltquc7ESOElA5paWl48uQpXF1bSE1v3bo1/P39ZZYXiUR48uQpAKBp02aoVs0K7dt3hI/PLanl/P3vy6yzZUtX+PvfL9odIKSUoGSM5KqVjRHW96wNEz3pqsgKeupY37M29TNGSBn29etXZGZmwsTERGp6hQoVEBkZKbO8SOSMiIgILFrkgUOHDuDIkYOoWbMG3Nw64s4dX265yMhImXWamJjIXSchvwPq9JXkqZWNEVpYG+JRSByif6TBWEcNdhb6VCJGyG9C8NOlzhiD4OeJAJo3bwaBQABjYxM0aFAfANC4cWOEhYXjn382wMnJUWKd0p/PaZ2E/A6oZOz/2rvP8Carhw3gd9JJKR2UCi1QGYK2WEbTvfKkbBAB2YhsEFFENiJ7CzJk/hFkFmSLKEsK6aArbZgqIFPKS7G0QFMslA7eD2ovEdDakZNx/64rH5qm6Z1DuHL3Oec5Twnk5eVBp9M9dTM3FnIZ/Os4of3rL8G/jhOLGJEZcHFxgYWFBX79NeOp+zMyMp45svXn45s0aYLo6Oin7vf398OVK1eKv37ekbU7d+489zmJzAGPjJXAvHnzMGPGjGfut7OrAju7KgISmQaOXdlw/MqG4/fv7OwAhUKB2NgT6Nmzd/H9R48eRceOHZ87hi1btkRkZCQqVbIvPtL1ww8/wd29ZvHjg4ODERMThwkTPi7+uejoWISEhJjNv4u5vM7yVlBgmuccsoyVwMcff4zRo0cXf63T6VC7dm3k5ubA0pJHiEqDZxOVDcevbDh+Jff+++9h8OCh8PZ+HQEB/li/fgNu3LiBfv36IDc3B1OnTsetW7ewbt0XAICsrEykp6dj3769qF27NrZv34E9e/Zg27bI4jF/990haNWqDWbNmok33miP7747gKioKERFHTGLfxe+/0rPVMeNZawEbGxsYGNjIzoGEZHede3aBXfv3sX8+Z/i9u3b8PLywsGDB+Hh4QEAuH37Nm7evFn8+Jo1awIAunfviSpV7OHp6Yk9e3ahTZvWxY8JDAzApk0bMHPmLMyaNRv16tXF5s0b4efnp98XR2QguM9YKZjLPmMViX8Zlg3Hr2w4fmXzb+PXunVbODk5YceOr/SYynjw/Vd63GeMiIioBFQqCXFxJ1BQUCA6CpFR4DQlCdOmTTucOnUaXl5eqFPnZbi7u8Pd3Q3u7u4ICgpCjRrVRUckolKQJAmzZs3BqVOnOPVIVAIsYyRMw4YNERd3AlqtFllZWUhJScGtW+nIy8tD586dEBm5WXREIioFhcIH9vb2iI6OYRkjKgFOU5IwixYtRIMGr8DFxQVXrlyBu7s7EhPjkZZ2HevXrxMdj4hKycrKCqGhIVCrY0RHITIKLGMkjJWVFZYuXYKMjAyMGTMK6enpCAwMxhdfrBUdjYjKSKWSkJSUhIcPH4qOQmTwWMZIKElSokuXt7Bly1ZERX2PESM+wNy58xEcHAaNhhcNJjJWkiQhLy8PiYlJoqMQGTyWMRJu3rw5+O2337B06TLMnDkdcXExqFTJFhERLTF27Djk5PAUcCJj06iRF1xdXREdzalKon/DMkbC1axZE59/vgROTo4AgCZNGkOtPoZ58+Zg06Yt8PUNwKFDhwSnJKL/QiaTQakMf+Y6lUT0LJYxMgi9evXEhAnji7+2tLTEiBEfICUlCa+99iq6du2Bfv36P3PBYiIyXBERKpw6dRr3798XHYXIoLGMkUGrU6cO9u3bi3XrvoBaHQ2FwhebN0eCF44gMnySpERRURHi4k6IjkJk0FjGyODJZDL06tUTWm0qWrdujffeG4727d/ElStXREcjon/w8ssvo27dOlCr1aKjEBk0ljEyGq6u1fDll2uxb99eXL9+Hf7+QVi0aAny8/NFRyOiF5AkiYv4if4FyxgZnZYtWyAlJQlDhw7B9OkzEBYm4eTJk6JjEdFzSJISFy/+jFu3bomOQmSwWMbIKFWuXBnz5s1BTMzxP87aisDEiZPw22+/iY5GRH+hVCoBgEfHiP4ByxgZNR8fH8TGqjF9+jSsXbsOfn6BOHo0SnQsIvqDq2s1eHt7Q62OFh2FyGCxjJHRs7Kywpgxo6DRJKJOnTro1OktDBo0BJmZWaKjERF+n6qMjo7hWdBEL8AyRiajfv36OHBgP1avXoUjR47Ax0eBr77azg8AIsEkSYlbt27h0qXLoqMQGSSWMTIpMpkMffv2gVabCpVKhcGDh6JTp7dw/fp10dGIzFZoaAgsLS25Gz/RC7CMkUmqXv0lbNq0AXv27MSFCxfh5xeIZctWoKCgQHQ0IrNjb28Pf38/LuInegGWMTJpbdq0QWpqMvr164tJkz6BJDXHmTNnRcciMjuSpERMTCwKCwtFRyEyOCxjZPKqVKmCzz5bgOPHjyIvLw9hYUpMmTINDx8+FB2NyGxIkoT79+/jzJkzoqMQGRyWMTIb/v7+iI+PxSeffIwVK1bC3z+Q0yZEeuLn54vKlStDreb/OaK/Yxkjs2JtbY0JE8YjOTkR7u7uaN++A4YNG467d++KjkZk0qytrRESEsxF/ETPwTJGZqlhwwY4dOgAli//HPv3fwsfHz/s3r2H22AQVSBJkpCQkIhHjx6JjkJkUFjGyGzJ5XIMHDgAWm0KQkKC0a/fAHTt2h1paWmioxGZJElS4tGjR0hO1oiOQmRQWMbI7Lm51cDWrVuwffs2nDlzFr6+AVi9+n8864uonHl7v45q1Vw4VUn0NyxjRH/o0OENaLUa9OrVA2PHjkfz5i3x448/iY5FZDLkcjmUSiVPnCH6G5Yxor9wdHTE0qVLcPToEeh0OgQHh2LmzFlc40JUTiRJidRULbKzs0VHITIYLGNEzxEcHITExHiMGzcGixcvRVBQCE6ciBcdi8joSZISRUVF/P9E9BcsY0QvYGNjg8mTP0FCwgk4Ozujdeu2GDFiJO7fvy86GpHRqlu3Ljw8PKBWR4uOQmQwWMaI/oWXlyeior7H4sWfYdeu3VAo/PHNN/tFxyIySjKZDCqVxHVjRH/BMkZUAnK5HO++OxRarQY+Ps3Qu3cf9OzZG7du3RIdjcjoSJIS58+fx+3bv4qOQmQQWMaI/oOaNWti587t2LJlE5KTNVAo/LFu3ZcoKioSHY3IaCiVSgDgFhdEf2AZI/qPZDIZ3nqrM06eTEHnzp0wcuQotG7dFhcuXBQdjcgoVK/+Ery8vDhVSfQHljGiUnJ2dsaqVStw6NABZGRkICgoBPPmzcfjx49FRyMyeCrV7+vGeAkyIpYxojILDw9DUlICPvxwBObPX4Dg4DAkJyeLjkVk0FQqJdLS0nD16lXRUYiEYxkjKgeVKlXCjBnTcOJELOzsKqF581YYPXoMdDqd6GhEBikkJAQWFhbc4oIILGNE5crb+3Wo1ccwf/5cREZug69vAA4ePCQ6FpHBcXBwgK+vguvGiMAyRlTuLCws8MEH7yM1NRmNGnmhW7ceeOedfjyNn+hvJEmJ2NhYno1MZo9ljKiCeHh4YO/e3Vi/fh1iY2OhUPhh06bNXLBM9AeVSoWsrLs4e/ac6ChEQrGMEVUgmUyGHj26Q6tNRbt2bTF8+Ado1+4NXL58WXQ0IuH8/f1QqVIlrhsjs8cyRqQH1aq5YO3aNdi/fx9u3EiDv38QFi5chPz8fNHRiISxsbFBcHAQN38ls8cyRqRHzZtHQKNJxLBh72LmzFkIDVVCq9WKjkUkjCRJSEhI5P58ZNZYxoj0rHLlypg7dzZiY6NhYWEBSWqO8eMn4sGDB6KjEemdSiUhNzcXGk2K6ChEwrCMEQnSrFlTxMaqMXPmDKxfvwF+foH4/vujomMR6VWTJo1RtaozpyrJrLGMEQlkaWmJUaNGQqNJRP369dG5cxcMGDAId+5kio5GpBdyuRzh4eFcxE9mjWWMyADUq1cP3367D2vWrEZUVBQUCl9s3bqN22CQWZAkJVJTtcjJyREdhUgIljEiAyGTydCnz9vQalMRERGBoUOH4c03O+HatWuioxFVKJVKQkFBAeLj40VHIRKCZYzIwLz0kis2blyPPXt24dKly/DzC8TSpctQUFAgOhpRhahfvz5q1aoFtZqXRiLzxDJGZKDatGmN1NRkDBw4AJMnT4FSGYHTp8+IjkVU7mQyGSRJyXVjZLZYxogMmL29PRYsmI/o6GPIz89HeLiEyZOnIjc3V3Q0onIlSUr8+OOPyMi4IzoKkd6xjBEZAV9fX8THx2LKlE+watVqeHt74/hxtehYROVGkpQAgJgYTlWS+WEZIzISVlZWGDduLJKTE1C7dm106NARQ4cOQ1ZWluhoRGXm5uYGT8/XEB3NMkbmh2WMyMg0aNAAx48fx8qVy/Hddwfg4+OHnTt3cRsMMnpcN0bmimWMyAjJ5XL0798PWm0KwsJCMWDAIHTp0g1paWmioxGVmiRJ+OWXX7idC5kdljEiI+bmVgORkZuxc+d2nDv3AxQKf6xcuQqFhYWioxH9Z6GhIZDL5ZyqJLPDMkZkAtq3bwetVoO33+6FCRM+RkREC/zww4+iYxH9J05OTlAofHidSjI7LGNEJsLBwQFLlixGVNT3ePDgAUJCwjBjxkw8evRIdDSiEpMkCdHRsSgqKhIdhUhvWMaITExgYAASEk5gwoRxWLLkcwQGBiMu7oToWEQlIklKZGZm8sgumRWWMSITZGNjg0mTPkZiYjxcXFzQpk07vP/+CNy7d090NKJ/FBgYAFtbW64bI7PCMkZkwjw9X8PRo0ewdOli7NmzFwqFP77+eh+3wSCDZWtri6CgIK4bI7PCMkZk4uRyOYYMGQytVgM/P1/06dMXPXv2xq1bt0RHI3ouSVLixIl45Ofni45CpBcsY0RmombNmti+fRu2bt2ClJRU+Pj4Ye3adVwoTQZHpVLit99+Q0pKqugoRHrBMkZkRmQyGTp16oiTJ1PQtWsXfPTRaLRq1Qbnz18QHY2oWNOmTeHk5MSpSjIbLGNEZsjJyQkrVizD4cMHkZmZiaCgEMydOw95eXmioxHBwsICYWGhXMRPZoNljMiMhYWFIikpAaNGjcSnny5EcHAoEhOTRMcigkolQaNJwYMHD0RHIapwLGNEZs7W1hbTpk1FfHwc7O3t0aJFK3z00SjodDrR0ciMSZKE/Px8xMcniI5CVOFYxogIAPD6641w/HgUFi78FNu2bYdC4Y/vvjsgOhaZqYYNG8DNzY1TlWQWWMaIqJiFhQWGD38PWq0G3t6vo0ePXujTpy/S02+LjkZmRiaTQZKULGNkFljGiOgZtWvXxp49u7Bx43rExZ2AQuGHjRs3cbNY0iuVSsLZs2eRmZklOgpRhWIZI6Lnkslk6NatK06eTEGHDm/g/fdHoG3b9rh06ZLoaGQmVCoJABAbGysyBlGFYxkjon/k4uKCNWtW49tvv8HNmzcREBCMhQs/4+7oVOHc3d3RsGEDqNXRoqMQVSiWMSIqkYgIFTSaJAwf/h5mzZqDkJBwpKSkiI5FJu73dWPRomMQVSiWMSIqMTs7O8yePROxsdGwsrKCStUC48ZN4F5QVGFUKhWuXr2GGzduiI5CVGFYxojoP2vatAliYo5jzpzZ2LBhI3x9A3D48BHRscgEhYWFQi6XQ63mWZVkuljGSiAvLw86ne6pG5G5s7S0xMiRI5CSkoQGDV5Bly7d0L//QGRk3BEdjUyIs7MzmjZtArVaLToKUYWRPeG56v9q+vTpmDFjxjP3Z2dnw8HBQUAiIsPy5MkTREZGYtSoUXjy5AkWL16Mvn37QiaTiY5GJmDixInYuHEj0tPT+Z4yczqdDo6Ojib3+csyVgJ5eXlPXUBZp9Ohdu3aSE+/aVJvBn2ys6uC3Nwc0TGMlqGO3507mZgwYSJ27NgJlUqFZcuWoF69eqJjPcNQx89Y6Hv8jh07jjff7ASNJgmNGnnp7fdWFL7/Sk+n08HNrZbJlTFOU5aAjY0NHBwcnroR0bNcXath/fp1+PrrPbhy5Qr8/YOwZMnnKCgoEB2NjFhwcBBsbGx4ViWZLJYxIip3rVq1REpKEgYNGoipU6chPFyFU6dOi45FRqpSpUoICAjgpZHIZLGMEVGFsLe3x6efzkN09DEUFhYiPFzCpEmTkZubiy++WAsvL29UreqKkJBwxMcnlOg5ExOT4ODgjMDAkGe+d//+fYwaNRr16jVA1aqu8PHx5RmeJkSlUiIu7gSPspJJYhkjogqlUChw4kQMpk2bijVrvoCXlzfGjZuA8ePHIiHhBIKDg9C5cxekpaX94/NkZ2djyJChkCTlM997/PgxOnToiF9+uYGtW7fg9GktVqxYDnd394p6WaRnkqRETk4OtFqt6ChE5Y5ljIgqnJWVFcaOHY3k5AQ8evQIBQUFiI9PgKtrNSxc+Clq1aqJtWu//Mfn+PDDkejevRsCAvyf+d7mzVtw79497NjxFYKCAuHh4YHg4CA0buxdUS+J9MzHxwcODg6cqiSTxDJGRHrj4eGB3NxcDB06BAcPHoKPjy927NiJiIgIJCcnv/DnNm+OxNWr1zBp0sfP/f6BAwfh7++PUaPGoE6d+vD1DcDChZ+hsLCwol4K6ZmlpSXCwkJZxsgksYwRkd5kZWWhsLAQPXp0h1abAqVSiYEDB+Po0aO4efP/nvszly9fxtSp07B+/TpYWlo+9zHXr1/Hvn3foLCwEF9/vRsTJozDsmXLsWDBwop8OaRnkqREUlIycnNzRUchKlcsY0SkdzIZUKNGdWzevBG7du1ARsYd/PLLL1ixYuVTR7MKCwsxYMAgTJ48CQ0aNHjh8xUVFcHV1RUrVixDs2bN0K1bV4wbN+5fpz7JuEiShMePHyMhIVF0FKJyxTJGRHrj4uICCwsL/PprRvF97dq1RbduXVGjRg1MnDgJKlVznD17DgCQk5ODkydPYfTosXBwcIaDgzPmzfsU586dg4ODc/GUVY0aNfDKK6/AwsKi+HlffbUhfv31Vzx+/Fi/L5IqjKfna6hevTqnKsnksIwRkd5YW1ujWbOmOH78+FP3x8fHo3fvXjh27Hvk5j5EWJgS06bNgJWVFTSaJCQmxhffBg8eiIYNGyAxMR5+fr4AgMDAQFy9ehVFRUXFz3n58mXUqFED1tbWen2NVHFkMhkkSckyRiaHZYyI9GrEiA+wceNmbNq0BRcuXMT48RORlnYTgwcPREBAAFq3bgVPT08sW7YcQUEhyMzMRKNGXsU3V1dX2NjYolEjL1SuXBkAMGTIINy9exfjxo3HpUuXcPjwYSxcuAjvvjtE8Kul8iZJEk6fPo27d++KjkJUbljGiEivunbtggUL5mP+/E8RFBSC+PgE7N27Gx4eHgCAO3fuwMnJEUlJCahevTratXsDw4d/gHv37r3wOWvVqoX9+7+GVnsSAQHBGDt2PN5//z2MGTNaXy+L9ESlUuLJkyeIjY0THYWo3PBC4aXw51XjeaHw0uOFcsvGXMavqKgIGzZsxOTJU2Fra4tFixaic+dOkMlkZXpecxm/iiJ6/Bo3boqICBWWLl0iLENZiB4/Y8YLhRMR6ZlcLsegQQNx8mQKAgMD8M47/dC9e0/83/89fxsMMg8qlYrrxsiksIwRkcFzc3PDV19txbZtkTh58hQUCn+sWfPFUwv2yXxIkhKXLl3GzZs3RUchKhcsY0RkNDp2fBNarQbdu3fD6NFj0aJFK/z003nRsUjPwsPDIJPJoFbz6BiZBpYxIjIqTk5OWLZsKb7//jDu3buH4OBQzJ49B3l5eaKjkZ64uLigcePGiI6OFh2FqFywjBGRUQoJCUZiYjzGjBmFzz5bjKCgEO7MbkZUKgnR0THgOWhkCljGiMho2draYsqUyYiPj4OjoyNatmyNkSNHITs7W3Q0qmCSpMTt27dx8eLPoqMQlRnLGBEZvUaNvBAV9T0WLVqI7dt3QKHwx7fffic6FlWg4OAgWFlZQa1Wi45CVGYsY0RkEiwsLDBs2LvQajVo2rQJevbsjd69+yA9PV10NKoAlStXRkCAP7e4IJPAMkZEJqVWrVrYtWsHNm3agISERCgU/li/fgO3wTBBKpWEuLgTKCgoEB2FqExYxojI5MhkMnTt2gUnT6agY8c3MWLESLRp0w4//3xJdDQqR5IkITs7G6dPnxYdhahMWMaIyGRVrVoVq1evxIED3yI9PR0BAUH49NMFePz4sehoVA4UCh/Y29tDrY4WHYWoTFjGiMjkSZISGk0SRoz4AHPmzINCoYBGoxEdi8rIysoKoaEh3PyVjB7LGBGZhUqVKmHmzOmIi4uBra0tIiJaYuzYccjJ4QWbjZkkKZGUlISHDx+KjkJUaixjRGRWmjRpjMTERMybNwebNm2Br28ADh8+LDoWlZJKpUJeXh6SkpJFRyEqNZYxIjI7lpaWGDHiA6SkJOG1115Fly7d0a9ff/z6a4boaPQfNWrkBVdXV25xQUaNZYyIzFadOnWwb99erFv3BaKjY6BQ+GLz5kheYseIyGQyKJXh3PyVjBrLGBGZNZlMhl69ekKrTUWbNm3w3nvD0b79m7hy5YroaFRCKpWEU6dO4/79+4KTEJUOyxgREYBq1Vywbt0X+Oabr3H9+nX4+wdh0aIlyM/PFx2N/oVKJaGoqAhxcSdERyEqFZYxIqK/aNGiOVJSkjB06BBMnz4D4eEqnDp1SnQs+gcvv/wy6tatg+joaNFRiEqFZYyI6G8qV66MefPmICbmOAAgPFyFiRMn4bfffhOcjF5EkiRu/kpGi2WMiOgFfHx8EBurxvTp07B27Tr4+QUiKuqY6Fj0HJKkxMWLP+PWrVuioxD9ZyxjRET/wMrKCmPGjIJGk4g6deqgY8fOGDRoCDIzs0RHo79QKpUAwC0uyCixjBERlUD9+vVx4MB+rF69CkeOHIGPjwJffbWd22AYCFfXavD29mYZI6PEMkZEVEIymQx9+/aBVpsKlUqFwYOHolOnt3D9+nXR0Qi/T1Wq1dEsyGR0WMaIiP6j6tVfwqZNG7Bnz05cuHARfn6BWLZsBQoKCkRHM2uSpMStW7dw6dJl0VGI/hOWMSKiUmrTpg1SU5PRr19fTJr0CVSq5jh79pzoWGYrNDQElpaW3OKCjA7LGBFRGVSpUgWffbYAx48fxaNHeQgNDceUKdPw8OFD0dHMjr29Pfz9/bhujIwOyxgRUTnw9/dHfHwsPvnkY6xYsRL+/oEsBQJIkhKxsbEoLCwUHYWoxFjGiIjKibW1NSZMGI/k5ES4u7ujffsOGDZsOO7evSs6mtmQJAn37t3HmTNnREchKjGWMSKictawYQMcOnQAy5d/jv37v4WPjx92797Ds/z0wM/PF3Z2dlCreVSSjAfLGBFRBZDL5Rg4cAC02hSEhASjX78B6Nq1O9LS0kRHM2nW1tYIDQ3hIn4yKixjREQVyM2tBrZu3YLt27fhzJmz8PUNwOrV/+OapgokSRISE5Pw6NEj0VGISoRljIhIDzp0eANarQa9evXA2LHj0aJFK/z440+iY5kkSVLi4cOHSE7WiI5CVCIsY0REeuLo6IilS5fg6NEjyM7ORkhIGGbOnMUjOOXM2/t1VKvmwqlKMhosY0REehYcHITExHiMHTsaixcvRVBQCE6ciBcdy2TI5XIolUpuLUJGg2WMiEgAGxsbTJ78CRISTsDZ2RmtW7fFiBEjcf/+fdHRTIIkKaHVnkR2drboKET/imWMiEggLy9PREV9j8WLP8OuXbuhUPjjm2/2i45l9CRJicLCQh5xJKPAMkZEJJhcLse77w6FVquBj08z9O7dB716vY309HTR0YxW3bp14eHhAbU6WnQUon/FMkZEZCBq1qyJnTu3Y8uWTUhKSoaPjx/WrfsSRUVFoqMZHZlMBpVK4roxMgosY0REBkQmk+Gttzrj5MkUdO7cCSNHjkLr1m1x8eLPoqMZHUlS4vz587h9+1fRUYj+EcsYEZEBcnZ2xqpVK3Do0AFkZGQgMDAY8+bNx+PHj0VHMxpKpRIAEBPDo2Nk2FjGiIgMWHh4GJKSEvDhhyMwf/4CBAeHITk5WXQso1C9+kvw8vLiujEyeCxjREQGrlKlSpgxYxri4mJgZ1cJzZu3wujRY6DT6URHM3iS9Pt+Y7xIOxkyljEiIiPRuLE31OpjmD9/LiIjt8HXNwAHDx4SHcugRURISEtLw9WrV0VHIXohljEiIiNiYWGBDz54H6mpyWjUyAvduvVA3779uUj9BUJCQmBhYcGzKsmgsYwRERkhDw8P7N27G+vXr0NMTAwUCj9s2rSZ03F/4+DgAF9fBdeNkUFjGSMiMlIymQw9enSHVpuKdu3aYvjwD9Cu3Ru4fPmy6GgGRZKUiI2N5X5tZLBYxoiIjFy1ai5Yu3YN9u/fhxs30uDvH4SFCxchPz9fdDSDoFKpkJV1F2fPnhMdhei5WMaIiExE8+YR0GgSMWzYu5g5cxZCQ5XQarWiYwnn7++HSpUqcd0YGSyWMSIiE1K5cmXMnTsbsbFqWFhYQJKaY/z4iXjw4IHoaMLY2NggODgI0dHRoqMQPRfLGBGRCWrWrBliY9WYOXMG1q/fAD+/QHz//VHRsYSRJAnx8Qm8ggEZJJYxIiITZWlpiVGjRkKjSUT9+vXRuXMXDBgwCHfuZIqOpncqlYTc3FxoNCmioxA9g2WMiMjE1atXD99+uw9r1qxGVFQUFApfbN26zay2wWjSpDGqVnXmVCUZJJYxIiIzIJPJ0KfP29BqUxEREYGhQ4fhzTc74dq1a6Kj6YVcLkd4eDgX8ZNBYhkjIjIjL73kio0b12PPnl24dOky/PwCsXTpMhQUFIiOVuEkSYmUlFTk5OSIjkL0FJYxIiIz1KZNa6SmJmPAgP6YPHkKlMoInD59RnSsCiVJShQUFCA+Pl50FKKnsIwREZkpe3t7LFz4KdTqKOTn5yM8XMLkyVORm5srOlqFeOWVV1CrVi2o1ZyqJMPCMkZEZOb8/PwQHx+LKVM+wapVq+HvH2iS13KUyWSQJCXXjZHBYRkjIiJYWVlh3LixSE5OQK1atfDGG29i6NBhyMrKEh2tXEmSEj/88AMyMu6IjkJUjGWMiIiKNWjQAAcPfoeVK5fju+8OwMfHDzt37jKZbTAkSQkAiInh0TEyHCxjRET0FLlcjv79+0GrTUFYWCgGDBiELl26IS0tTXS0MnNzc4On52ucqiSDwjJGRETP5eZWA5GRm7Fjx1c4d+4HKBT+WLlyFQoLC0VHKxOuGyNDwzJGRET/6I032kOr1eDtt3th/PiJCA4Oxg8//Cg6VqlJkoTr16+bzYa3ZPhYxoiI6F85ODhgyZLFiIr6Hjk5OQgJCcOMGTPx6NEj0dH+s9DQEMjlch4dI4PBMlYCeXl50Ol0T92IiMxRUFAgTp06hQkTxmHJks8RGBiMuLgTomP9J05OTlAofHidSjIYsiemcopMBZo+fTpmzJjxzP3Z2dlwcHAQkIiISLyffvoJQ4YMQUJCAgYPHowFCxbA2dlZdKwS+eSTT7B27Vrcvn0bcjmPSxgLnU4HR0dHk/v8ZRkrgby8POTl5RV/rdPpULt2baSn3zSpN4M+2dlVQW4urw9XWhy/suH4lc1fx6+oqAhffrkeU6ZMg52dHRYtWohOnTpCJpMJTvnPoqNj0L59ByQlJcDb+3W9/m6+/0pPp9PBza2WyZUx/jlQAjY2NnBwcHjqRkREv2+DMWTIYGi1Gvj5+aJPn77o2bM3bt26JTraPwoMDICtra1JXmmAjA/LGBERlVnNmjWxffs2bN26BSkpqfDx8cPatetQVFQkOtpz2draIjAwkOvGyCCwjBERUbmQyWTo1KkjtFoNunbtgo8+Go1Wrdrg/PkLoqM9l0olIT4+Afn5+aKjkJljGSMionLl7OyMFSuW4fDhg8jMzERQUAjmzJn71NpbQ6BSKfHgwQOkpmpRUFCAlStXGeVWHWT8WMaIiKhChIWFIikpAaNGjcSCBZ8hODgUiYlJomOhqKgIubm5aNq0KZycnKBWq5GUlIzx4yfi2rXrouORGWIZIyKiCmNra4tp06YiPj4O9vb2aNGiFT76aJTQ/RojI7fhtde8cOXKVYSFhSI6OgapqVrY2dmhQYNXhOUi88UyRkREFe711xvh+PEoLFz4KbZt2w6Fwh/ffXdASJYOHdrjpZdeQufOXeDrq4BGkwKNRoNmzZrC0tJSSCYybyxjRESkFxYWFhg+/D2kpibD2/t19OjRC3369EV6+m295nB2dsbevbvx8OFD7Ny5C/n5+UhMTIJCodBrDqI/sYwREZFeeXh4YM+eXdiw4UvExZ2AQuGHjRs3QZ97kHt4eGDv3t24fv0XWFtbIyMjAwqFj95+P9FfsYwREZHeyWQydO/eDSdPpqBDhzfw/vsj0LZte1y6dElvGZo2bYLIyM3FW1v4+vLIGInBMkZERMK4uLhgzZrV+Pbbb3Dz5k0EBARjwYKFePz4sV5+f6tWLTFmzGi4u7vj5Zdf1svvJPo7ljEiIhIuIkIFjSYJw4e/h9mz5yI0VImUlBS9/O4ZM6bh0qULBn89TTJdLGNERGQQ7OzsMHv2TMTGRsPKygoqVQuMGzcBDx48EB2NqEKxjBERkUFp2rQJYmKOY86c2diwYSN8fQNw+PAR0bGIKgzLGBERGRxLS0uMHDkCKSlJaNDgFXTp0g39+w9ERsYd0dGIyh3LGBERGay6deti//59+OKL/+HYsWNQKHwRGbn1qW0wPvzwI0RFHROYkqhsWMaIiMigyWQyvP12byxevAhyuQXeffc9ODm5oG3b9rh69SoyMzMxfPgH+Pnnn9GvX3/UquUBV9caxScB/PzzJVSu7ICLF39+6nmXLVsBT8/X9bq/GdHzsIwREZFRsLKywrJlS7Fq1XJUq1YNJ07Eo0WL1pgxYxqysrIgSc2Rnn4bO3fuQFJSPEaNGomioiI0bNgAzZo1w44dO556vp07d6F79248i5KEkz3hnwT/mU6ng6OjI9LTb8LBwUF0HKNkZ1cFubk5omMYLY5f2XD8ysYQxu/BgweYNGkyvvxyPV59tSGqVauG+PgEREcfg5+f3zOPX758Bdas+QI//HAWAHDp0iU0bapAaqoGnp6v6TW7IYyfsdLpdHBzq4Xs7GyT+vzlkTEiIjIKV69eRf/+A9GoUWPUr98QX321HQDw6FEe4uMTYGFhgenTZz132rFr1664cSMNGo0GALBjx040btxY70WM6HlYxoiIyCh069YDd+/exYoVy1Czpjtyc3MBALm5uahSpQoKCwsRHR2N5ctXPPOzbm41EB4ejp07dwEAdu3ajZ49e+g1P9GLsIwREZHBy8rKwoULFzFhwnioVBL27duLqVMnAwACAwPh6ekJuVwOOzs7XLjw83Ofo0eP7ti9ey+Sk5Nx9eo1dOvWRX8vgOgfsIwREZHBc3Z2hotLVaxfvwFXrlzB1avXcODAQQDA22/3wpEjB1G/fj00a9YU77zzNq5du4Z9+75BcnJy8XN07NgBOTk5GDlyNMLDw+Hu7i7q5RA9hWWMiIgMnlwux8aNG3D69Gn4+QViwoSPMWfO7OLvW1tbY//+fXB1dcVbb3WFv38QFi1aDAsLi+LHODg4oF27tjh37hx69Ogu4mUQPRfPpiwFnk1ZdjybqGw4fmXD8Ssbjl/ZcPxKj2dTEhEREVG5YxkjIiIiEohljIiIiEggljEiIiIigSxFByAiIjI0hUVPoL2RjTsPHsPV3hoKD0dYyHkNS6oYLGNERER/cfR8JuYeuYxfdY+L76vuYI1JrV9BS89qApORqeI0JRER0R+Ons/ER7t+eqqIAUCG7jE+2vUTjp7PFJSMTBnLGBEREX6fmpx75DKet/nmn/fNO3IFhUXcnpPKF8sYERERAO2N7GeOiP3VEwC3dXnQ3sjWXygyCyxjREREAO48eHERK83jiEqKZYyIiAiAq711uT6OqKRYxoiIiAAoPBxR3cEaL9rAQgaghoMNFB6O+oxFZoBljIiICICFXIZJrV8BgGcK2Z9ff9y6Pvcbo3LHMkZERPSHlp7VsLSbF15yeHoqsrqDDZZ28+I+Y1QhuOkrERHRX7T0rIaIV124Az/pDcsYERHR31jIZfCv4yQ6BpkJTlMSERERCcQyRkRERCQQyxgRERGRQCxjRERERAKxjBEREREJxDJGREREJBDLGBEREZFALGNEREREArGMEREREQnEMkZEREQkEMsYERERkUAsY0REREQCsYwRERERCcQyRkRERCQQyxgRERGRQCxjRERERAKxjBEREREJxDJGREREJBDLGBEREZFALGNEREREArGMEREREQnEMkZEREQkEMsYERERkUAsY0REREQCsYwRERERCcQyRkRERCQQyxgRERGRQCxjRERERAKxjBEREREJxDJGREREJJCl6ADG6MmTJwCAnJwcwUmMV0HBE+TmcvxKi+NXNhy/suH4lQ3Hr/T+/Nz983PYVLCMlUJWVhYAoGFDT8FJiIiIzE9WVhYcHR1Fxyg3LGOlULVqVQDAjRs3TOrNoC86nQ61a9dGWloaHBwcRMcxOhy/suH4lQ3Hr2w4fmWTnZ0NDw+P4s9hU8EyVgpy+e9L7RwdHfmfqQwcHBw4fmXA8Ssbjl/ZcPzKhuNXNn9+DpsK03o1REREREaGZYyIiIhIIJaxUrCxscG0adNgY2MjOopR4viVDcevbDh+ZcPxKxuOX9mY6vjJnpja+aFERERERoRHxoiIiIgEYhkjIiIiEohljIiIiEggljEiIiIigVjGiIiIiARiGSMiIiISiGWMiIiISCCWMSIiIiKB/h+ZhcAWO4BClwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABLYAAAGbCAYAAADZbBnaAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8o6BhiAAAACXBIWXMAAA9hAAAPYQGoP6dpAABlR0lEQVR4nO3deZyN9f//8eeZfcbMYCzZx75lX0MZksgWlY8ta6v4lEI+KhkpVFI+7SFCKJSPKJHtoyyNJEQq2QpfZRvG0izv3x9+cz6OmWHOONt1edxvt7ndnOt6n+u8znWu57lmXq7FYYwxAgAAAAAAACwmyN8FAAAAAAAAAHlBYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjC4BlzJgxQw6HI8efNWvW+LtEjyhbtqz69evn7zKy9ffff+vhhx9W8eLFFRwcrDp16vi7pCz27dsnh8OhGTNm+LsUSdL69euVmJiokydPZpnXokULtWjRwuc1Xa5fv34BUUcgS0xMlMPh8HcZ1+Sjjz7SjTfeqMjISDkcDm3dutXfJXnEmjVrLLkPcDgcSkxMdD7O3Mft27fPreWMGzdOixYt8mhtVrBu3TqFh4dr//79zmktWrRQjRo1rvi8Tz75RD169FDFihUVGRmpsmXLqlevXvrll1+8XbLP/fzzzwoLC9OWLVv8XQoAeFWIvwsAAHdNnz5dVatWzTK9evXqfqjm+vL222/r3Xff1euvv6769esrOjra3yUFvPXr12vMmDHq16+fChQo4DLvrbfe8k9RcNv999+vtm3b+ruMPPvzzz/Vu3dvtW3bVm+99ZbCw8NVuXJlf5flEfXq1dOGDRssvw9o3769NmzYoOLFi7v1vHHjxumee+5R586dvVNYADLGaMiQIXrggQcUHx/v1nNffPFFFStWTE8//bTKly+vgwcPaty4capXr542btyoG2+80UtV+17lypXVq1cvPf7441q7dq2/ywEAr6GxBcByatSooQYNGvi7jOvSjh07FBkZqcGDB/u7FFuw+h/i14OzZ88qKipKpUqVUqlSpfxdTp79/PPPSk1N1b333quEhASPLDNz3fhLamqqHA6HYmNjddNNN/mtDk8pUqSIihQp4u8yLGHZsmXasmWL5syZ4/ZzP/vsMxUtWtRl2q233qqyZcvq1Vdf1dSpUz1VZp6lp6crLS1N4eHh17yswYMHq0GDBlq/fr2aNm3qgeoAIPBwKiIA25k3b54cDofeeOMNl+mjR49WcHCwVqxY4Zw2ZswYNW7cWHFxcYqNjVW9evU0bdo0GWNcnlu2bFl16NBBS5YsUd26dRUZGalq1appyZIlki6eQlKtWjXly5dPjRo10ubNm12e369fP0VHR+vHH39Uq1atlC9fPhUpUkSDBw/W2bNnr/qekpOTNWzYMJUrV05hYWEqWbKkhgwZopSUFJdx8+fPV+PGjZU/f35FRUWpfPnyGjBgwFWXf/78eY0cOdJl+YMGDXI5fc7hcGjq1Kk6d+6c8/TPq53u99VXX6lVq1aKjY1VVFSUmjVrppUrVzrn//LLL4qNjVXXrl1dnrdq1SoFBwdr1KhRzmmZn8Gnn36qWrVqKSIiQuXLl9e///3vq76/X3/9Vf3791elSpUUFRWlkiVLqmPHjtq+fbvLuMxTmubOnaunn35aJUqUUGxsrG677Tbt3r3bZeyKFSt05513qlSpUoqIiFDFihX10EMP6a+//nKOSUxM1PDhwyVJ5cqVy3LabHanIh4/flyPPPKISpYsqbCwMJUvX15PP/20Lly44DLO4XBo8ODBmjVrlqpVq6aoqCjVrl3buU1m+vPPP/Xggw+qdOnSCg8PV5EiRdSsWTN99dVXV11v2ZkzZ46aNGmi6OhoRUdHq06dOpo2bZrLmPfff1+1a9dWRESE4uLi1KVLF+3atctlTGYmfvrpJ7Vp00b58uVT8eLFNWHCBEnSxo0bdfPNNytfvnyqXLmyPvjgA5fnZ562tWLFCvXv319xcXHKly+fOnbsqN9++81lbG4+K+l/pxtu2bJF99xzjwoWLKgKFSq4zLvUqlWr1KJFCxUqVEiRkZEqU6aM7r77bpdMB8Ln2a9fP918882SpG7dusnhcLhsd4sXL1aTJk0UFRWlmJgYtW7dWhs2bMj1urncDz/8IIfDkWW7kKQvvvhCDodDixcvluR+NmfNmqWhQ4eqZMmSCg8P16+//prjqYi5eV/9+vVT2bJls9SZ3eed1+/X5ORkPfDAAypUqJCio6PVtm1b/fzzz1nGZXcq4vfff68OHTqoaNGiCg8PV4kSJdS+fXv9/vvvki5uNykpKfrggw+c3y+Zn+2ff/6pRx55RNWrV1d0dLSKFi2qW2+9VevWrXN53czTtydOnKhJkyapXLlyio6OVpMmTbRx48YsdW7atEkdO3ZUoUKFFBERoQoVKmjIkCEuY3755Rf17NnTWXe1atX05ptvuozJyMjQ888/rypVqigyMlIFChRQrVq1NHny5Kuu07ffflsNGzZUlSpVrjr2cpc3tSSpRIkSKlWqlA4ePHjV52ee7piUlKRbbrnFuS1MmDBBGRkZLmMPHDige++912U9vPLKKy7jMtf/Sy+9pOeff17lypVTeHi4Vq9e7dwOt23bpq5duyp//vyKi4vTE088obS0NO3evVtt27ZVTEyMypYtq5deeilLvfXr11e1atX0zjvvuL2uAMAyDABYxPTp040ks3HjRpOamuryk5aW5jL24YcfNmFhYSYpKckYY8zKlStNUFCQeeaZZ1zG9evXz0ybNs2sWLHCrFixwowdO9ZERkaaMWPGuIyLj483pUqVMjVq1DBz5841n3/+uWncuLEJDQ01zz77rGnWrJn55JNPzKeffmoqV65sbrjhBnP27Fnn8/v27WvCwsJMmTJlzAsvvGCWL19uEhMTTUhIiOnQoUOW1+rbt6/zcUpKiqlTp44pXLiwmTRpkvnqq6/M5MmTTf78+c2tt95qMjIyjDHGrF+/3jgcDtO9e3fz+eefm1WrVpnp06eb3r17X3G9ZmRkmDZt2piQkBAzatQos3z5cjNx4kSTL18+U7duXXP+/HljjDEbNmww7dq1M5GRkWbDhg1mw4YN5ujRozkud9asWcbhcJjOnTubTz75xHz22WemQ4cOJjg42Hz11VfOcfPmzTOSzOTJk40xxhw+fNjccMMNJiEhweVzjY+PNyVLljRlypQx77//vvn8889Nr169jCTz8ssvO8ft3bvXSDLTp093Tlu7dq0ZOnSoWbBggVm7dq359NNPTefOnU1kZKT56aefnONWr15tJJmyZcuaXr16maVLl5q5c+eaMmXKmEqVKrnU8/bbb5vx48ebxYsXm7Vr15oPPvjA1K5d21SpUsX8/fffxhhjDh48aP75z38aSeaTTz5xrrdTp04ZY4xJSEgwCQkJzmWeO3fO1KpVy+TLl89MnDjRLF++3IwaNcqEhISYdu3auazfzDobNWpkPv74Y/P555+bFi1amJCQELNnzx7nuDZt2pgiRYqY9957z6xZs8YsWrTIPPvss2bevHk5bxQ5GDVqlJFk7rrrLjN//nyzfPlyM2nSJDNq1CjnmHHjxhlJpkePHmbp0qVm5syZpnz58iZ//vzm559/do7LzES1atXM5MmTzYoVK0z//v2NJDNy5EhTuXJlM23aNPPll1+aDh06GElm8+bNzudnfh+ULl3aDBgwwHzxxRfmvffeM0WLFjWlS5c2J06ccOuzMsaY0aNHG0kmPj7ejBgxwqxYscIsWrTIZV6mvXv3moiICNO6dWuzaNEis2bNGvPhhx+a3r17O187UD7PX3/91bz55ptGkhk3bpzZsGGD+fHHH40xxnz44YdGkrn99tvNokWLzEcffWTq169vwsLCzLp163K1brJTt25d06xZsyzT//GPf5iiRYua1NRUY4z72SxZsqS55557zOLFi82SJUvMsWPHnPNWr17tHJ/b99W3b18THx+fpc7LP+9r+X5t2bKlCQ8Pd373jx492pQvX95IMqNHj3aOzdym9+7da4wx5syZM6ZQoUKmQYMG5uOPPzZr1641H330kXn44YfNzp07jTEXv5cjIyNNu3btnN8vmZ/tTz/9ZAYOHGjmzZtn1qxZY5YsWWLuu+8+ExQU5LKuMr8zy5Yta9q2bWsWLVpkFi1aZGrWrGkKFixoTp486Ry7bNkyExoaamrVqmVmzJhhVq1aZd5//33TvXt355gff/zR5M+f39SsWdPMnDnTLF++3AwdOtQEBQWZxMRE57jx48eb4OBgM3r0aLNy5UqzbNky89prr7mMyc6FCxdMZGSkefLJJ7PMS0hIMDfeeOMVn5+dPXv2mKCgIPP4449fdWxCQoIpVKiQqVSpknnnnXfMihUrzCOPPGIkmQ8++MA57ujRo6ZkyZKmSJEi5p133jHLli0zgwcPNpLMwIEDneMy13/JkiVNy5YtzYIFC8zy5cvN3r17ndthlSpVzNixY82KFSvMk08+aSSZwYMHm6pVq5p///vfLt+fCxcuzFLzwIEDTeHChZ2/LwCA3dDYAmAZmb/0Z/cTHBzsMvb8+fOmbt26ply5cmbnzp3ZNkoul56eblJTU81zzz1nChUq5PILYHx8vImMjDS///67c9rWrVuNJFO8eHGTkpLinL5o0SIjySxevNg5rW/fvi7Nm0wvvPCCkWS+/vprl9e6tLE1fvx4ExQU5GzSZVqwYIGRZD7//HNjjDETJ040klz+CMmNZcuWGUnmpZdecpn+0UcfGUnmvffec3kf+fLlu+oyU1JSTFxcnOnYsaPL9PT0dFO7dm3TqFEjl+kDBw40YWFhZsOGDebWW281RYsWNYcOHXIZEx8fbxwOh9m6davL9NatW5vY2FjnZ5BdY+tyaWlp5u+//zaVKlVy+UMm8w/ky5sOH3/8sZFkNmzYkO3yMjIyTGpqqtm/f7+RZP7zn/8457388ssuf6xe6vLG1jvvvGMkmY8//thl3IsvvmgkmeXLlzunSTI33HCDSU5Odk47cuSICQoKMuPHj3dOi46ONkOGDMlxXeTWb7/9ZoKDg02vXr1yHHPixAnnH9mXOnDggAkPDzc9e/Z0TsvMxKV/hKWmppoiRYoYSWbLli3O6ceOHTPBwcHmiSeecE7L/D7o0qWLy2t98803RpJ5/vnns63xSp9V5h+Rzz77bJbnXd7oyMzf5dvjpQLp88zctufPn++clp6ebkqUKGFq1qxp0tPTndNPnz5tihYtapo2beqcdqV1k51///vfRpLZvXu3c9rx48dNeHi4GTp0aI7Pu1o2mzdvnuN7y2zWuPO+ctvYyuv36xdffHHF7/4rNbY2b95sJF2xgWiMMfny5XPZZ+QkLS3NpKammlatWrnkJvM7s2bNmi77yG+//dZIMnPnznVOq1ChgqlQoYI5d+5cjq/Tpk0bU6pUKWcDP9PgwYNNRESEOX78uDHGmA4dOpg6depcte7Lbdq0yUjKtpmbl8ZWamqqadGihYmNjTUHDhy46viEhAQjyWzatMllevXq1U2bNm2cj//1r39lO27gwIHG4XA4s5G5/itUqODSaDfmf9vhK6+84jK9Tp06zv8wufR9FClSxNx1111Zap4yZYqRZHbt2nXV9wcAVsSpiAAsZ+bMmUpKSnL52bRpk8uY8PBwffzxxzp27Jjq1asnY4zmzp2r4OBgl3GrVq3Sbbfdpvz58ys4OFihoaF69tlndezYMR09etRlbJ06dVSyZEnn42rVqkm6eFrCpdeZyZx+6Z2aMvXq1cvlcc+ePSVJq1evzvH9LlmyRDVq1FCdOnWUlpbm/GnTpo3L6TcNGzaUJP3jH//Qxx9/rD/++CPHZV6+DiRluRNj165dlS9fPpdTB3Nr/fr1On78uPr27etSc0ZGhtq2baukpCSX0yhfffVV3XjjjWrZsqXWrFmj2bNnZ3sB5RtvvFG1a9d2mdazZ08lJydf8a5PaWlpGjdunKpXr66wsDCFhIQoLCxMv/zyS5ZT5CSpU6dOLo9r1aolyfUzPXr0qB5++GGVLl1aISEhCg0NdV7EOLtl5saqVauUL18+3XPPPS7TMz+byz+Lli1bKiYmxvn4hhtuUNGiRV3qbNSokWbMmKHnn39eGzduVGpqap5qW7FihdLT0zVo0KAcx2zYsEHnzp3Lsi2VLl1at956a5b6HQ6H2rVr53wcEhKiihUrqnjx4qpbt65zelxcXJb3lenyTDVt2lTx8fEumXL3s7r77rtzfI+Z6tSpo7CwMD344IP64IMPspz+KAX25ylJu3fv1qFDh9S7d28FBf3vV8Lo6Gjdfffd2rhxY5ZTpXOzbqSLn0t4eLjL6cpz587VhQsX1L9/f+c0d7OZm9fPy/u6mrx+v2Zuhzl9919JxYoVVbBgQY0YMULvvPOOdu7c6VbNkvTOO++oXr16ioiIcG77K1euzHbdtm/f3mUfefn33s8//6w9e/bovvvuU0RERLavd/78ea1cuVJdunRRVFSUy/d/u3btdP78eefpjY0aNdIPP/ygRx55RF9++aWSk5Nz9Z4OHTokKftTCt1ljNF9992ndevWaebMmSpdunSunlesWDE1atTIZVqtWrVcsrpq1SpVr149y7h+/frJGOPc92bq1KmTQkNDs329Dh06uDyuVq2aHA6H7rjjDue0zO/P7L4nM9dVbrdbALAaGlsALKdatWpq0KCBy0/9+vWzjKtYsaJuueUWnT9/Xr169crSKPn22291++23S5KmTJmib775RklJSXr66aclSefOnXMZHxcX5/I4LCzsitPPnz/vMj0kJESFChVymVasWDFJ0rFjx3J8v//3f/+nbdu2KTQ01OUnJiZGxhjndYKaN2+uRYsWKS0tTX369FGpUqVUo0YNzZ07N8dlZ752SEhIlosWOxwOFStW7Iq1XalmSbrnnnuy1P3iiy/KGKPjx487x4eHh6tnz546f/686tSpo9atW2e73Mz1ld20K9X5xBNPaNSoUercubM+++wzbdq0SUlJSapdu3aWz1lSls8p8wK+mWMzMjJ0++2365NPPtGTTz6plStX6ttvv3X+wZbdMnPj2LFjKlasWJZr+xQtWlQhISFZ3uPldWbWeunrf/TRR+rbt6+mTp2qJk2aKC4uTn369NGRI0fcqu3PP/+UpCteQD2zvuyakiVKlMhSf1RUVJY/kMPCwrJkKnP65ZmSct4mMl8rL59Vbu5KV6FCBX311VcqWrSoBg0apAoVKqhChQou1wcK5M8zsz4p588rIyNDJ06ccJme2zv2xcXFqVOnTpo5c6bS09MlXbyGVKNGjVzuOuduNnPz+nl5X1dzrd+vOX33X0n+/Pm1du1a1alTR0899ZRuvPFGlShRQqNHj85VQ3PSpEkaOHCgGjdurIULF2rjxo1KSkpS27Zt8/S9l9vvgLS0NL3++utZvvszm9iZ+6yRI0dq4sSJ2rhxo+644w4VKlRIrVq1ynKNystl1pNTcy23jDG6//77NXv2bM2YMUN33nlnrp+bm6weO3Ysx20wc/6lrrRtZ/d7Rk7fn9l9T2aOy+u+CQACHXdFBGBbU6dO1dKlS9WoUSO98cYb6tatmxo3buycP2/ePIWGhmrJkiUuvxwuWrTIK/WkpaXp2LFjLr8QZ/4xmt0vyZkKFy6syMhIvf/++znOz3TnnXfqzjvv1IULF7Rx40aNHz9ePXv2VNmyZdWkSZNsn1+oUCGlpaXpzz//dGluGWN05MgR55EK7sis6fXXX8/xbmU33HCD8987duzQs88+q4YNGyopKUmTJk3SE088keU52f3xnpt1OHv2bPXp00fjxo1zmf7XX3+pQIECV30/l9uxY4d++OEHzZgxQ3379nVO//XXX91e1qUKFSqkTZs2yRjj0gw5evSo0tLSXD7r3CpcuLBee+01vfbaazpw4IAWL16sf/3rXzp69KiWLVuW6+Vkbhu///57jkc1ZH4Ghw8fzjLv0KFDear/anLaJipWrCgpb5/V5Y2onNxyyy265ZZblJ6ers2bN+v111/XkCFDdMMNN6h79+4B/XlKV/+8goKCVLBgQZfpuV03ktS/f3/Nnz9fK1asUJkyZZSUlKS3337bZYy72czN67vzviIiIrJcyD/z9S93Ld+vOX33X03NmjU1b948GWO0bds2zZgxQ88995wiIyP1r3/964rPnT17tlq0aJFlnZ8+fTpXr325S78DclKwYEEFBwerd+/eOR7dWa5cOUkX/7PniSee0BNPPKGTJ0/qq6++0lNPPaU2bdro4MGDOd5xMzM3l/7niLsym1rTp0/XtGnTdO+99+Z5WTkpVKhQjtugpCz5dydb7spcV974DgaAQMARWwBsafv27Xr00UfVp08frVu3TrVq1VK3bt1c/pfe4XAoJCTE5dSLc+fOadasWV6r68MPP3R5nHmr8svvjHepDh06aM+ePSpUqFCWI9UaNGiQ7R29wsPDlZCQoBdffFHSxTtr5aRVq1aSLv4RdKmFCxcqJSXFOd8dzZo1U4ECBbRz585sa27QoIHzyLaUlBR17dpVZcuW1erVqzV48GD961//ynJ6qST9+OOP+uGHH1ymzZkzRzExMapXr16O9Tgcjiy3TV+6dGmeT8vI/APk8mW+++67WcZeftTDlbRq1UpnzpzJ0lydOXOmc/61KFOmjAYPHqzWrVtf8dTN7Nx+++0KDg7O8kfypZo0aaLIyMgs29Lvv/+uVatWXXP92bk8U+vXr9f+/fudmXLns8qr4OBgNW7c2HnXt8x1G8ifpyRVqVJFJUuW1Jw5c1zuBJuSkqKFCxc67yiYV7fffrtKliyp6dOna/r06YqIiFCPHj1cxng6m5J776ts2bI6evSo8yhTSfr777/15Zdf5rh8d75fW7ZsKSnn7/7ccjgcql27tl599VUVKFDA5fO+/EihS59z+brdtm1bljtD5lblypVVoUIFvf/++9k2A6WLR2G2bNlS33//vWrVqpXtd392/wlRoEAB3XPPPRo0aJCOHz/ucmfIy2We7r9nz548vQ9jjB544AFNnz5d7777rsupsZ7UqlUr7dy5M0s2Z86cKYfD4dw2fOG3335TUFBQnu4iCQBWwBFbACxnx44dSktLyzK9QoUKKlKkiFJSUvSPf/xD5cqV01tvvaWwsDB9/PHHqlevnvr37+/8I7N9+/aaNGmSevbsqQcffFDHjh3TxIkTs/wh4ClhYWF65ZVXdObMGTVs2FDr16/X888/rzvuuEM333xzjs8bMmSIFi5cqObNm+vxxx9XrVq1lJGRoQMHDmj58uUaOnSoGjdurGeffVa///67WrVqpVKlSunkyZOaPHmyQkNDlZCQkOPyW7durTZt2mjEiBFKTk5Ws2bNtG3bNo0ePVp169ZV79693X6v0dHRev3119W3b18dP35c99xzj4oWLao///xTP/zwg/78809ng+Thhx/WgQMH9O233ypfvnx65ZVXtGHDBnXv3l3ff/+9y1EbJUqUUKdOnZSYmKjixYtr9uzZWrFihV588cUr/gHeoUMHzZgxQ1WrVlWtWrX03Xff6eWXX77iKTVXUrVqVVWoUEH/+te/ZIxRXFycPvvsM61YsSLL2Jo1a0qSJk+erL59+yo0NFRVqlRxuZZSpj59+ujNN99U3759tW/fPtWsWVNff/21xo0bp3bt2um2225zq85Tp06pZcuW6tmzp6pWraqYmBglJSVp2bJluuuuu9xaVtmyZfXUU09p7NixOnfunHr06KH8+fNr586d+uuvvzRmzBgVKFBAo0aN0lNPPaU+ffqoR48eOnbsmMaMGaOIiAiNHj3ardfMjc2bN+v+++9X165ddfDgQT399NMqWbKkHnnkEUnufVbueOedd7Rq1Sq1b99eZcqU0fnz551HVWZ+ToH8eUpSUFCQXnrpJfXq1UsdOnTQQw89pAsXLujll1/WyZMnNWHCBLeXeang4GD16dNHkyZNUmxsrO666y7lz5/fZYyns+nu++rWrZueffZZde/eXcOHD9f58+f173//23n6ZKa8fr/efvvtat68uZ588kmlpKSoQYMG+uabb3L1HyhLlizRW2+9pc6dO6t8+fIyxuiTTz7RyZMnXU7XrlmzptasWaPPPvtMxYsXV0xMjKpUqaIOHTpo7NixGj16tBISErR7924999xzKleuXLb70Nx488031bFjR9100016/PHHVaZMGR04cEBffvmls3k3efJk3Xzzzbrllls0cOBAlS1bVqdPn9avv/6qzz77zHltqY4dO6pGjRpq0KCBihQpov379+u1115TfHy8KlWqlGMNpUqVUvny5bVx40Y9+uijWeYnJydrwYIFWaYXKVJECQkJevTRRzVt2jQNGDBANWvWdJ6WLF1sEl56fb9r8fjjj2vmzJlq3769nnvuOcXHx2vp0qV66623NHDgQFWuXNkjr5MbGzduVJ06dbIcgQkAtuHzy9UDQB5d6a6IksyUKVOMMcbce++9JioqynnL80zz5883ksyrr77qnPb++++bKlWqmPDwcFO+fHkzfvx4M23atCx3sYuPjzft27fPUpMkM2jQIJdpmXc4evnll53TMu8muG3bNtOiRQsTGRlp4uLizMCBA82ZM2dcnn/5XRGNuXjb92eeecZUqVLFhIWFOW+l/vjjj5sjR44YY4xZsmSJueOOO0zJkiVNWFiYKVq0qGnXrp3Lre1zcu7cOTNixAgTHx9vQkNDTfHixc3AgQPNiRMnXMbl9q6ImdauXWvat29v4uLiTGhoqClZsqRp3769885smXdquvwOhr/++quJjY01nTt3dlkv7du3NwsWLDA33nijCQsLM2XLljWTJk1yeW52d0U8ceKEue+++0zRokVNVFSUufnmm826deuy3JUwuzvH5bTMnTt3mtatW5uYmBhTsGBB07VrV3PgwIEsdzozxpiRI0eaEiVKmKCgIJe7t13++sZcvAPgww8/bIoXL25CQkJMfHy8GTlypDl//rzLuOy2vcz1lLn9nD9/3jz88MOmVq1aJjY21kRGRpoqVaqY0aNHu9zJ0x0zZ840DRs2NBERESY6OtrUrVs3y+c3depUU6tWLee2euedd2bJY07bUk53Nbs8g5nfB8uXLze9e/c2BQoUcN6R8ZdffnF5bm4/q8w7kP35559ZXv/yu+Rt2LDBdOnSxcTHx5vw8HBTqFAhk5CQ4HI3VGMC5/PMads25uKdXBs3bmwiIiJMvnz5TKtWrcw333yT7fvPbt1cyc8//+z8jl6xYkWW+deazUvnZebKnfdljDGff/65qVOnjomMjDTly5c3b7zxRpbP+1q+X0+ePGkGDBhgChQoYKKiokzr1q3NTz/9dNW7Iv7000+mR48epkKFCiYyMtLkz5/fNGrUyMyYMcNl+Vu3bjXNmjUzUVFRRpJzvV24cMEMGzbMlCxZ0kRERJh69eqZRYsWZbkTZHb7rEzZfZ9t2LDB3HHHHSZ//vwmPDzcVKhQweUOlpnLHDBggClZsqQJDQ01RYoUMU2bNnW5W+krr7ximjZtagoXLmzCwsJMmTJlzH333Wf27dt31XU6atQoU7BgwSw5yrxjYXY/meslPj4+xzHZ3SHzcjl9R2V3h839+/ebnj17mkKFCpnQ0FBTpUoV8/LLL7vcrfNK6z+n3Lnz/Xn69GkTFRWV5c6KAGAnDmMuOUYbAOAV/fr104IFC3TmzBl/l2JZZcuWVY0aNbRkyRJ/l4IAMGPGDPXv319JSUlq0KCBv8sB4EOHDh1SuXLlNHPmTHXr1s3f5QS0adOm6bHHHtPBgwc5YguAbXGNLQAAAACWUaJECQ0ZMkQvvPCCMjIy/F1OwEpLS9OLL76okSNH0tQCYGtcYwsAAACApTzzzDOKiorSH3/8keOdWq93Bw8e1L333quhQ4f6uxQA8CpORQQAAAAAAIAlcSoiAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGloXNmDFDDodDmzdvvurYfv36qWzZsnl+rZkzZ6p79+6qUqWKgoKCrmlZwPUikDP69ddfq127dipYsKAiIyNVqVIljR071mWMw+HI8adq1ap5rhWwIvIMXH8COfcAfJvR+++/XzVq1FCBAgUUGRmpypUra/jw4frrr7+yjD1z5oyGDBmiEiVKKCIiQnXq1NG8efOyjGPf7Dkh/i4A1jBr1iwdOXJEjRo1UkZGhlJTU/1dEoBLuJPROXPmqHfv3vrHP/6hmTNnKjo6Wnv27NGhQ4dcxm3YsCHLczdt2qQhQ4aoS5cuHn8PAC4iz8D1h9+1gcCWkpKiBx98UBUrVlRERIQ2b96sF154QZ9//rm+//57hYWFOcfeddddSkpK0oQJE1S5cmXNmTNHPXr0UEZGhnr27Okcx77Zc2hsIVe+/PJLBQVdPMCvQ4cO2rFjh58rAnCp3Gb0jz/+0IMPPqiHHnpIb731lnN6y5Yts4y96aabskx799135XA4dN9993mocgCXI8/A9YfftYHANnfuXJfHt956q2JiYvTII4/o66+/1q233ipJ+vzzz7VixQpnM0u6uF/ev3+/hg8frm7duik4OFgS+2ZP4lREG5oxY4aqVKmi8PBwVatWTTNnzrzmZWbuaAFcO39mdOrUqUpJSdGIESPcfo3Tp09r/vz5SkhIUMWKFd1+PmBH5Bm4/vC7NhDYvJHR7BQpUkSSFBLyv+OFPv30U0VHR6tr164uY/v3769Dhw5p06ZNOS6PfXPe8Q1qMzNmzFD//v1VrVo1LVy4UM8884zGjh2rVatWZRnbr18/ORwO7du3z/eFAtcpf2f0v//9r+Li4vTTTz+pTp06CgkJUdGiRfXwww8rOTn5is+dN2+eUlJSdP/993usHsDKyDNw/fF37gFcmbczmpaWppSUFH3zzTcaNWqUbr75ZjVr1sw5f8eOHapWrZpLs0uSatWq5ZyfE/bNecepiDaSkZGhp59+WvXq1dOnn34qh8MhSbr55ptVqVIllShRwmV8cHCwgoODneMAeFcgZPSPP/7Q2bNn1bVrV40cOVKvvfaakpKSNHr0aO3YsUPr1q3L8fWmTZumAgUK6O677/ZYPYBVkWfg+hMIuQeQM29ndOPGjWrSpInzcbt27TRv3jznqYWSdOzYMZUvXz7Lc+Pi4pzzc8K+Oe84YstGdu/erUOHDqlnz54u4YyPj1fTpk2zjJ82bZrS0tIUHx/vyzKB61YgZDQjI0Pnz5/XU089pZEjR6pFixYaPny4xo8fr2+++UYrV67M9nk//vijNm3apF69eikiIsJj9QBWRZ6B608g5B5Azryd0Zo1ayopKUlr167V5MmT9f3336t169Y6e/asy7grNcpymse++drQ2LKRzO5vsWLFsszLbhoA3wqEjBYqVEiS1KZNG5fpd9xxhyRpy5Yt2T5v2rRpksSh0cD/R56B608g5B5Azryd0Xz58qlBgwZq3ry5Hn30UX366afatGmT3n33XeeYQoUKZXtU1vHjxyX978ity7FvvjY0tmwk8xfcI0eOZJmX3TQAvhUIGc08v/9yxhhJ2V+89u+//9asWbNUv3591alTx5vlAZZBnoHrTyDkHkDOfJ3RBg0aKCgoSD///LNzWs2aNbVr1y6lpaW5jN2+fbskqUaNGlmWw7752tHYspEqVaqoePHimjt3rvOXWknav3+/1q9f78fKAEiBkdHMc/a/+OILl+mff/65pOxvO7x48WL99ddf3HYYuAR5Bq4/gZB7ADnzdUbXrl2rjIwMlzsYdunSRWfOnNHChQtdxn7wwQcqUaKEGjdunGU57JuvHRePt5GgoCCNHTtW999/v7p06aIHHnhAJ0+eVGJiYraHXt5333364IMPtGfPnqueV7xz507t3LlT0sVu99mzZ7VgwQJJUvXq1VW9enXPvyHAZgIho7fffrs6duyo5557ThkZGbrpppu0efNmjRkzRh06dNDNN9+cZdnTpk1TZGSkevbsea2rALAN8gxcfwIh9wBy5q2MLlmyRFOmTFGnTp0UHx+v1NRUbd68Wa+99poqVqzocvrgHXfcodatW2vgwIFKTk5WxYoVNXfuXC1btkyzZ892udB8JvbNHmBgWdOnTzeSTFJSksv0qVOnmkqVKpmwsDBTuXJl8/7775u+ffua+Ph4l3F9+/Y1kszevXuv+lqjR482krL9GT16tOfeFGAjgZrRs2fPmhEjRpjSpUubkJAQU6ZMGTNy5Ehz/vz5LMs9cOCACQoKMn369HH37QO2Qp6B60+g5h7ARb7K6K5du8w999xj4uPjTUREhImIiDBVq1Y1w4cPN8eOHcsy/vTp0+bRRx81xYoVM2FhYaZWrVpm7ty52S6bfbNnOIy55Bg9AAAAAAAAwCK4xhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxpafZGRkKDo6WkOHDvV3KVd15swZDRkyRCVKlFBERITq1KmjefPm5eq5W7duVfv27VWmTBlFRkYqLi5OTZo00ezZs7OMXbNmjRwOR7Y/Gzdu9PTbAjyCLGfNsiR9++23atOmjWJiYhQdHa2WLVvqm2++8eTbATzuesnz5aZOnSqHw6Ho6GiPjgX8iTxnn1H2z7AaskyWcyPE3wVcr3788UelpKSoYcOG/i7lqu666y4lJSVpwoQJqly5subMmaMePXooIyNDPXv2vOJzT548qdKlS6tHjx4qWbKkUlJS9OGHH6p3797at2+fnnnmmSzPGTdunFq2bOkyrUaNGh59T4CnkOWsWU5KSlLz5s3VqFEjzZo1S8YYvfTSS2rVqpVWr16tJk2aePutAnlyveT5Un/88YeGDRumEiVK6NSpUx4bC/gbec6aUfbPsCKyTJZzxcAvpk6daiSZX3/91d+lXNHSpUuNJDNnzhyX6a1btzYlSpQwaWlpeVpu48aNTenSpV2mrV692kgy8+fPz3O9gK+R5axZbtOmjbnhhhtMSkqKc1pycrIpXLiwadq0aZ5eB/CF6zHPHTp0MB07djR9+/Y1+fLl89hYwN/Ic9aMsn+GFZFlspwbnIroA1OmTFHNmjUVERGhGjVq6Msvv9S3336rggULqkKFCv4u74o+/fRTRUdHq2vXri7T+/fvr0OHDmnTpk15Wm7hwoUVEsIBg7AWspxVdln+5ptv1KJFC0VFRTmnxcTEqHnz5lq/fr0OHz6cp9cCPIk8S7Nnz9batWv11ltveXQs4GvkOXcZZf+MQEeWyXJe0VnwsiFDhujdd9/VsGHDdOutt+qnn35S3759FRYWpgYNGnjlNY0xSk9Pz9XYqzWXduzYoWrVqmUZV6tWLef8pk2bXvV1MjIylJGRoRMnTmj+/Pn68ssv9cYbb2Q7dtCgQerevbuioqLUpEkTjRo1SjfffHOu3g/gLWT5otxk+e+//1Z4eHiW52ZO2759u4oXL37V1wK8hTxLR48e1ZAhQzRhwgSVKlXKY2MBXyPPuc8o+2cEMrJMlq+JX48Xs7kFCxYYSWbevHku08eNG2ckmaeeesoYY8wvv/xigoODzblz51zGnT9/3vTr18+UKlXKxMTEmMaNG5tvvvnmqq+beUpfbn727t17xWVVqlTJtGnTJsv0Q4cOGUlm3LhxV63HGGMeeugh52uGhYWZt956K8uYLVu2mMcee8x8+umn5r///a95//33TbVq1UxwcLBZtmxZrl4H8Aay/D+5yXKdOnVM5cqVTXp6unNaamqqKV++fLaHaAO+RJ4vuvvuu03Tpk1NRkaGMcZc8fRCd8YCvkSeL8ptRtk/I1CR5YvIct5xxJYXjR07Vg0bNlS3bt1cplevXl2SnJ3nbdu2qUqVKoqIiHAZl5aWpnLlyumbb75RqVKlNGvWLHXq1EkHDhxwOezwcvXr11dSUlKuaixRosRVxzgcjjzNu9RTTz2l+++/X0ePHtVnn32mwYMHKyUlRcOGDXOOqVu3rurWret8fMstt6hLly6qWbOmnnzySbVp0yZXrwV4Gln+n9xk+Z///Kfuu+8+DR48WE8//bQyMjI0ZswY7d+/X5IUFMRZ8PAf8iwtXLhQn332mb7//nuPjgV8jTy7l1H2zwhUZJksXzN/d9bs6vDhw0aSefXVV7PMe+ONN4wkc/DgQWOMMc8++6zp0aNHrpZbsGBBs3Xr1iuOycjIMKmpqbn6uZqbbrrJNGzYMMv0HTt2GEnm3XffzVXdl3v44YdNSEiIOXr0aK7GSjJnz57N02sB14IsX1lOWZ4wYYKJjo52/i9XkyZNzIgRI4wks27dujy9FnCtyLMxp0+fNjfccIMZOnSoOXHihPOnR48eJl++fObEiRPmzJkzbo8FfI085y2j7J8RaMgyWfaE67CV5xu///67JGV7buucOXNUrFgx53mzP/zwg/Pc2yv56aefdO7cuateOG/t2rUKDQ3N1c++ffuuuKyaNWtq165dSktLc5m+fft2SVKNGjWuWnd2GjVqpLS0NP32229XHWuMkZT7I0oATyLLV5ZTlkeMGKG//vpL27dv1759+7R+/XqdOHFC+fLlU/369fP0WsC1Is/SX3/9pf/7v//TK6+8ooIFCzp/5s6dq5SUFBUsWFC9evVyeyzga+Q5bxll/4xAQ5bJsidwKqKXFClSRNLFi8RdekjlggULtH79enXo0ME5bdu2bXrooYeuuLyzZ8+qd+/eeuaZZxQdHX3FsZ48pLJLly6aMmWKFi5c6PI+PvjgA5UoUUKNGzfO1etcbvXq1QoKClL58uWvOO7EiRNasmSJ6tSpk+WQU8AXyPKVXSnL4eHhzp34gQMH9NFHH+mBBx5QZGRknl4LuFbkWSpWrJhWr16dZfqECRO0du1affHFFypcuLDbYwFfI895zyj7ZwQSskyWPcLfh4zZVUZGhmnYsKHJly+fmTx5slm9erUZM2aMiYuLM5LMmDFjjDHGnDp1yjgcDvPHH3/kuKy///7btG/f3vTp08d5ITlfat26tSlYsKB57733zKpVq8wDDzxgJJnZs2e7jFuzZo0JDg52vjdjjHnggQfM0KFDzUcffWTWrFljFixYYLp162YkmeHDh7s8v0ePHmbEiBFm/vz5ZvXq1ea9994zVapUMSEhIWbFihU+ea/A5cjyRe5kefv27SYxMdEsWbLErFixwkycONEULlzYNGjQwJw+fdon7xXIDnnOmTsXhOfi8QgE5DlnOWWU/TMCEVnOGVnOPRpbXrR3717Ttm1bEx0dbQoUKGA6duxopk2bZiSZpUuXGmOMWbdunSlUqFCOy0hPTzfdu3c3nTp1ytW5vd5w+vRp8+ijj5pixYqZsLAwU6tWLTN37tws4zLvKjF69GjntPfff9/ccsstpnDhwiYkJMQUKFDAJCQkmFmzZmV5/vjx402dOnVM/vz5TXBwsClSpIjp0qWL+fbbb7359oCrIsvuZXn37t2mefPmJi4uzoSFhZmKFSuaZ555hmvxICCQ5+zR2IIVkefs5ZRR9s8IVGQ5e2Q59xzG/P8LGMEv3nrrLX388cdatmyZc1pQUJDCwsIkSQ888IB++eUXLVu2jFPxgABGlgH7IM+AfZBnwB7IMq6Ei8f72Q8//KC1a9cqMjLS+XP33XdLkvbv36+pU6dq06ZNKly4sKKjoxUdHa1169b5uWoAlyPLgH2QZ8A+yDNgD2QZV8IRWwAAAAAAALAkjtgCAAAAAACAJdHYAgAAAAAAgCXR2AIAAAAAAIAl0dgCAAAAAACAJdHYAgAAAAAAgCWF+LsAScrIyNChQ4cUExMjh8Ph73IArzLG6PTp0ypRooSCguzXWybPuJ6QZ8Ae7J5liTzj+mH3PJNlXE9ym+eAaGwdOnRIpUuX9ncZgE8dPHhQpUqV8ncZHkeecT0iz4A92DXLEnnG9ceueSbLuB5dLc8B0diKiYmRJP388y7nv5G9qKgYnT172t9lWE4grbfTp0+rcuVqtt3WybN7AmnbtIJAW1/kGXkVaNvy9c7uWZbIszeQ44sCbT3YPc9k2XcCbdsOJL5aN7nNc0A0tjIPoYyJiVFsbKyfqwlsUVExCgnhkFN3BeJ6s+uhw+TZPYG4bQayQF1f5BnuCtRt+Xpn1yxL5NkbyPFFgboe7Jpnsuw7gbptBwJfr5ur5dl+Jx0DAAAAAADgukBjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWFOLvAtwR9Z94f5fgXyExUtf9eXpq4qwkDxdjHeGhwRo7IMHfZeAy132eJTLtJrIcuMizm64h+5mux+8Ar0o77+8KAgJZdsP/z/H4eVt0ITXd39X4DfvmwEWerxEZz1Eg5p4jtgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEkh/i7AHWfv3O/vEvwuKo/PS+zd0KN1ANeKPF9EpmEH5Nl9ec1+Jr4DPCs5OVkvD/Z3Ff5Hlt0TJWlk93r+LgPIFnm+dmTcOjhiCwAAAAAAAJZkqSO2rCTqP/GeX2hIjNSVznumxFlJuRoXHhqssQMSvFwN7I5Me0ducyyRZfiGV7J+ObIPwCbGz9vCvhm4zgRi7jliCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlhTi7wLs6uyd+72y3CivLNWaEns39HcJuI6Qae8gxwg03sr65a737AOwh5Hd6/m7BAA+Foi554gtAAAAAAAAWBJHbPlY1H/i8/7kkBipq2/+J9lKEmclXXF+eGiwxg5I8FE1uJ5cU54lMn0ZsoxAds15vxTZBwAA8BiO2AIAAAAAAIAl0dgCAAAAAACAJdHYAgAAAAAAgCXR2AIAAAAAAIAl0dgCAAAAAACAJdHYAgAAAAAAgCXR2AIAAAAAAIAl0dgCAAAAAACAJdHYAgAAAAAAgCWF+LuA683ZO/df0/OjPFSHnST2bujvEnCdutY8S2T6UmQZgcwTeb8U2QcAAPAMjtgCAAAAAACAJdHYspCopTX8XYIljZ+3xd8lAFlE/SeeTOfR+HlblDgryd9lAHlC9gHYCb9nA9evQMo/jS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFhSiL8LQO6dbb9DUf4uwoJGdq/n7xKALM7euV+SyHQekGlYGdkHYCfsk4HrVyDlnyO2AAAAAAAAYEk0tgAAAAAAAGBJNLYsJGppDX+XYGnj523xdwmACzKdN+PnbVHirKQsP4BVkH0AdsHv18D1K5DyT2MLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJYU4u8CkHtn2+9QlL+LsLCR3ev5uwTABZnOG7IMqyP7AOyCfTJw/Qqk/HPEFgAAAAAAACyJxhYAAAAAAAAsiVMRcd0YP2+LLqSmOx8n9m7ox2oAKWppDanrfn+XYTlkGVZH9gHYQeKsJIWHBmvsgAR/lwLABxJnJUlSQOaeI7YAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEkh/i4A8JWR3ev5uwTAxdn2OxTl7yIsiCzD6sg+ADtI7N3Q3yUA8KFAzjxHbAEAAAAAAMCSaGwBAAAAAADAkjgVEQAAAACQZ+PnbdGF1PSAPlUJwLVJnJUkSQoPDdbYAQl+rsaV20dsffDBB1q6dKnz8ZNPPqkCBQqoadOm2r9/v0eLA+Bd5BmwB7IM2Ad5BuyDPAO+4XZja9y4cYqMjJQkbdiwQW+88YZeeuklFS5cWI8//rjHCwTgPeQZsAeyDNgHeQbsgzwDvuH2qYgHDx5UxYoVJUmLFi3SPffcowcffFDNmjVTixYtPF0fAC8iz4A9kGXAPsgzYB/kGfANt4/Yio6O1rFjxyRJy5cv12233SZJioiI0Llz5zxbHQCvIs+APZBlwD7IM2Af5BnwDbeP2GrdurXuv/9+1a1bVz///LPat28vSfrxxx9VtmxZT9cHwIvIM2APZBmwD/IM2Ad5BnzD7SO23nzzTTVp0kR//vmnFi5cqEKFCkmSvvvuO/Xo0cPjBQLwHvIM2ANZBuyDPAP2QZ4B33AYY4y/i0hOTlb+/Pl1+PDvio2N9Xc5AS0qKkZnz572dxmWE0jrLTk5WcWLl9KpU6dsub2TZ/cE0rZpBYG2vsgz8irQtuXrnd2zLJFnbyDHF0VFxWjU+2t1ITVdib0b+rsc2+eZLPsOGXeVOCtJkhQeGqyxAxJ8sm5ym2e3j9iSpHXr1unee+9V06ZN9ccff0iSZs2apa+//jpv1QLwG/IM2ANZBuyDPAP2QZ4B73O7sbVw4UK1adNGkZGR2rJliy5cuCBJOn36tMaNG+fxAgF4D3kG7IEsA/ZBnmFFI7vXC4ijtQINeYadJPZuqMTeDTWyez1/l5KF242t559/Xu+8846mTJmi0NBQ5/SmTZtqy5YtHi0OgHeRZ8AeyDJgH+QZsA/yDPiG242t3bt3q3nz5lmmx8bG6uTJk56oCYCPkGfAHsgyYB/kGbAP8gz4Roi7TyhevLh+/fXXLLcn/frrr1W+fHlP1QXkWeZF7TJlXtwOWZFnWEXirCSyfAVkGbAP8gwruPwi0sgeeYadBHLu3T5i66GHHtJjjz2mTZs2yeFw6NChQ/rwww81bNgwPfLII96oEYCXkGfAHsgyYB/kGbAP8gz4httHbD355JM6deqUWrZsqfPnz6t58+YKDw/XsGHDNHjwYG/UCMBLyDNgD2QZsA/yDNgHeQZ8w63GVnp6ur7++msNHTpUTz/9tHbu3KmMjAxVr15d0dHR3qoRgBeQZ8AeyDJgH+QZsA/yDPiOW42t4OBgtWnTRrt27VJcXJwaNGjgrboAeBl5BuyBLAP2QZ4B+yDPgO+4fY2tmjVr6rfffvNGLQB8jDwD9kCWAfsgz4B9kGfAN9xubL3wwgsaNmyYlixZosOHDys5OdnlB4B1kGfAHsgyYB/kGbAP8gz4htsXj2/btq0kqVOnTnI4HM7pxhg5HA6lp6d7rjoAXkWeAXsgy4B9kGfAPsgz4BtuN7ZWr17tjToA+AF5BuyBLAP2QZ4B+yDPgG+43dhKSEjwRh2AxyT2bujvEiyDPMMqyPWVkWXAPsgzrID9cu6QZ9hJIOfe7cbWf//73yvOb968eZ6LAeBb5BmwB7IM2Ad5BuyDPAO+4XZjq0WLFlmmXXq+MOcJA9ZBngF7IMuAfZBnwD7IM+Abbje2Tpw44fI4NTVV33//vUaNGqUXXnjBY4UB1yJxVpLz3+GhwRo7gMOAs0OeAXsgy4B9kGcEOn7Pzj3yDLsI9Ny73djKnz9/lmmtW7dWeHi4Hn/8cX333XceKQyA95FnwB7IMmAf5BmwD/IM+EaQpxZUpEgR7d6921OLA+BH5BmwB7IM2Ad5BuyDPAOe5fYRW9u2bXN5bIzR4cOHNWHCBNWuXdtjhQHwPvIM2ANZBuyDPAP2QZ4B33C7sVWnTh05HA4ZY1ym33TTTXr//fc9VhgA7yPPgD2QZcA+yDNgH+QZ8A23G1t79+51eRwUFKQiRYooIiLCY0UB8A3yDNgDWQbsgzwD9kGeAd9w+xpba9euVbFixRQfH6/4+HiVLl1aERER+vvvvzVz5kxv1AjAS8gzYA9kGbAP8gzYB3kGfMPtxlb//v116tSpLNNPnz6t/v37e6QoAL5BngF7IMuAfZBnwD7IM+Abbje2jDFyOBxZpv/+++/Z3s4UQOAiz4A9kGXAPsgzYB/kGfCNXF9jq27dunI4HHI4HGrVqpVCQv731PT0dO3du1dt27b1SpGAuxJ7N/R3CQGNPAP2QJYB+yDPsAp+z7468gy7CfTc57qx1blzZ0nS1q1b1aZNG0VHRzvnhYWFqWzZsrr77rs9XiAAzyPPgD2QZcA+yDNgH+QZ8K1cN7ZGjx4tSSpbtqy6devGnRwACyPPgD2QZcA+yDNgH+QZ8K1cN7Yy9e3b1xt1AB6VOCvJ+e/w0GCNHZDgx2oCF3mGFY2ft0Uju9fzdxkBhSwD9kGeAfsgz4BvuN3YSk9P16uvvqqPP/5YBw4c0N9//+0y//jx4x4rDoB3kWfAHsgyYB/kGbAP8gz4htt3RRwzZowmTZqkf/zjHzp16pSeeOIJ3XXXXQoKClJiYqIXSgTgLeQZsAeyDNgHeQbsgzwDvuF2Y+vDDz/UlClTNGzYMIWEhKhHjx6aOnWqnn32WW3cuNEbNQLwEvIM2ANZBuyDPAP2QZ4B33C7sXXkyBHVrFlTkhQdHa1Tp05Jkjp06KClS5d6tjoAXkWeAXsgy4B9kGfAPsgz4BtuN7ZKlSqlw4cPS5IqVqyo5cuXS5KSkpIUHh7u2eoAeBV5BuyBLAP2QZ4B+yDPgG+43djq0qWLVq5cKUl67LHHNGrUKFWqVEl9+vTRgAEDPF4gAO8hz4A9kGXAPsgzYB/kGfANt++KOGHCBOe/77nnHpUqVUrr169XxYoV1alTJ48WB8C7yDNgD2QZsA/yDNgHeQZ8w+3G1uVuuukm3XTTTZ6oBYCfkWfAHsgyYB/kGbAP8gx4h9unIkrSrFmz1KxZM5UoUUL79++XJL322mv6z3/+49HigLxK7N3Q+TOyez1/lxPQyDOshkxnjywD9kGeAfsgz4D3ud3Yevvtt/XEE0+oXbt2OnnypNLT0yVJBQoU0Guvvebp+gB4EXkG7IEsA/ZBngH7IM+Ab7jd2Hr99dc1ZcoUPf300woODnZOb9CggbZv3+7R4gB4F3kG7IEsA/ZBngH7IM+Ab7h9ja29e/eqbt26WaaHh4crJSXFI0UBnpA4K0mSFB4arLEDEvxcTWAiz7Ci8fO26ELqxf/xTOzd0M/VBAayDNgHeYYVsW/OHnmGnQVS7t0+YqtcuXLaunVrlulffPGFqlev7omaAPgIeQbsgSwD9kGeAfsgz4BvuH3E1vDhwzVo0CCdP39exhh9++23mjt3rsaPH6+pU6d6o0YAXkKeAXsgy4B9kGfAPsgz4BtuN7b69++vtLQ0Pfnkkzp79qx69uypkiVLavLkyerevbs3agTgJeQZsAeyDNgHeQbsgzwDvpGrUxEXL16s1NRU5+MHHnhA+/fv19GjR3XkyBEdPHhQ9913n9eKBOA55BmwB7IM2Ad5BuyDPAO+l6vGVpcuXXTy5ElJUnBwsI4ePSpJKly4sIoWLeq14gB4HnkG7IEsA/ZBngH7IM+A7+WqsVWkSBFt3LhRkmSMkcPh8GpRALyHPAP2QJYB+yDPgH2QZ8D3cnWNrYcfflh33nmnHA6HHA6HihUrluPY9PR0jxUHwPPIM2APZBmwD/IM2Ad5BnwvV42txMREde/eXb/++qs6deqk6dOnq0CBAl4uDYA3kGfAHsgyYB/kGbAP8gz4Xq7vili1alVVrVpVo0ePVteuXRUVFeXNugB4EXkG7IEsA/ZBngH7IM+AbzmMMcbfRSQnJyt//vw6fPh3xcbG+rucgBYVFaOzZ0/7uwzLCaT1lpycrOLFS+nUqVO23N7Js3sCadu0gkBbX+QZeRVo2/L1zu5ZlsizN5DjiwJtPdg9z2TZdwJt2w4kvlo3uc1zri4eDwAAAAAAAASaXJ+KCFjV+HlbNHZAgr/LAOAh4+dt0YXUdCX2bujvUgAAgP63b87EPhqwv0DKPUdsAQAAAAAAwJJobAEAAAAAAMCSPNbY+r//+z8999xznlocAD8iz4A9kGXAPsgzYB/kGfAsjzW2jhw5ojFjxnhqcQD8iDwD9kCWAfsgz4B9kGfAs3J98fht27Zdcf7u3buvuRgAvkGeAXsgy4B9kGfAPsgz4Fu5bmzVqVNHDodDxpgs8zKnOxwOjxYHwDvIM2APZBmwD/IM2Ad5Bnwr142tQoUK6cUXX1SrVq2ynf/jjz+qY8eOHisMgPeQZ8AeyDJgH+QZsA/yDPhWrhtb9evX16FDhxQfH5/t/JMnT2bbkQYQeMgzYA9kGbAP8gzYB3kGfCvXja2HHnpIKSkpOc4vU6aMpk+f7pGiAHgXeQbsgSwD9kGeAfsgz4BvOUwAtIqTk5OVP39+HT78u2JjY/1dTkCLiorR2bOn/V2G5QTSektOTlbx4qV06tQpW27v5Nk9gbRtWkGgrS/yjLwKtG35emf3LEvk2RvI8UWBth7snmey7DuBtm0HEl+tm9zmOcjrlQAAAAAAAABekOtTESXp3Llz+u677xQXF6fq1au7zDt//rw+/vhj9enTx6MFAp4yft4WXUhNdz5O7N3Qj9X4H3mG1Yyft0VjByT4u4yAQ5YB+yDPCHSJs5JcHoeHBrNvzgF5ht1d/vd1Jn/8nZ3rI7Z+/vlnVatWTc2bN1fNmjXVokULHT582Dn/1KlT6t+/v1eKBOBZ5BmwB7IM2Ad5BuyDPAO+levG1ogRI1SzZk0dPXpUu3fvVmxsrJo1a6YDBw54sz4AXkCeAXsgy4B9kGfAPsgz4Fu5bmytX79e48aNU+HChVWxYkUtXrxYd9xxh2655Rb99ttv3qwRgIeRZ8AeyDJgH+QZsA/yDPhWrq+xde7cOYWEuA5/8803FRQUpISEBM2ZM8fjxQHwDvIM2ANZBuyDPAP2QZ4B38p1Y6tq1aravHmzqlWr5jL99ddflzFGnTp18nhxALyDPAP2QJYB+yDPgH2QZ8C3cn0qYpcuXTR37txs573xxhvq0aOHjDEeKwyA95BnwB7IMmAf5BmwD/IM+FauG1sjR47U559/nuP8t956SxkZGR4pCoB3kWfAHsgyYB/kGbAP8gz4Vq4bWwAAAAAAAEAgobEFAAAAAAAAS8r1xeMBqxvZvZ6/SwBwDcgwAAD+ldi7ob9LABAgAul3c47YAgAAAAAAgCVxxBZsb/y8LRo7IMHfZQDwkPHztuhCarrLNP4HGQAA/2HfDNhL4qykHOeFhwYH3N/XeWps7d69W6+//rp27dolh8OhqlWr6p///KeqVKni6foAeBl5BuyBLAP2QZ4B+yDPgPe5fSriggULVKNGDX333XeqXbu2atWqpS1btqhGjRqaP3++N2oE4CXkGbAHsgzYB3kG7IM8A77h9hFbTz75pEaOHKnnnnvOZfro0aM1YsQIde3a1WPFAfAu8gzYA1kG7IM8A/ZBngHfcPuIrSNHjqhPnz5Zpt977706cuSIR4oC4BvkGbAHsgzYB3kG7IM8A77hdmOrRYsWWrduXZbpX3/9tW655RaPFAXAN8gzYA9kGbAP8gzYB3kGfMPtUxE7deqkESNG6LvvvtNNN90kSdq4caPmz5+vMWPGaPHixS5jAQQu8gzYA1kG7IM8A/ZBngHfcBhjjDtPCArK3UFeDodD6enpVx8oKTk5Wfnz59fhw78rNjbWnXKuO1FRMTp79rS/y7CU8fO2aOyAhIBZb8nJySpevJROnTrl9+2dPPsfmXZPVFSMRr2/NmBuKR4oefZGliXy7E1kP7AESpYl8mwl5Pgi9s0543dta7ueM544KynHeeGhwT77+zq3eXb7iK2MjIxrKgxA4CDPgD2QZcA+yDNgH+QZ8A23r7EFAAAAAAAABAK3j9iSpLVr12rixInatWuXHA6HqlWrpuHDh3MBPASkkd3r+buEgEaeYTVkOntkGbAP8gyrYd+cM/IMK/LXqcR55fYRW7Nnz9Ztt92mqKgoPfrooxo8eLAiIyPVqlUrzZkzxxs1AvAS8gzYA1kG7IM8A/ZBngHfcPvi8dWqVdODDz6oxx9/3GX6pEmTNGXKFO3atcvtIrgAXu5dzxewuxaXX9TSnx3oQLqgJXn2PzKde4F2IwgpcPLsjSxL5NmbyH5gCZQsS+TZSsjxRVw8Pmf8rm1t12vGr3TheCkwLx7v9hFbv/32mzp27JhleqdOnbR37153FwfAj8gzYA9kGbAP8gzYB3kGfMPtxlbp0qW1cuXKLNNXrlyp0qVLe6QoAL5BngF7IMuAfZBnwD7IM+Abub54/IABAzR58mQNHTpUjz76qLZu3aqmTZvK4XDo66+/1owZMzR58mRv1grAQ8gzYA9kGbAP8gzYB3kGfCvXja0PPvhAEyZM0MCBA1WsWDG98sor+vjjjyVdPHf4o48+0p133um1QgF4DnkG7IEsA/ZBngH7IM+Ab+W6sXXpNea7dOmiLl26eKUgAN5HngF7IMuAfZBnwD7IM+Bbbl1jy+FweKsOAD5GngF7IMuAfZBnwD7IM+A7uT5iS5IqV6581YAeP378mgoC4BvkGbAHsgzYB3kG7IM8A77jVmNrzJgxyp8/v7dqAeBD5BmwB7IM2Ad5BuyDPAO+41Zjq3v37ipatKi3agHgQ+QZsAeyDNgHeQbsgzwDvpPrxhbnCMPqRnav5+8SAgZ5hhWR4azIMmAf5BlWxj7aFXmGlSX2bujvEtyW64vHX3pnBwDWRp4BeyDLgH2QZ8A+yDPgW7k+YisjI8ObdQBekTgrSeGhwRo7IMHfpQQU8gyrSJyV5Pw3Wc6KLAP2QZ5hZePnbdGF1PQs06145IcnkGdY1aW/e+ckEH8nz/URWwAAAAAAAEAgobEFAAAAAAAAS6KxBQAAAAAAAEuisQUAAAAAAABLorEFAAAAAAAAS6KxBQAAAAAAAEuisQUAAAAAAABLorEFAAAAAAAAS6KxBQAAAAAAAEsK8XcBgDcl9m7o7xIAXAMyDABA4BvZvZ6/SwDgAVb93ZsjtgAAAAAAAGBJHLEFALCU8fO26EJqumX/RwkAAKtInJV0xfnhocEaOyDBR9UA8JarZf1SgZh7jtgCAAAAAACAJdHYAgAAAAAAgCXR2AIAAAAAAIAl0dgCAAAAAACAJdHYAgAAAAAAgCXR2AIAAAAAAIAl0dgCAAAAAACAJdHYAgAAAAAAgCXR2AIAAAAAAIAlhfi7AAAA3DGyez1/lwAAwHUhsXdDf5cAwAesnnWO2AIAAAAAAIAlccSWBUUtraGz7Xf4uwwA8JnEWUkKDw3W2AEJ/i4FAADbS5yVlKtx7JuB69f4eVt0ITX9mpbhqSPFOGILAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWFOLvAuC+s+13+LsEAPCpxN4N/V0CAADXDfa7AK5mZPd6/i7BiSO2AAAAAAAAYEkcsWVBUUtrSGmnXaadvXO/n6qxjvHztuhCarrLNP43CoHg8kyT5yvLLss5IeMIZOzPAdiFO/tmT2D/DlxZ4qwkry07PDRYYwckeG35ecERWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsKQQfxcA951tv8PfJVjSyO71/F0CkC0y7R6yDLsg+wDsgn0zEFgSezf0dwk+xRFbAAAAAAAAsCSO2LKgqKU1pLTT2c47e+d+H1djHePnbdGF1PQs06+3bjYCT06ZJs/ZyynLlyPbCHRX2p9LfAcACEyJs5Kc/w4PDdbYAQl+rAaAv1z+O7k/f/fmiC0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFhSiL8LgPvOtt/h7xIsaWT3ev4uAcgWmXYPWYZdkH0AVpTYu6G/SwAQAALpd3KO2AIAAAAAAIAl0dgCAAAAAACAJXEqogVFLa0hpZ2+6rizd+73QTXWMX7eFl1ITff663B4NtyVm0yT5//xVZYl8gzvyu3+XOI7AAAAICccsQUAAAAAAABLorEFAAAAAAAAS6KxBQAAAAAAAEuisQUAAAAAAABLorEFAAAAAAAAS6KxBQAAAAAAAEuisQUAAAAAAABLorEFAAAAAAAASwrxdwFw39n2O/xdgiWN7F7P3yUA2SLT7iHLsAuyDwAAcO04YgsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlhTi7wIkyRgjSTp9+rSfKwl8aWlGZ8+yntwVSOstczvP3O7thjy7J5C2TSsItPVFnpFXgbYtX+/snmWJPHsDOb4o0NaD3fNMln0n0LbtQOKrdZPbPAdEYyuz2MqVq/m5EsB3Tp8+rfz58/u7DI8jz7gekWfAHo4dO2bLLEvkGdcf9s2AfVwtzw4TAK3sjIwMHTp0SDExMXI4HP4uJ2AlJyerdOnSOnjwoGJjY/1djmUE2nozxuj06dMqUaKEgoLsdzYwec69QNs2A10gri/yjLwIxG35enfq1CmVKVNGJ06cUIECBfxdjleQZ88ixxcF4npg3wxPCMRtO1D4ct3kNs8BccRWUFCQSpUq5e8yLCM2NpZw5UEgrTc7/u9RJvLsvkDaNq0g0NYXeUZeBdq2DNnyj+BM5Nk7yPFFgbYe2DfDUwJt2w4kvlo3ucmzfffeAAAAAAAAsDUaWwAAAAAAALAkGlsWEh4ertGjRys8PNzfpVgK6w2Bim3TPawv2AXbcuDhM4G72GYuYj3Arti2cxaI6yYgLh4PAAAAAAAAuIsjtgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgJIv3791LlzZ3+XEdBatGihIUOGSJLKli2r1157za/1AFdCpnNGlmFnZB+AFbFvBq4/dsl9iL8LAPIqKSlJ+fLl83cZAK4RWQYAILCwbwauP1bOPY0tWFaRIkX8XQIADyDLAAAEFvbNwPXHyrnnVEQ/WLBggWrWrKnIyEgVKlRIt912m1JSUpzzJ06cqOLFi6tQoUIaNGiQUlNTnfNmz56tBg0aKCYmRsWKFVPPnj119OhR5/w1a9bI4XBo6dKlql27tiIiItS4cWNt377dp+/RFy4/VNLhcOjdd99Vhw4dFBUVpWrVqmnDhg369ddf1aJFC+XLl09NmjTRnj17XJbz2WefqX79+oqIiFD58uU1ZswYpaWl+fjdwMrI9LUhy7Aqsm8Ny5Yt080336wCBQqoUKFC6tChg8v3x++//67u3bsrLi5O+fLlU4MGDbRp0ybt3r1bDodDP/30k8vyJk2apLJly8oY4+u3Ah9ge7mIfTPsioznzMq5p7HlY4cPH1aPHj00YMAA7dq1S2vWrNFdd93lDMLq1au1Z88erV69Wh988IFmzJihGTNmOJ//999/a+zYsfrhhx+0aNEi7d27V/369cvyOsOHD9fEiROVlJSkokWLqlOnTi6/UNvV2LFj1adPH23dulVVq1ZVz5499dBDD2nkyJHavHmzJGnw4MHO8V9++aXuvfdePfroo9q5c6feffddzZgxQy+88IK/3gIshkx7B1lGoCP71pGSkqInnnhCSUlJWrlypYKCgtSlSxdlZGTozJkzSkhI0KFDh7R48WL98MMPevLJJ5WRkaEqVaqofv36+vDDD12WN2fOHPXs2VMOh8NP7wjexPaSM/bNsAMy7h7L5N7Ap7777jsjyezbty/LvL59+5r4+HiTlpbmnNa1a1fTrVu3HJf37bffGknm9OnTxhhjVq9ebSSZefPmOcccO3bMREZGmo8++siD78Q/EhISzGOPPWaMMSY+Pt68+uqrznmSzDPPPON8vGHDBiPJTJs2zTlt7ty5JiIiwvn4lltuMePGjXN5jVmzZpnixYt75w3Adsh03pBlWB3Zt66jR48aSWb79u3m3XffNTExMebYsWPZjp00aZIpX7688/Hu3buNJPPjjz/6qlz42fW0vbBvxvXoesp4duySe47Y8rHatWurVatWqlmzprp27aopU6boxIkTzvk33nijgoODnY+LFy/ucmrC999/rzvvvFPx8fGKiYlRixYtJEkHDhxweZ0mTZo4/x0XF6cqVapo165dXnpXgaNWrVrOf99www2SpJo1a7pMO3/+vJKTkyVJ3333nZ577jlFR0c7fx544AEdPnxYZ8+e9W3xsCQy7R1kGYGO7FvHnj171LNnT5UvX16xsbEqV66cpIvreuvWrapbt67i4uKyfW737t21f/9+bdy4UZL04Ycfqk6dOqpevbrP6odvsb3kjH0z7ICMu8cquaex5WPBwcFasWKFvvjiC1WvXl2vv/66qlSpor1790qSQkNDXcY7HA5lZGRIunjY5O23367o6GjNnj1bSUlJ+vTTTyVdPKXhaux6eOSlLl1/me83u2mZ6zQjI0NjxozR1q1bnT/bt2/XL7/8ooiICB9WDqsi095BlhHoyL51dOzYUceOHdOUKVO0adMmbdq0SdLFdR0ZGXnF5xYvXlwtW7bUnDlzJElz587Vvffe6/Wa4T9sLzlj3ww7IOPusUruuSuiHzgcDjVr1kzNmjXTs88+q/j4eOcvtFfy008/6a+//tKECRNUunRpSXKe13q5jRs3qkyZMpKkEydO6Oeff1bVqlU99yZsol69etq9e7cqVqzo71JgYWTa/8gy/IHsB75jx45p165devfdd3XLLbdIkr7++mvn/Fq1amnq1Kk6fvx4jv9D36tXL40YMUI9evTQnj171L17d5/UDt9je/Es9s0INGTc+/yVe47Y8rFNmzZp3Lhx2rx5sw4cOKBPPvlEf/75p6pVq3bV55YpU0ZhYWF6/fXX9dtvv2nx4sUaO3ZstmOfe+45rVy5Ujt27FC/fv1UuHBhde7c2cPvxvqeffZZzZw5U4mJifrxxx+1a9cuffTRR3rmmWf8XRosgkwHBrIMXyP71lCwYEEVKlRI7733nn799VetWrVKTzzxhHN+jx49VKxYMXXu3FnffPONfvvtNy1cuFAbNmxwjrnrrruUnJysgQMHqmXLlipZsqQ/3gp8gO3Fs9g3I9CQce/zV+5pbPlYbGys/vvf/6pdu3aqXLmynnnmGb3yyiu64447rvrcIkWKaMaMGZo/f76qV6+uCRMmaOLEidmOnTBhgh577DHVr19fhw8f1uLFixUWFubpt2N5bdq00ZIlS7RixQo1bNhQN910kyZNmqT4+Hh/lwaLINOBgSzD18i+NQQFBWnevHn67rvvVKNGDT3++ON6+eWXnfPDwsK0fPlyFS1aVO3atVPNmjU1YcIEl+ujxcbGqmPHjvrhhx/Uq1cvf7wN+Ajbi2exb0agIePe56/cO/7/1e5hE2vWrFHLli114sQJFShQwN/lALhGZBq4PpF9AACA3OGILQAAAAAAAFgSjS0AAAAAAABYEqciAgAAAAAAwJI4YgsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGPL5hITE1WnTh3n4379+qlz584+eS0AnkWeAfsgz4A9kGXAPsizddHY8rAjR47on//8p8qXL6/w8HCVLl1aHTt21MqVKz32Gi1atNCQIUNyNXbYsGEefe1MDodDixYt8slrAf5Cnskz7IM8k2fYA1kmy7AP8kyePSXE3wXYyb59+9SsWTMVKFBAL730kmrVqqXU1FR9+eWXGjRokH766Sef1WKMUXp6uqKjoxUdHe2T1/TlawHeRp7JM+yDPJNn2ANZJsuwD/JMnj3KwGPuuOMOU7JkSXPmzJks806cOGGMMWb//v2mU6dOJl++fCYmJsZ07drVHDlyxDlu9OjRpnbt2mbmzJkmPj7exMbGmm7dupnk5GRjjDF9+/Y1klx+9u7da1avXm0kmWXLlpn69eub0NBQs2rVKufyMvXt29fceeedJjEx0RQpUsTExMSYBx980Fy4cME5Jj4+3rz66qsu9deuXduMHj3aOf/S14+Pj3epPVN6eroZM2aMKVmypAkLCzO1a9c2X3zxhXP+3r17jSSzcOFC06JFCxMZGWlq1apl1q9f7xyzb98+06FDB1OgQAETFRVlqlevbpYuXerOxwLkCXkmz7AP8kyeYQ9kmSzDPsgzefYkTkX0kOPHj2vZsmUaNGiQ8uXLl2V+gQIFZIxR586ddfz4ca1du1YrVqzQnj171K1bN5exe/bs0aJFi7RkyRItWbJEa9eu1YQJEyRJkydPVpMmTfTAAw/o8OHDOnz4sEqXLu187pNPPqnx48dr165dqlWrVra1rly5Urt27dLq1as1d+5cffrppxozZkyu32tSUpIkafr06Tp8+LDz8eUmT56sV155RRMnTtS2bdvUpk0bderUSb/88ovLuKefflrDhg3T1q1bVblyZfXo0UNpaWmSpEGDBunChQv673//q+3bt+vFF1+ksw2vI89ZkWdYFXnOijzDishyVmQZVkWesyLP18ivbTUb2bRpk5FkPvnkkxzHLF++3AQHB5sDBw44p/34449Gkvn222+NMRc7t1FRUc4uszHGDB8+3DRu3Nj5OCEhwTz22GMuy87sOi9atMhlenZd57i4OJOSkuKc9vbbb5vo6GiTnp5ujLl619kYYySZTz/99IqvVaJECfPCCy+4jGnYsKF55JFHjDH/6zpPnTo1y/rYtWuXMcaYmjVrmsTERAP4Enkmz7AP8kyeYQ9kmSzDPsgzefY0jtjyEGOMpIsXhsvJrl27VLp0aZcucfXq1VWgQAHt2rXLOa1s2bKKiYlxPi5evLiOHj2aqzoaNGhw1TG1a9dWVFSU83GTJk105swZHTx4MFevkRvJyck6dOiQmjVr5jK9WbNmLu9Vkkt3vHjx4pLkfL+PPvqonn/+eTVr1kyjR4/Wtm3bPFYjkBPy7Io8w8rIsyvyDKsiy67IMqyMPLsiz9eOxpaHVKpUSQ6HI8uGdyljTLbhvXx6aGioy3yHw6GMjIxc1ZHdoZy5lVlDUFCQ88smU2pq6jUtM1N26+DS95s5L/P93n///frtt9/Uu3dvbd++XQ0aNNDrr7+ep1qA3CLPV15mJvIMKyDPV15mJvKMQEeWr7zMTGQZVkCer7zMTOQ592hseUhcXJzatGmjN998UykpKVnmnzx5UtWrV9eBAwdcurs7d+7UqVOnVK1atVy/VlhYmNLT0/Nc6w8//KBz5845H2/cuFHR0dEqVaqUJKlIkSI6fPiwc35ycrL27t3rsozQ0NAr1hAbG6sSJUro66+/dpm+fv16t96rJJUuXVoPP/ywPvnkEw0dOlRTpkxx6/mAu8izK/IMKyPPrsgzrIosuyLLsDLy7Io8XzsaWx701ltvKT09XY0aNdLChQv1yy+/aNeuXfr3v/+tJk2a6LbbblOtWrXUq1cvbdmyRd9++6369OmjhISEXB0Gmals2bLatGmT9u3bp7/++ivXHelMf//9t+677z7t3LlTX3zxhUaPHq3BgwcrKOji5nDrrbdq1qxZWrdunXbs2KG+ffsqODg4Sw0rV67UkSNHdOLEiWxfZ/jw4XrxxRf10Ucfaffu3frXv/6lrVu36rHHHst1rUOGDNGXX36pvXv3asuWLVq1apXb4Qbygjy7Is+wMvLsijzDqsiyK7IMKyPPrsjztQnxdwF2Uq5cOW3ZskUvvPCChg4dqsOHD6tIkSKqX7++3n77bTkcDi1atEj//Oc/1bx5cwUFBalt27ZuHx44bNgw9e3bV9WrV9e5c+eydISvplWrVqpUqZKaN2+uCxcuqHv37kpMTHTOHzlypH777Td16NBB+fPn19ixY7O8xiuvvKInnnhCU6ZMUcmSJbVv374sr/Poo48qOTlZQ4cO1dGjR1W9enUtXrxYlSpVynWt6enpGjRokH7//XfFxsaqbdu2evXVV916v0BekGdX5BlWRp5dkWdYFVl2RZZhZeTZFXm+Ng5z+QmhAAAAAAAAgAVwKiIAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACzp/wG6UJWiZMA+FwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1500x400 with 5 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "index = [1, 2, 3, 4, 5]\n",
+    "cns.consistency_plot(selection=index, max_features=21)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "cumulative": {
+          "enabled": true
+         },
+         "histnorm": "percent",
+         "hovertemplate": "Top %{x:.0f} features explain at least 90%<br>of the model for %{y:.1f}% of the instances",
+         "hovertext": "none",
+         "marker": {
+          "color": "rgba(255, 166, 17, 0.9)"
+         },
+         "name": "",
+         "type": "histogram",
+         "x": [
+          4,
+          6,
+          6,
+          7,
+          8,
+          11,
+          10,
+          5,
+          9,
+          4,
+          9,
+          6,
+          8,
+          3,
+          6,
+          8,
+          5,
+          6,
+          6,
+          9,
+          5,
+          10,
+          6,
+          9,
+          5,
+          9,
+          10,
+          7,
+          6,
+          9,
+          5,
+          4,
+          4,
+          7,
+          6,
+          5,
+          7,
+          8,
+          4,
+          6,
+          8,
+          4,
+          6,
+          9,
+          2,
+          5,
+          9,
+          5,
+          4,
+          9,
+          4,
+          8,
+          9,
+          6,
+          9,
+          9,
+          6,
+          6,
+          6,
+          4,
+          9,
+          6,
+          9,
+          7,
+          5,
+          6,
+          8,
+          6,
+          9,
+          7,
+          4,
+          6,
+          4,
+          9,
+          6,
+          8,
+          9,
+          8,
+          6,
+          9,
+          9,
+          6,
+          9,
+          6,
+          7,
+          4,
+          8,
+          5,
+          9,
+          8,
+          8,
+          5,
+          4,
+          5,
+          8,
+          8,
+          4,
+          4,
+          4,
+          2,
+          2,
+          10,
+          4,
+          4,
+          9,
+          6,
+          5,
+          9,
+          4,
+          6,
+          11,
+          9,
+          6,
+          9,
+          9
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "cumulative": {
+          "direction": "decreasing",
+          "enabled": true
+         },
+         "histnorm": "percent",
+         "hovertemplate": "Top 5 features explain at least %{x:.0f}%<br>of the model for %{y:.1f}% of the instances",
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "",
+         "type": "histogram",
+         "x": [
+          62.27984619140625,
+          77.69200897216797,
+          77.69203186035156,
+          60.868072509765625,
+          50.406982421875,
+          79.7265396118164,
+          11.565017700195312,
+          94.0938949584961,
+          47.36039733886719,
+          76.27253723144531,
+          82.78956604003906,
+          72.96168518066406,
+          38.0950927734375,
+          90.80529022216797,
+          76.15373992919922,
+          38.97829055786133,
+          99.32422637939453,
+          77.69207763671875,
+          77.69203186035156,
+          44.81510925292969,
+          90.53871154785156,
+          19.920730590820312,
+          73.60841369628906,
+          82.78956604003906,
+          96.21476745605469,
+          44.81510925292969,
+          17.046737670898438,
+          19.77273178100586,
+          80.23736572265625,
+          47.36039733886719,
+          96.9686508178711,
+          65.49175262451172,
+          76.27253723144531,
+          60.961387634277344,
+          76.15373992919922,
+          90.10739135742188,
+          86.29658508300781,
+          30.46487045288086,
+          76.27253723144531,
+          77.69203186035156,
+          37.46528625488281,
+          76.27253723144531,
+          77.69203186035156,
+          27.695608139038086,
+          96.4424819946289,
+          96.38581085205078,
+          47.36039733886719,
+          90.10739135742188,
+          76.27253723144531,
+          44.81510925292969,
+          66.94755554199219,
+          38.97829055786133,
+          82.67252349853516,
+          77.69203186035156,
+          44.81510925292969,
+          86.97869873046875,
+          77.69203186035156,
+          77.69203186035156,
+          77.69203186035156,
+          76.27253723144531,
+          47.36039733886719,
+          77.69203186035156,
+          47.36039733886719,
+          66.01457214355469,
+          90.10739135742188,
+          77.69203186035156,
+          49.89971923828125,
+          77.69203186035156,
+          44.81510925292969,
+          78.3909683227539,
+          76.27253723144531,
+          77.69203186035156,
+          76.27253723144531,
+          44.81510925292969,
+          77.69203186035156,
+          38.32597732543945,
+          82.78956604003906,
+          52.946327209472656,
+          77.69203186035156,
+          32.49473571777344,
+          44.81510925292969,
+          73.60841369628906,
+          26.552820205688477,
+          77.69203186035156,
+          56.688045501708984,
+          76.27253723144531,
+          32.017372131347656,
+          96.2148208618164,
+          47.36039733886719,
+          43.294620513916016,
+          50.407005310058594,
+          93.81294250488281,
+          76.27253723144531,
+          96.95012664794922,
+          52.946327209472656,
+          52.946327209472656,
+          76.27253723144531,
+          73.2259292602539,
+          76.27253723144531,
+          89.79256439208984,
+          89.79256439208984,
+          15.721702575683594,
+          76.27253723144531,
+          76.27253723144531,
+          30.63640594482422,
+          77.69203186035156,
+          96.21476745605469,
+          44.81510925292969,
+          77.9197006225586,
+          77.69203186035156,
+          19.42887306213379,
+          47.36039733886719,
+          77.69203186035156,
+          44.81510925292969,
+          44.81510925292969
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial",
+           "size": 14
+          },
+          "showarrow": false,
+          "text": "Number of features required<br>to explain 90% of the model's output",
+          "x": 0.2,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial",
+           "size": 14
+          },
+          "showarrow": false,
+          "text": "Percentage of the model output<br>explained by the 5 most important<br>features per instance",
+          "x": 0.8,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1,
+          "yanchor": "bottom",
+          "yref": "paper"
+         }
+        ],
+        "hovermode": "closest",
+        "margin": {
+         "t": 150
+        },
+        "showlegend": false,
+        "template": {
+         "data": {
+          "scatter": [
+           {
+            "type": "scatter"
+           }
+          ]
+         }
+        },
+        "title": {
+         "font": {
+          "color": "rgb(50, 50, 50)",
+          "family": "Arial",
+          "size": 24
+         },
+         "pad": {
+          "b": 50
+         },
+         "text": "Compacity of explanations:<span style='font-size: 16px;'><br />How many variables are enough to produce accurate explanations?</span>",
+         "x": 0.5,
+         "xanchor": "center",
+         "y": 0.8,
+         "yanchor": "bottom"
+        },
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          0.4
+         ],
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Number of selected features"
+         }
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0.6000000000000001,
+          1
+         ],
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Percentage of model output<br>explained (%)"
+         }
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Cumulative distribution over<br>dataset's instances (%)"
+         }
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Cumulative distribution over<br>dataset's instances (%)"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# xpl.plot.compacity_plot(selection=index, approx=.85, nb_features=3)\n",
+    "xpl.plot.compacity_plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "hovertemplate": "%{hovertext}<extra></extra>",
+         "hovertext": [
+          "<b>Feature: %dl_volume</b><br />Importance: 0.00754026088701642<br />Variability: 0.27983824565561244",
+          "<b>Feature: %tcp_protocol</b><br />Importance: 0.15454479345808858<br />Variability: 0.07401721770672695",
+          "<b>Feature: %udp_protocol</b><br />Importance: 0.0<br />Variability: 0.0",
+          "<b>Feature: %ul_volume</b><br />Importance: 0.0<br />Variability: 0.0",
+          "<b>Feature: avg_dl_volume</b><br />Importance: 0.09754979027354199<br />Variability: 0.27510512847650753",
+          "<b>Feature: avg_ul_volume</b><br />Importance: 0.11641795589872028<br />Variability: 0.09130852209042212",
+          "<b>Feature: dl_data_volume</b><br />Importance: 0.0016124646528623999<br />Variability: 0.26235595898811565",
+          "<b>Feature: dl_packet</b><br />Importance: 0.0037734851063958006<br />Variability: 0.3348205767264438",
+          "<b>Feature: kB/s</b><br />Importance: 0.040018185009451014<br />Variability: 0.4355620571657631",
+          "<b>Feature: max_dl_volume</b><br />Importance: 0.0023382330859970787<br />Variability: 0.08111178882979363",
+          "<b>Feature: max_ul_volume</b><br />Importance: 0.012913767442755077<br />Variability: 0.1611966767034534",
+          "<b>Feature: min_dl_volume</b><br />Importance: 0.06076857185234194<br />Variability: 0.09888649031965305",
+          "<b>Feature: min_ul_volume</b><br />Importance: 0.0<br />Variability: 0.0",
+          "<b>Feature: nb_downlink_packet</b><br />Importance: 0.009779974818229675<br />Variability: 0.24163735729525798",
+          "<b>Feature: nb_packet/s</b><br />Importance: 0.0<br />Variability: 0.0",
+          "<b>Feature: nb_uplink_packet</b><br />Importance: 0.015427270187469928<br />Variability: 0.18890334712240198",
+          "<b>Feature: session_time</b><br />Importance: 0.011047294650874707<br />Variability: 0.6353005220604878",
+          "<b>Feature: std_dl_volume</b><br />Importance: 0.456763296801111<br />Variability: 0.10185825410197773",
+          "<b>Feature: std_ul_volume</b><br />Importance: 0.0056770143625528915<br />Variability: 0.06557788812535127",
+          "<b>Feature: ul_data_volume</b><br />Importance: 0.003827608111516937<br />Variability: 0.31107252445755246",
+          "<b>Feature: ul_packet</b><br />Importance: 0.0<br />Variability: 0.0"
+         ],
+         "marker": {
+          "color": [
+           0.00754026088701642,
+           0.15454479345808858,
+           0,
+           0,
+           0.09754979027354199,
+           0.11641795589872028,
+           0.0016124646528623999,
+           0.0037734851063958006,
+           0.040018185009451014,
+           0.0023382330859970787,
+           0.012913767442755077,
+           0.06076857185234194,
+           0,
+           0.009779974818229675,
+           0,
+           0.015427270187469928,
+           0.011047294650874707,
+           0.456763296801111,
+           0.0056770143625528915,
+           0.003827608111516937,
+           0
+          ],
+          "colorscale": [
+           [
+            0,
+            "rgb(52, 55, 54)"
+           ],
+           [
+            0,
+            "rgb(74, 99, 138)"
+           ],
+           [
+            0,
+            "rgb(116, 153, 214)"
+           ],
+           [
+            0.005119135233440659,
+            "rgb(162, 188, 213)"
+           ],
+           [
+            0.008379850435276101,
+            "rgb(212, 234, 242)"
+           ],
+           [
+            0.016508027111249452,
+            "rgb(235, 216, 134)"
+           ],
+           [
+            0.024186038432253993,
+            "rgb(255, 204, 83)"
+           ],
+           [
+            0.03377519668395651,
+            "rgb(244, 192, 0)"
+           ],
+           [
+            0.13304171389848443,
+            "rgb(255, 166, 17)"
+           ],
+           [
+            0.25487589899197244,
+            "rgb(255, 123, 38)"
+           ],
+           [
+            1,
+            "rgb(255, 77, 7)"
+           ]
+          ],
+          "line": {
+           "color": "white",
+           "width": 0.8
+          },
+          "opacity": 0.8,
+          "size": 10
+         },
+         "mode": "markers",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          0.27983824565561244,
+          0.07401721770672695,
+          0,
+          0,
+          0.27510512847650753,
+          0.09130852209042212,
+          0.26235595898811565,
+          0.3348205767264438,
+          0.4355620571657631,
+          0.08111178882979363,
+          0.1611966767034534,
+          0.09888649031965305,
+          0,
+          0.24163735729525798,
+          0,
+          0.18890334712240198,
+          0.6353005220604878,
+          0.10185825410197773,
+          0.06557788812535127,
+          0.31107252445755246,
+          0
+         ],
+         "y": [
+          0.00754026088701642,
+          0.15454479345808858,
+          0,
+          0,
+          0.09754979027354199,
+          0.11641795589872028,
+          0.0016124646528623999,
+          0.0037734851063958006,
+          0.040018185009451014,
+          0.0023382330859970787,
+          0.012913767442755077,
+          0.06076857185234194,
+          0,
+          0.009779974818229675,
+          0,
+          0.015427270187469928,
+          0.011047294650874707,
+          0.456763296801111,
+          0.0056770143625528915,
+          0.003827608111516937,
+          0
+         ]
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "rgba(117, 152, 189, 0.9)",
+          "dash": "dot"
+         },
+         "mode": "lines",
+         "name": "<-- Stable",
+         "type": "scatter",
+         "x": [
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15
+         ],
+         "y": [
+          0,
+          0.456763296801111
+         ]
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "rgba(255, 166, 17, 0.9)",
+          "dash": "dot"
+         },
+         "mode": "lines",
+         "name": "--> Unstable",
+         "type": "scatter",
+         "x": [
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3
+         ],
+         "y": [
+          0,
+          0.456763296801111
+         ]
+        }
+       ],
+       "layout": {
+        "coloraxis": {
+         "showscale": false
+        },
+        "hovermode": "closest",
+        "template": {
+         "data": {
+          "scatter": [
+           {
+            "type": "scatter"
+           }
+          ]
+         }
+        },
+        "title": {
+         "font": {
+          "color": "rgb(50, 50, 50)",
+          "family": "Arial",
+          "size": 24
+         },
+         "pad": {
+          "b": 50
+         },
+         "text": "Importance & Local Stability of explanations:<span style='font-size: 16px;'><br />How similar are explanations for closeby neighbours?</span>",
+         "x": 0.5,
+         "xanchor": "center",
+         "yanchor": "bottom"
+        },
+        "xaxis": {
+         "automargin": true,
+         "range": [
+          -0.03,
+          0.6653005220604878
+         ],
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Variability of the Normalized Local Contribution Values<span style='font-size: 12px;'><br />(standard deviation / mean)</span>"
+         }
+        },
+        "yaxis": {
+         "automargin": true,
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Importance<span style='font-size: 12px;'><br />(Average contributions)</span>"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "xpl.plot.stability_plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": "rgb(116, 153, 214)"
+         },
+         "name": "min_dl_volume",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.014513703994452953,
+          0.02406895160675049
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgb(255, 166, 17)"
+         },
+         "name": "avg_ul_volume",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.01451369933784008,
+          0.02817234769463539
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgb(255, 166, 17)"
+         },
+         "name": "avg_dl_volume",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.014513715170323849,
+          0.028172364458441734
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgb(255, 166, 17)"
+         },
+         "name": "%tcp_protocol",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.014513668604195118,
+          0.03341539949178696
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgb(255, 77, 7)"
+         },
+         "name": "std_dl_volume",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.01451369933784008,
+          0.03696049004793167
+         ]
+        },
+        {
+         "hoverinfo": "none",
+         "marker": {
+          "color": [
+           0.05955486558377743,
+           0.4128984361886978
+          ],
+          "colorbar": {
+           "len": 300,
+           "lenmode": "pixels",
+           "thickness": 20,
+           "title": {
+            "text": "Importance<br />(Average contributions)"
+           },
+           "y": 1,
+           "yanchor": "top",
+           "ypad": 60
+          },
+          "colorscale": [
+           [
+            0,
+            "rgb(52, 55, 54)"
+           ],
+           [
+            0.07471997571321667,
+            "rgb(74, 99, 138)"
+           ],
+           [
+            0.1494399514264334,
+            "rgb(116, 153, 214)"
+           ],
+           [
+            0.19304606009645187,
+            "rgb(162, 188, 213)"
+           ],
+           [
+            0.205538301723272,
+            "rgb(212, 234, 242)"
+           ],
+           [
+            0.21803054335009217,
+            "rgb(235, 216, 134)"
+           ],
+           [
+            0.24631393846127,
+            "rgb(255, 204, 83)"
+           ],
+           [
+            0.2745973335724478,
+            "rgb(244, 192, 0)"
+           ],
+           [
+            0.4309912249024296,
+            "rgb(255, 166, 17)"
+           ],
+           [
+            0.7154956124512147,
+            "rgb(255, 123, 38)"
+           ],
+           [
+            1,
+            "rgb(255, 77, 7)"
+           ]
+          ],
+          "showscale": true,
+          "size": 1
+         },
+         "mode": "markers",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          null
+         ],
+         "y": [
+          null
+         ]
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "rgba(117, 152, 189, 0.9)",
+          "dash": "dot"
+         },
+         "mode": "lines",
+         "name": "<-- Stable",
+         "type": "scatter",
+         "x": [
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15
+         ],
+         "y": [
+          "%tcp_protocol",
+          "avg_dl_volume",
+          "avg_ul_volume",
+          "min_dl_volume",
+          "std_dl_volume"
+         ]
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "rgba(255, 166, 17, 0.9)",
+          "dash": "dot"
+         },
+         "mode": "lines",
+         "name": "--> Unstable",
+         "type": "scatter",
+         "x": [
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3
+         ],
+         "y": [
+          "%tcp_protocol",
+          "avg_dl_volume",
+          "avg_ul_volume",
+          "min_dl_volume",
+          "std_dl_volume"
+         ]
+        }
+       ],
+       "layout": {
+        "coloraxis": {
+         "showscale": false
+        },
+        "height": 500,
+        "hovermode": "closest",
+        "template": {
+         "data": {
+          "scatter": [
+           {
+            "type": "scatter"
+           }
+          ]
+         }
+        },
+        "title": {
+         "font": {
+          "color": "rgb(50, 50, 50)",
+          "family": "Arial",
+          "size": 24
+         },
+         "pad": {
+          "b": 50
+         },
+         "text": "Importance & Local Stability of explanations:<span style='font-size: 16px;'><br />How similar are explanations for closeby neighbours?</span>",
+         "x": 0.5,
+         "xanchor": "center",
+         "yanchor": "bottom"
+        },
+        "xaxis": {
+         "automargin": true,
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Normalized local contribution value variability"
+         }
+        },
+        "yaxis": {
+         "automargin": true,
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": ""
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "xpl.plot.stability_plot(selection=[100,9], max_features=5, distribution=\"boxplot\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "10th closest neighbor",
+         "opacity": 0.2,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.00746087497100234,
+          -0.009552525356411934,
+          -0.010299584828317165,
+          -0.020691998302936554,
+          -0.05242697894573212,
+          0.06126288324594498,
+          -0.12645266950130463,
+          -0.13756631314754486,
+          -0.15727302432060242,
+          -0.3985995948314667
+         ],
+         "y": [
+          "session_time",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_ul_volume",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "9th closest neighbor",
+         "opacity": 0.28,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.007321763783693314,
+          -0.009374414570629597,
+          -0.010107544250786304,
+          -0.020306186750531197,
+          -0.051449455320835114,
+          0.05758177489042282,
+          -0.12409491091966629,
+          -0.13500133156776428,
+          -0.15687943994998932,
+          -0.4145053029060364
+         ],
+         "y": [
+          "session_time",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_ul_volume",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "8th closest neighbor",
+         "opacity": 0.36,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.007323349826037884,
+          -0.009376444853842258,
+          -0.010109733790159225,
+          -0.02031058445572853,
+          -0.05146060138940811,
+          0.06013363227248192,
+          -0.12412179261445999,
+          -0.1350305825471878,
+          -0.15437403321266174,
+          -0.4145950675010681
+         ],
+         "y": [
+          "session_time",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_ul_volume",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "7th closest neighbor",
+         "opacity": 0.44000000000000006,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.00746087497100234,
+          -0.009552525356411934,
+          -0.010299584828317165,
+          -0.020691998302936554,
+          -0.05242697894573212,
+          0.06126288324594498,
+          -0.12645266950130463,
+          -0.13756631314754486,
+          -0.15727302432060242,
+          -0.3985995948314667
+         ],
+         "y": [
+          "session_time",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_ul_volume",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "6th closest neighbor",
+         "opacity": 0.52,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.007450249046087265,
+          -0.009538920596241951,
+          -0.010284915566444397,
+          -0.020662527531385422,
+          -0.052352312952280045,
+          0.05859224125742912,
+          -0.12627257406711578,
+          -0.13737039268016815,
+          -0.15963242948055267,
+          -0.4042308032512665
+         ],
+         "y": [
+          "session_time",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_ul_volume",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "5th closest neighbor",
+         "opacity": 0.6000000000000001,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.00746087497100234,
+          -0.009552525356411934,
+          -0.010299584828317165,
+          -0.020691998302936554,
+          -0.05242697894573212,
+          0.06126288324594498,
+          -0.12645266950130463,
+          -0.13756631314754486,
+          -0.15727302432060242,
+          -0.3985995948314667
+         ],
+         "y": [
+          "session_time",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_ul_volume",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "4th closest neighbor",
+         "opacity": 0.6800000000000002,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.00746087497100234,
+          -0.009552525356411934,
+          -0.010299584828317165,
+          -0.020691998302936554,
+          -0.05242697894573212,
+          0.06126288324594498,
+          -0.12645266950130463,
+          -0.13756631314754486,
+          -0.15727302432060242,
+          -0.3985995948314667
+         ],
+         "y": [
+          "session_time",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_ul_volume",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "3rd closest neighbor",
+         "opacity": 0.76,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.00746087497100234,
+          -0.009552525356411934,
+          -0.010299584828317165,
+          -0.020691998302936554,
+          -0.05242697894573212,
+          0.06126288324594498,
+          -0.12645266950130463,
+          -0.13756631314754486,
+          -0.15727302432060242,
+          -0.3985995948314667
+         ],
+         "y": [
+          "session_time",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_ul_volume",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "2nd closest neighbor",
+         "opacity": 0.8400000000000001,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.0073320260271430016,
+          -0.009387553669512272,
+          -0.010121711529791355,
+          -0.020334647968411446,
+          -0.05152156949043274,
+          0.06020487844944,
+          -0.12426884472370148,
+          -0.13519056141376495,
+          -0.15455691516399384,
+          -0.4089856743812561
+         ],
+         "y": [
+          "session_time",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_ul_volume",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "closest neighbor",
+         "opacity": 0.9199999999999999,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          0.10760843008756638,
+          -0.008613788522779942,
+          -0.00928743276745081,
+          -0.018658572807908058,
+          -0.04727492108941078,
+          0.057580865919589996,
+          -0.1140260323882103,
+          -0.12404751777648926,
+          -0.13947927951812744,
+          -0.35677751898765564
+         ],
+         "y": [
+          "session_time",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_ul_volume",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(255, 166, 17, 0.9)"
+         },
+         "name": "instance",
+         "opacity": 1,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.00746087497100234,
+          -0.009552525356411934,
+          -0.010299584828317165,
+          -0.020691998302936554,
+          -0.05242697894573212,
+          0.06126288324594498,
+          -0.12645266950130463,
+          -0.13756631314754486,
+          -0.15727302432060242,
+          -0.3985995948314667
+         ],
+         "y": [
+          "session_time",
+          "nb_downlink_packet",
+          "max_ul_volume",
+          "nb_uplink_packet",
+          "kB/s",
+          "min_dl_volume",
+          "avg_ul_volume",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "std_dl_volume"
+         ]
+        }
+       ],
+       "layout": {
+        "barmode": "group",
+        "height": 1210,
+        "hovermode": "closest",
+        "legend": {
+         "traceorder": "reversed"
+        },
+        "template": {
+         "data": {
+          "scatter": [
+           {
+            "type": "scatter"
+           }
+          ]
+         }
+        },
+        "title": {
+         "font": {
+          "color": "rgb(50, 50, 50)",
+          "family": "Arial",
+          "size": 24
+         },
+         "pad": {
+          "b": 50
+         },
+         "text": "Comparing local explanations in a neighborhood - Id: <b>9</b><span style='font-size: 16px;'><br />How similar are explanations for closeby neighbours?</span>",
+         "x": 0.5,
+         "xanchor": "center",
+         "yanchor": "bottom"
+        },
+        "xaxis": {
+         "automargin": true,
+         "side": "bottom",
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Normalized contribution values"
+         }
+        },
+        "yaxis": {
+         "automargin": true,
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": ""
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "xpl.plot.local_neighbors_plot(index=9)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import shap\n",
+    "\n",
+    "# treeSHAP = shap.TreeExplainer(clf).shap_values(X_train, check_additivity=False)[1]\n",
+    "# samplingSHAP = shap.SamplingExplainer(clf.predict_proba, shap.kmeans(X_train, 200)).shap_values(X_train, check_additivity=False)[1]\n",
+    "# kernelSHAP = shap.KernelExplainer(clf.predict_proba, shap.kmeans(X_train, 200)).shap_values(X_train, check_additivity=False)[1]\n",
+    "\n",
+    "# treeSHAP = pd.DataFrame(treeSHAP, columns=X_train.columns)\n",
+    "# samplingSHAP = pd.DataFrame(samplingSHAP, columns=X_train.columns)\n",
+    "# kernelSHAP = pd.DataFrame(kernelSHAP, columns=X_train.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xpl.generate_report(\n",
+    "    output_file='report.html',\n",
+    "    project_info_file='shapash_project_info.yml',\n",
+    "    x_train=X_train,\n",
+    "    y_train=y_train_orig,\n",
+    "    y_test=y_test_orig,\n",
+    "    title_story=\"User Network Activities Classification\",\n",
+    "    title_description=\"This document is a data science report of the user network activities classification.\",\n",
+    "    metrics=[\n",
+    "        {\n",
+    "            'path': 'sklearn.metrics.mean_squared_error',\n",
+    "            'name': 'Mean squared error',  # Optional : name that will be displayed next to the metric\n",
+    "        },\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mi_xai",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/xai/Accountability/lightGBM.ipynb
+++ b/xai/Accountability/lightGBM.ipynb
@@ -12,7 +12,16 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\thuli\\AppData\\Roaming\\Python\\Python39\\site-packages\\xgboost\\compat.py:31: FutureWarning: pandas.Int64Index is deprecated and will be removed from pandas in a future version. Use pandas.Index with the appropriate dtype instead.\n",
+      "  from pandas import MultiIndex, Int64Index\n"
+     ]
+    }
+   ],
    "source": [
     "import xgboost as xgb\n",
     "import pandas as pd\n",
@@ -165,7 +174,7 @@
     "    features_dict=features_dict # optional parameter, specifies label for features name \n",
     ")\n",
     "xpl.compile(x=X_test,\n",
-    "            y_target=y_test_orig # Optional: allows to display True Values vs Predicted Values\n",
+    "            # y_target=y_test_orig # Optional: allows to display True Values vs Predicted Values\n",
     "           )"
    ]
   },

--- a/xai/Accountability/lightGBM.ipynb
+++ b/xai/Accountability/lightGBM.ipynb
@@ -1,0 +1,3110 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Import binary data - Taken from binarized dataset\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xgboost as xgb\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.metrics import mean_squared_error\n",
+    "from sklearn.preprocessing import StandardScaler\n",
+    "from sklearn.model_selection import train_test_split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The shape of the full dataset: (382, 22)\n",
+      "Features: ['session_time', '%tcp_protocol', '%udp_protocol', 'ul_data_volume', 'max_ul_volume', 'min_ul_volume', 'avg_ul_volume', 'std_ul_volume', '%ul_volume', 'dl_data_volume', 'max_dl_volume', 'min_dl_volume', 'avg_dl_volume', 'std_dl_volume', '%dl_volume', 'nb_uplink_packet', 'nb_downlink_packet', 'ul_packet', 'dl_packet', 'kB/s', 'nb_packet/s']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Load the dataset from csv files\n",
+    "full_dataset = pd.read_csv(\"../../output_full_web_or_not.csv\", header=0, usecols=[*range(1,23)], sep=\";\") \n",
+    "full_dataset.dropna(axis = 0, inplace = True)\n",
+    "print(\"The shape of the full dataset: \" + str(full_dataset.shape))\n",
+    "\n",
+    "full_dataset.head()\n",
+    "\n",
+    "# Set of features in the dataset\n",
+    "features = list(full_dataset.columns)\n",
+    "print(\"Features: \" + str(features[:-1]))\n",
+    "\n",
+    "activity_df = full_dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shape of the training dataset: (267, 21), (267, 1)\n",
+      "Shape of the testing dataset: (115, 21), (115, 1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "y_df = activity_df['output'].to_frame()\n",
+    "X_df = activity_df[activity_df.columns.difference(['output'])]\n",
+    "\n",
+    "X_train, X_test, y_train_orig, y_test_orig = train_test_split(X_df, y_df, stratify=y_df, train_size=0.7, random_state=9)\n",
+    "\n",
+    "print(\"Shape of the training dataset: \" + str(X_train.shape) + \", \" + str(y_train_orig.shape))\n",
+    "print(\"Shape of the testing dataset: \" + str(X_test.shape) + \", \" + str(y_test_orig.shape))\n",
+    "\n",
+    "# print(X_train.index.tolist())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "output\n",
+       "1         212\n",
+       "2          55\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y_train_orig.value_counts()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\thuli\\anaconda3\\envs\\mi_xai\\lib\\site-packages\\sklearn\\preprocessing\\_label.py:98: DataConversionWarning: A column-vector y was passed when a 1d array was expected. Please change the shape of y to (n_samples, ), for example using ravel().\n",
+      "  y = column_or_1d(y, warn=True)\n",
+      "c:\\Users\\thuli\\anaconda3\\envs\\mi_xai\\lib\\site-packages\\sklearn\\preprocessing\\_label.py:133: DataConversionWarning: A column-vector y was passed when a 1d array was expected. Please change the shape of y to (n_samples, ), for example using ravel().\n",
+      "  y = column_or_1d(y, warn=True)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "LGBMClassifier()"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import lightgbm as ltb\n",
+    "clf = ltb.LGBMClassifier()\n",
+    "# Using Y_train here got an error of shape\n",
+    "clf.fit(X_train, y_train_orig)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Shapash"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from shapash import SmartExplainer\n",
+    "# features = list(features)\n",
+    "features_dict = dict(zip(features, features))\n",
+    "xpl = SmartExplainer(\n",
+    "    model=clf,\n",
+    "    #preprocessing=encoder,   # Optional: compile step can use inverse_transform method\n",
+    "    features_dict=features_dict # optional parameter, specifies label for features name \n",
+    ")\n",
+    "xpl.compile(x=X_test,\n",
+    "            y_target=y_test_orig # Optional: allows to display True Values vs Predicted Values\n",
+    "           )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "customdata": [
+          "ul_packet",
+          "ul_data_volume",
+          "kB/s",
+          "min_ul_volume",
+          "nb_downlink_packet",
+          "nb_uplink_packet",
+          "dl_packet",
+          "dl_data_volume",
+          "max_ul_volume",
+          "%dl_volume",
+          "std_ul_volume",
+          "%udp_protocol",
+          "%ul_volume",
+          "min_dl_volume",
+          "max_dl_volume",
+          "session_time",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "avg_ul_volume",
+          "std_dl_volume"
+         ],
+         "hovertemplate": "Feature: %{customdata}<br />Contribution: %{x:.4f}<extra></extra>",
+         "marker": {
+          "color": [
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)",
+           "rgba(244, 192, 0, 1.0)"
+          ],
+          "line": {
+           "color": "rgba(52, 55, 54, 0.8)",
+           "width": 0.5
+          }
+         },
+         "name": "Global",
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          0.0017,
+          0.0019,
+          0.0023,
+          0.003,
+          0.0034,
+          0.0062,
+          0.0064,
+          0.0064,
+          0.0085,
+          0.0087,
+          0.0132,
+          0.0152,
+          0.0153,
+          0.0206,
+          0.0295,
+          0.0341,
+          0.045,
+          0.2162,
+          0.2549,
+          0.3077
+         ],
+         "y": [
+          "ul_packet",
+          "ul_data_volume",
+          "kB/s",
+          "min_ul_volume",
+          "nb_downlink_packet",
+          "nb_uplink_packet",
+          "dl_packet",
+          "dl_data_volume",
+          "max_ul_volume",
+          "%dl_volume",
+          "std_ul_volume",
+          "%udp_protocol",
+          "%ul_volume",
+          "min_dl_volume",
+          "max_dl_volume",
+          "session_time",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "avg_ul_volume",
+          "std_dl_volume"
+         ]
+        }
+       ],
+       "layout": {
+        "autosize": false,
+        "barmode": "group",
+        "height": 500,
+        "hovermode": "closest",
+        "margin": {
+         "b": 50,
+         "l": 160,
+         "r": 0,
+         "t": 95
+        },
+        "template": {
+         "data": {
+          "scatter": [
+           {
+            "type": "scatter"
+           }
+          ]
+         }
+        },
+        "title": {
+         "font": {
+          "color": "rgb(50, 50, 50)",
+          "family": "Arial",
+          "size": 24
+         },
+         "text": "Features Importance<br><sup>Response: <b>2</b> - Total number of features: 21</sup>",
+         "x": 0.5,
+         "xanchor": "center",
+         "y": 0.9,
+         "yanchor": "middle"
+        },
+        "width": 900,
+        "xaxis": {
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Contribution"
+         }
+        },
+        "yaxis": {
+         "automargin": true,
+         "dtick": 1,
+         "tickmode": "array",
+         "ticktext": [
+          "ul_packet",
+          "ul_data_volume",
+          "kB/s",
+          "min_ul_volume",
+          "nb_downlink_packet",
+          "nb_uplink_packet",
+          "dl_packet",
+          "dl_data_volume",
+          "max_ul_volume",
+          "%dl_volume",
+          "std_ul_volume",
+          "%udp_protocol",
+          "%ul_volume",
+          "min_dl_volume",
+          "max_dl_volume",
+          "session_time",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "avg_ul_volume",
+          "std_dl_volume"
+         ],
+         "tickvals": [
+          "ul_packet",
+          "ul_data_volume",
+          "kB/s",
+          "min_ul_volume",
+          "nb_downlink_packet",
+          "nb_uplink_packet",
+          "dl_packet",
+          "dl_data_volume",
+          "max_ul_volume",
+          "%dl_volume",
+          "std_ul_volume",
+          "%udp_protocol",
+          "%ul_volume",
+          "min_dl_volume",
+          "max_dl_volume",
+          "session_time",
+          "avg_dl_volume",
+          "%tcp_protocol",
+          "avg_ul_volume",
+          "std_dl_volume"
+         ],
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          }
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "xpl.plot.features_importance()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "customdata": [
+          [
+           99.6474217717056,
+           59
+          ],
+          [
+           89.1891891891892,
+           137
+          ],
+          [
+           100,
+           323
+          ],
+          [
+           0,
+           198
+          ],
+          [
+           100,
+           125
+          ],
+          [
+           99.8981462619678,
+           286
+          ],
+          [
+           1.1857707509881423,
+           158
+          ],
+          [
+           99.1150442477876,
+           240
+          ],
+          [
+           2.380952380952381,
+           351
+          ],
+          [
+           100,
+           1
+          ],
+          [
+           99.89163415691374,
+           300
+          ],
+          [
+           100,
+           296
+          ],
+          [
+           5.813953488372093,
+           348
+          ],
+          [
+           0.3766478342749529,
+           216
+          ],
+          [
+           100,
+           98
+          ],
+          [
+           100,
+           213
+          ],
+          [
+           0,
+           219
+          ],
+          [
+           100,
+           322
+          ],
+          [
+           98.27586206896552,
+           270
+          ],
+          [
+           99.92306508693645,
+           302
+          ],
+          [
+           8.333333333333334,
+           360
+          ],
+          [
+           100,
+           361
+          ],
+          [
+           99.02912621359224,
+           313
+          ],
+          [
+           94.89795918367346,
+           309
+          ],
+          [
+           99.85742291926572,
+           63
+          ],
+          [
+           99.61315280464216,
+           231
+          ],
+          [
+           10.526315789473683,
+           222
+          ],
+          [
+           96.03960396039604,
+           261
+          ],
+          [
+           97.82608695652172,
+           110
+          ],
+          [
+           94.05940594059406,
+           381
+          ],
+          [
+           2.687140115163148,
+           164
+          ],
+          [
+           0.6153846153846154,
+           345
+          ],
+          [
+           100,
+           276
+          ],
+          [
+           2.3769100169779285,
+           145
+          ],
+          [
+           91.48936170212764,
+           102
+          ],
+          [
+           100,
+           267
+          ],
+          [
+           5.095541401273885,
+           155
+          ],
+          [
+           92.45283018867924,
+           119
+          ],
+          [
+           90.36144578313252,
+           283
+          ],
+          [
+           99.05660377358492,
+           238
+          ],
+          [
+           3.902439024390244,
+           151
+          ],
+          [
+           100,
+           117
+          ],
+          [
+           100,
+           50
+          ],
+          [
+           2.25140712945591,
+           149
+          ],
+          [
+           98.83381924198252,
+           272
+          ],
+          [
+           95.91836734693878,
+           312
+          ],
+          [
+           100,
+           301
+          ],
+          [
+           99.76119402985074,
+           65
+          ],
+          [
+           93.33333333333331,
+           170
+          ],
+          [
+           100,
+           171
+          ],
+          [
+           100,
+           46
+          ],
+          [
+           8.615384615384615,
+           150
+          ],
+          [
+           99.53051643192488,
+           379
+          ],
+          [
+           92.45283018867924,
+           118
+          ],
+          [
+           96.03960396039604,
+           310
+          ],
+          [
+           98.94736842105264,
+           319
+          ],
+          [
+           99.51980792316928,
+           249
+          ],
+          [
+           99.6661101836394,
+           223
+          ],
+          [
+           94.9367088607595,
+           336
+          ],
+          [
+           99.86033519553072,
+           22
+          ],
+          [
+           99.88372093023256,
+           248
+          ],
+          [
+           99.86684420772303,
+           289
+          ],
+          [
+           91.83673469387756,
+           120
+          ],
+          [
+           0,
+           359
+          ],
+          [
+           95.78947368421052,
+           308
+          ],
+          [
+           98.50746268656717,
+           376
+          ],
+          [
+           95.83333333333331,
+           317
+          ],
+          [
+           100,
+           14
+          ],
+          [
+           100,
+           194
+          ],
+          [
+           2.8112449799196786,
+           168
+          ],
+          [
+           99.7372569626905,
+           87
+          ],
+          [
+           98,
+           265
+          ],
+          [
+           100,
+           56
+          ],
+          [
+           95.78947368421052,
+           307
+          ],
+          [
+           99.5127892813642,
+           24
+          ],
+          [
+           1.8867924528301887,
+           148
+          ],
+          [
+           23.07692307692308,
+           175
+          ],
+          [
+           99.67213114754098,
+           226
+          ],
+          [
+           99.95455922447744,
+           58
+          ],
+          [
+           6.956521739130435,
+           347
+          ],
+          [
+           97.79005524861878,
+           325
+          ],
+          [
+           99.51040391676868,
+           246
+          ],
+          [
+           0,
+           212
+          ],
+          [
+           99.91773609740046,
+           290
+          ],
+          [
+           99.8619261304798,
+           61
+          ],
+          [
+           99.8931623931624,
+           64
+          ],
+          [
+           4.23572744014733,
+           159
+          ],
+          [
+           94.73684210526316,
+           128
+          ],
+          [
+           99.6832101372756,
+           232
+          ],
+          [
+           1.8975332068311197,
+           146
+          ],
+          [
+           100,
+           34
+          ],
+          [
+           100,
+           126
+          ],
+          [
+           100,
+           197
+          ],
+          [
+           99.5475113122172,
+           244
+          ],
+          [
+           90.69767441860463,
+           108
+          ],
+          [
+           100,
+           271
+          ],
+          [
+           100,
+           91
+          ],
+          [
+           100,
+           12
+          ],
+          [
+           99.88682661837936,
+           49
+          ],
+          [
+           100,
+           40
+          ],
+          [
+           98.46153846153848,
+           256
+          ],
+          [
+           100,
+           326
+          ],
+          [
+           92.15686274509804,
+           335
+          ],
+          [
+           100,
+           129
+          ],
+          [
+           99.88556715777428,
+           303
+          ],
+          [
+           99.70414201183432,
+           281
+          ],
+          [
+           95.45454545454544,
+           306
+          ],
+          [
+           98,
+           337
+          ],
+          [
+           100,
+           114
+          ],
+          [
+           100,
+           52
+          ],
+          [
+           6.25,
+           199
+          ],
+          [
+           100,
+           292
+          ],
+          [
+           91.11111111111111,
+           112
+          ],
+          [
+           94.44444444444444,
+           387
+          ],
+          [
+           100,
+           320
+          ]
+         ],
+         "hovertemplate": "<b>%{hovertext}</b><br />%tcp_protocol: %{customdata[0]}<br />Contribution: %{y:.4f}<extra></extra>",
+         "hovertext": [
+          "Id: 59",
+          "Id: 137",
+          "Id: 323",
+          "Id: 198",
+          "Id: 125",
+          "Id: 286",
+          "Id: 158",
+          "Id: 240",
+          "Id: 351",
+          "Id: 1",
+          "Id: 300",
+          "Id: 296",
+          "Id: 348",
+          "Id: 216",
+          "Id: 98",
+          "Id: 213",
+          "Id: 219",
+          "Id: 322",
+          "Id: 270",
+          "Id: 302",
+          "Id: 360",
+          "Id: 361",
+          "Id: 313",
+          "Id: 309",
+          "Id: 63",
+          "Id: 231",
+          "Id: 222",
+          "Id: 261",
+          "Id: 110",
+          "Id: 381",
+          "Id: 164",
+          "Id: 345",
+          "Id: 276",
+          "Id: 145",
+          "Id: 102",
+          "Id: 267",
+          "Id: 155",
+          "Id: 119",
+          "Id: 283",
+          "Id: 238",
+          "Id: 151",
+          "Id: 117",
+          "Id: 50",
+          "Id: 149",
+          "Id: 272",
+          "Id: 312",
+          "Id: 301",
+          "Id: 65",
+          "Id: 170",
+          "Id: 171",
+          "Id: 46",
+          "Id: 150",
+          "Id: 379",
+          "Id: 118",
+          "Id: 310",
+          "Id: 319",
+          "Id: 249",
+          "Id: 223",
+          "Id: 336",
+          "Id: 22",
+          "Id: 248",
+          "Id: 289",
+          "Id: 120",
+          "Id: 359",
+          "Id: 308",
+          "Id: 376",
+          "Id: 317",
+          "Id: 14",
+          "Id: 194",
+          "Id: 168",
+          "Id: 87",
+          "Id: 265",
+          "Id: 56",
+          "Id: 307",
+          "Id: 24",
+          "Id: 148",
+          "Id: 175",
+          "Id: 226",
+          "Id: 58",
+          "Id: 347",
+          "Id: 325",
+          "Id: 246",
+          "Id: 212",
+          "Id: 290",
+          "Id: 61",
+          "Id: 64",
+          "Id: 159",
+          "Id: 128",
+          "Id: 232",
+          "Id: 146",
+          "Id: 34",
+          "Id: 126",
+          "Id: 197",
+          "Id: 244",
+          "Id: 108",
+          "Id: 271",
+          "Id: 91",
+          "Id: 12",
+          "Id: 49",
+          "Id: 40",
+          "Id: 256",
+          "Id: 326",
+          "Id: 335",
+          "Id: 129",
+          "Id: 303",
+          "Id: 281",
+          "Id: 306",
+          "Id: 337",
+          "Id: 114",
+          "Id: 52",
+          "Id: 199",
+          "Id: 292",
+          "Id: 112",
+          "Id: 387",
+          "Id: 320"
+         ],
+         "marker": {
+          "color": [
+           0.000013207469629691185,
+           0.000008441520982271612,
+           0.000012461799070871256,
+           0.9996683095211694,
+           0.0009252637309588829,
+           0.00001335204810774487,
+           0.999761010195765,
+           0.000009676725001636708,
+           0.15410638726990739,
+           0.000009620329756404789,
+           0.000008946777398376091,
+           0.000009329878394534298,
+           0.9994649836014188,
+           0.9997081546007957,
+           0.000011902903459251993,
+           0.9985175644474461,
+           0.9996559951595438,
+           0.000012452361787567963,
+           0.000010346540622933033,
+           0.000008947651952933973,
+           0.9942306135270517,
+           0.9979700806963131,
+           0.000015941455537098208,
+           0.000014653861667369453,
+           0.000028202181154273245,
+           0.000022486565678473713,
+           0.9995195108487891,
+           0.00000970845363386115,
+           0.000007937215204758098,
+           0.000009178414980612276,
+           0.9998006655007904,
+           0.9995465795356402,
+           0.000014396597253628296,
+           0.9996812045064123,
+           0.000009848048615410915,
+           0.000009156904539908617,
+           0.9995438148081827,
+           0.000010477264560759444,
+           0.00003267002771621698,
+           0.00001245498032804175,
+           0.999616440116695,
+           0.000007953818223075685,
+           0.000007515001419140109,
+           0.9997247089338166,
+           0.000014400464691885382,
+           0.000015993404990001374,
+           0.000013767814069505383,
+           0.000008940656573044194,
+           0.0011795296181474715,
+           0.00002625742324475058,
+           0.000009342307540534832,
+           0.9921943070645515,
+           0.000016094373525940652,
+           0.000016187895528268063,
+           0.0000159417361260889,
+           0.000017144718789133378,
+           0.000021177879227159703,
+           0.00002298662040423926,
+           0.00001590059582492908,
+           0.000035740466505011304,
+           0.000016896014783436064,
+           0.000008947194927944421,
+           0.000009864009570247332,
+           0.9992323552987274,
+           0.000018228665340538797,
+           0.00000913801311314297,
+           0.000015937677259464774,
+           0.000008968429922453774,
+           0.0029799572488461335,
+           0.07947453457044143,
+           0.000010134359694882186,
+           0.000016107515658087953,
+           0.000009330309298874851,
+           0.000015937619128680405,
+           0.00003574646245187484,
+           0.9997070683217179,
+           0.9986224727861059,
+           0.000025035976171416863,
+           0.000008947041231620714,
+           0.9994940561158806,
+           0.000009227923340698007,
+           0.000019992973632141277,
+           0.7371507111521768,
+           0.000013337612036567871,
+           0.00003572107789930652,
+           0.000008949067184893989,
+           0.9972615066984517,
+           0.0009252441515001904,
+           0.00002288599414304361,
+           0.9996485329544198,
+           0.000009620292114975112,
+           0.0015309821317373708,
+           0.002368062101552826,
+           0.000016754692000766418,
+           0.000012157381743050716,
+           0.000014396587699982894,
+           0.000011890895615366552,
+           0.000007525619885405331,
+           0.000016319058643143487,
+           0.08804845329255363,
+           0.000008955932373168523,
+           0.000009226521180429688,
+           0.00002225753259809801,
+           0.0009252441515001894,
+           0.000028202218732092746,
+           0.000009227411407132774,
+           0.00001768521897209898,
+           0.00000923570096346723,
+           0.00000845255845841481,
+           0.000009619890966106462,
+           0.11438228756622351,
+           0.00000933030602953369,
+           0.000009750129171114404,
+           0.000010352161169992339,
+           0.000009713863195142838
+          ],
+          "coloraxis": "coloraxis",
+          "line": {
+           "color": "white",
+           "width": 0.8
+          },
+          "opacity": 0.8,
+          "size": 10
+         },
+         "mode": "markers",
+         "type": "scatter",
+         "x": [
+          99.6474217717056,
+          89.1891891891892,
+          100,
+          0,
+          100,
+          99.8981462619678,
+          1.1857707509881423,
+          99.1150442477876,
+          2.380952380952381,
+          100,
+          99.89163415691374,
+          100,
+          5.813953488372093,
+          0.3766478342749529,
+          100,
+          100,
+          0,
+          100,
+          98.27586206896552,
+          99.92306508693645,
+          8.333333333333334,
+          100,
+          99.02912621359224,
+          94.89795918367346,
+          99.85742291926572,
+          99.61315280464216,
+          10.526315789473683,
+          96.03960396039604,
+          97.82608695652172,
+          94.05940594059406,
+          2.687140115163148,
+          0.6153846153846154,
+          100,
+          2.3769100169779285,
+          91.48936170212764,
+          100,
+          5.095541401273885,
+          92.45283018867924,
+          90.36144578313252,
+          99.05660377358492,
+          3.902439024390244,
+          100,
+          100,
+          2.25140712945591,
+          98.83381924198252,
+          95.91836734693878,
+          100,
+          99.76119402985074,
+          93.33333333333331,
+          100,
+          100,
+          8.615384615384615,
+          99.53051643192488,
+          92.45283018867924,
+          96.03960396039604,
+          98.94736842105264,
+          99.51980792316928,
+          99.6661101836394,
+          94.9367088607595,
+          99.86033519553072,
+          99.88372093023256,
+          99.86684420772303,
+          91.83673469387756,
+          0,
+          95.78947368421052,
+          98.50746268656717,
+          95.83333333333331,
+          100,
+          100,
+          2.8112449799196786,
+          99.7372569626905,
+          98,
+          100,
+          95.78947368421052,
+          99.5127892813642,
+          1.8867924528301887,
+          23.07692307692308,
+          99.67213114754098,
+          99.95455922447744,
+          6.956521739130435,
+          97.79005524861878,
+          99.51040391676868,
+          0,
+          99.91773609740046,
+          99.8619261304798,
+          99.8931623931624,
+          4.23572744014733,
+          94.73684210526316,
+          99.6832101372756,
+          1.8975332068311197,
+          100,
+          100,
+          100,
+          99.5475113122172,
+          90.69767441860463,
+          100,
+          100,
+          100,
+          99.88682661837936,
+          100,
+          98.46153846153848,
+          100,
+          92.15686274509804,
+          100,
+          99.88556715777428,
+          99.70414201183432,
+          95.45454545454544,
+          98,
+          100,
+          100,
+          6.25,
+          100,
+          91.11111111111111,
+          94.44444444444444,
+          100
+         ],
+         "y": [
+          -1.0239423312176514,
+          -1.2377279737271842,
+          -1.3483508557595325,
+          5.071467306018306,
+          -1.2495136719737616,
+          -1.0315987982112778,
+          3.6080294841093683,
+          -1.3125481998100423,
+          5.0759816200271235,
+          -1.362213666015055,
+          -1.0472941860430105,
+          -1.225432354544302,
+          2.453807983445859,
+          4.164962268868438,
+          -1.341648648583437,
+          -0.8540619167596774,
+          5.105418520038707,
+          -1.3483513058399097,
+          -1.2744838545898611,
+          -1.0472966483569923,
+          1.603670839930376,
+          -0.8540624400024887,
+          -1.4041896555370401,
+          -1.2294097826381372,
+          -1.0312800001971798,
+          -1.3518113434531203,
+          1.9222932195100788,
+          -1.349222770610452,
+          -1.3582245044578174,
+          -1.3405516027140025,
+          3.5954295206680693,
+          4.153749733331547,
+          -1.32748934758322,
+          3.59063022772123,
+          -1.2136948225733752,
+          -1.3528330370984092,
+          1.9854434866901767,
+          -1.2064219950669521,
+          -1.206483125122349,
+          -1.295316645923652,
+          2.4247004648116195,
+          -1.4110920264729236,
+          -1.2254901193382934,
+          4.155433156001737,
+          -1.274641568220322,
+          -1.4129705436926967,
+          -1.0376241800449082,
+          -1.0656315827075027,
+          -1.0472574259255572,
+          -1.2185761470898238,
+          -1.2254102706189511,
+          1.9093818993943006,
+          -1.2746137907628685,
+          -1.1552706974108273,
+          -1.4131181052941049,
+          -1.3950155367682815,
+          -1.3470355170742756,
+          -1.263427644439693,
+          -1.4133772635963102,
+          -1.0315130558614871,
+          -1.4450277989067075,
+          -1.0870343612966331,
+          -1.213616629004403,
+          4.731179301582864,
+          -1.3965130137856336,
+          -1.3469913349374587,
+          -1.4131650610025692,
+          -1.0472136582753298,
+          -1.0311960615386082,
+          4.903312786588716,
+          -1.0015466463389948,
+          -1.2745102506851511,
+          -1.225432560193991,
+          -1.4131650710371528,
+          -1.0505616069891512,
+          3.608540406734336,
+          1.758932415405188,
+          -1.2633705897258907,
+          -1.0473080924805342,
+          2.428706251733131,
+          -1.3397714264808944,
+          -1.3542986027907216,
+          6.327404065336841,
+          -1.0316190285087452,
+          -1.03157387848242,
+          -1.0472884251194854,
+          1.9605735680089058,
+          -1.2255645708669265,
+          -1.1352709392840201,
+          4.016641586957146,
+          -1.3622136968788188,
+          -1.2530478969578218,
+          -1.2110035649068136,
+          -1.3921362168400515,
+          -1.1873900925770495,
+          -1.3276730700691368,
+          -1.3417052049723361,
+          -1.04716080467844,
+          -1.0311629617133382,
+          -1.0442541570786261,
+          -1.1307073644305994,
+          -1.3929690746493957,
+          -1.2590644933379334,
+          -1.249689106559789,
+          -1.031279488757595,
+          -1.3308816589324572,
+          -1.3894404038890107,
+          -1.3397026156208915,
+          -1.4038683513578762,
+          -1.362213585426955,
+          2.039878454263418,
+          -1.2254323564822385,
+          -1.213830374529714,
+          -1.2835044465846006,
+          -1.3929762249789381
+         ]
+        }
+       ],
+       "layout": {
+        "coloraxis": {
+         "colorbar": {
+          "title": {
+           "text": "Predicted Proba"
+          }
+         },
+         "colorscale": [
+          [
+           0,
+           "rgb(52, 55, 54)"
+          ],
+          [
+           0.0000014371091063646936,
+           "rgb(74, 99, 138)"
+          ],
+          [
+           0.0000018156827989467725,
+           "rgb(116, 153, 214)"
+          ],
+          [
+           0.0000026623451661203613,
+           "rgb(162, 188, 213)"
+          ],
+          [
+           0.00000583247870544161,
+           "rgb(212, 234, 242)"
+          ],
+          [
+           0.000008480157687244125,
+           "rgb(235, 216, 134)"
+          ],
+          [
+           0.000014097655249343268,
+           "rgb(255, 204, 83)"
+          ],
+          [
+           0.000028236102467057038,
+           "rgb(244, 192, 0)"
+          ],
+          [
+           0.2707637443902593,
+           "rgb(255, 166, 17)"
+          ],
+          [
+           0.9997333725718844,
+           "rgb(255, 123, 38)"
+          ],
+          [
+           1,
+           "rgb(255, 77, 7)"
+          ]
+         ]
+        },
+        "height": 600,
+        "hovermode": "closest",
+        "template": {
+         "data": {
+          "scatter": [
+           {
+            "type": "scatter"
+           }
+          ]
+         }
+        },
+        "title": {
+         "font": {
+          "color": "rgb(50, 50, 50)",
+          "family": "Arial",
+          "size": 24
+         },
+         "text": "<b>%tcp_protocol</b> - Feature Contribution<br><sup>Response: <b>2</b></sup>",
+         "x": 0.5,
+         "xanchor": "center",
+         "y": 0.9,
+         "yanchor": "middle"
+        },
+        "width": 900,
+        "xaxis": {
+         "automargin": true,
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "%tcp_protocol"
+         }
+        },
+        "yaxis": {
+         "automargin": true,
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Contribution"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "xpl.plot.contribution_plot(\"%tcp_protocol\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [],
+       "layout": {
+        "barmode": "group",
+        "height": 550,
+        "hovermode": "closest",
+        "margin": {
+         "b": 70,
+         "l": 150,
+         "r": 20,
+         "t": 80
+        },
+        "template": {
+         "data": {
+          "scatter": [
+           {
+            "type": "scatter"
+           }
+          ]
+         }
+        },
+        "title": {
+         "font": {
+          "color": "rgb(50, 50, 50)",
+          "family": "Arial",
+          "size": 24
+         },
+         "text": "Local Explanation - <b>No Matching Entry</b>",
+         "x": 0.5,
+         "xanchor": "center",
+         "y": 0.9,
+         "yanchor": "middle"
+        },
+        "width": 900,
+        "xaxis": {
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Contribution"
+         }
+        },
+        "yaxis": {
+         "automargin": true,
+         "dtick": 1,
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          }
+         },
+         "type": "category"
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "xpl.plot.local_plot(index=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 100/100 [00:00<00:00, 441.27it/s]\n",
+      " 30%|███       | 3/10 [03:03<07:08, 61.22s/it]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from shapash.explainer.consistency import Consistency\n",
+    "cns = Consistency()\n",
+    "\n",
+    "cns.compile(x=X_train, # Dataset for which we need explanations\n",
+    "            model=clf, # Model to explain\n",
+    "            #preprocessing=encoder, # Optional\n",
+    "            )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAnsAAAJfCAYAAAAHCRC3AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8o6BhiAAAACXBIWXMAAA9hAAAPYQGoP6dpAAC+HklEQVR4nOzddVhU29cH8O/Q0qmihIWIV0QHQRQLCxULuztRbOyrYrdeG0Gxu7sRE7sDDBoppaRjv3/wzvnNOAMM5SCuz/Pc58rJdXLW2WfvfXiMMQZCCCGEEFIuyck6AEIIIYQQUnoo2SOEEEIIKcco2SOEEEIIKcco2SOEEEIIKcco2SOEEEIIKcco2SOEEEIIKcco2SOEEEIIKcco2SOEEEIIKcco2SNECllZWbIOgRBSAuhaJn8jBVkHQPL27t073Lx5E69fv0ZwcDCSkpIgLy8PLS0t1K5dG7a2tujYsSN0dHRkHapMWFtbAwAMDQ1x4cKFUllHYmIitmzZgvr166Nz586lsg5ScsLDw7Fnzx48evQIsbGxAABtbW0MGzYMffr0kXF0svP06VOMHTsWANC5c2e4u7vLOKLfr6BrecyYMXj27BkA4Pz586hSpcrvDpGQUkPJXhn06tUrbNy4Ea9fvxYbl5mZibS0NERFReHu3bvYsmULhg8fjuHDh0NBgQ5nSXry5Anmzp2LHz9+oF69erIOhxQgNDQUQ4YMQWJiosjwqKgoqKioyCgqUhbQtUz+dpQdlDE7duyAl5cXBJ8slpeXR8OGDWFubg5tbW1kZWUhODgYfn5+iI+PR3p6Onbs2IFXr15hzZo1qFChgoy3oPx4/vw5fvz4IeswiJQ8PT25RE9bWxuOjo7Q19dHUlIS+Hy+jKMjskTXMvnbUbJXhmzcuBH79+/n/u7evTvGjx8PfX19sWkzMzOxf/9+7NixA9nZ2Xj48CEWLFiANWvW/M6QZUrwyoUQAAgICOD+vXbtWjRs2FCG0ZA/zc6dO2UdAiGlhhpolBE3btzgEj0ej4eFCxfi33//lZjoAYCioiJGjBiBxYsXc8Nu3bqFK1eu/JZ4CSlrUlJSuH//888/MoyEEELKFkr2yoD09HSsXbuW+3vYsGHo2rWrVPN26NABnTp14v7esWMH9wqYkL9JTk4O928lJSUZRkIIIWULj1FmIHOnTp3CsmXLAOTWNbp48WKhKpQHBwejR48eAABTU1Ns3rwZVatWlTjt169fcfLkSTx79gzfvn1DRkYGtLW1YW5ujlatWsHJyQmKiooS542IiECXLl0AABMnTsTw4cMRGhqK48eP48GDB4iKigKPx4OhoSGaN2+Ofv365VkyKfDgwQNcuXIFr169QkxMDABAR0cH5ubmaNasGZycnKCsrCxxXmla4xZl+QsXLsy3de/ChQslJuORkZE4deoUHj58iPDwcKSkpHD7tnXr1nBycsqzEU1p7Fsgt9HCqVOn8OjRI4SGhiIjIwNaWlqwsLCAo6MjHB0dIS8vz02/adMm7N27F4B0rTZTU1PRvn17bluvXLmS5/mTn+zsbNy6dQvXr1/Hu3fvEBcXBwUFBRgYGMDa2hpdunSBpaWl2HweHh4Fvn7L63hJ482bNzh//jyePn2K2NhYZGVlQV9fHw0aNECnTp1gZ2cncb7Vq1fj6NGjAABVVVUcP34clStXljit8Dbo6enh6NGjXAt7QQtRwTn+8+dPHDp0CDdu3EBERAQYYzAxMUGzZs3Qr18/6OnpSVyHtK1xGWPw9fXF3bt38ebNG8TGxuLnz59QVVWFjo4OLC0t0a5dOzRv3lzi/KV1Hj9+/Bi3b9/Gy5cvERMTg8TERCgrK0NbWxsWFhZwcHBAu3btRM5loHDXsrStcZOTk3H27Fncu3cPnz9/RkJCAtTU1FC1alXY2dmhZ8+eeR5r4fWYmpri1KlTyMzMxOnTp3H9+nUEBQXh58+f0NHRQcOGDdG9e3fY2Njku28iIiJw5swZ+Pn5ITg4GGlpadDU1ESVKlVga2uLbt26wcjIKM/5O3fujG/fvnGxCc4TUr5Qnb0yQPjVq6OjY6FbDpqammLbtm0wMzODrq6uxGnS0tKwYcMGnDx5UqzkLzo6GtHR0bh79y52796NlStXom7dugWu98KFC1ixYgXS0tJEhn/+/BmfP3/GsWPHsHr1aok/iKmpqZg7dy7u3LkjNi4yMhKRkZHw9fWFp6cn1q9fDwsLiwLj+Z3L/9X+/fuxfft2pKeniwyPiYlBTEwM7t27h71792LNmjWoWbNmgcsrzr4Fcku5tm7div379yM7O1tk3Pfv33Hv3j3cu3cPR48exfr167kkwcnJiUv2fHx8MHfu3DyTbQC4c+cO9/rU0dGxSIne58+fMX/+fHz69ElkeHp6OpKTkxEUFISTJ0/C0dER//77729phJSeno5ly5bh4sWLYuPCw8MRHh6Oixcvwt7eHsuWLYOGhobINK6urnj48CFCQkKQkpKC1atXY/369WLL+vDhA3bt2sX9vWDBgjy7UgoNDYWrqytCQ0NFhgcEBCAgIABHjx7FmjVr0Lhx46JsMgIDAzFr1ix8+fJFbFxSUhKSkpIQEhKCixcvomnTpli1ahVUVVXzXWZxz+OYmBjMnj0bL1++FBuXlZWF5ORkhIeH48aNGzhw4AD++++/PBPeknDr1i0sXboUCQkJIsMTEhKQkJCA9+/f48CBAxgzZgyGDx9e4PLCw8Mxbdo0fP78WWR4VFQUrly5gitXrqBnz56YM2cOeDye2PxnzpzBypUrkZmZKTL8x48f+PHjB96+fYu9e/di9OjRGD16dBG2mJQXlOzJWFpamsiNrKCnuLzkd4PPysqCm5sbHjx4wA37559/0KhRI6iqqiIkJAS+vr74+fMnwsPDMWrUKGzZsiXfFowPHjzAy5cvkZOTg5o1a6JJkybQ1NREcHAwbt68ibS0NCQnJ2PmzJk4e/as2A/YmjVruERMTU0NzZs3h6mpKXg8HsLDw3Hr1i0kJycjOjoaEyZMwJkzZ6CpqSn1/ijO8h0dHVGzZk34+fnh0aNHAID27dtzCeGv9cGES8MAwMrKCg0bNoSamhq+ffuGO3fuIDY2FsHBwRg+fDh27doFMzOzUtu3ALBkyRKcO3eO+7tWrVqws7ODmpoagoKCcOvWLWRmZuLt27dwcXHBvn37oKysjJo1a6JOnTr4+PEjkpOTcf/+fbRu3TrPWC9fvsz9W7g6gbQ+f/6MUaNGISkpCQCgoqKC5s2bo2bNmsjMzMSrV6/w9OlTAMDVq1cRFhaGnTt3cg9EdnZ2XPLn7e3NtcadPHkyt47C1t/LzMyEi4sLd10qKCjA3t4e5ubm4PF4CAwMxN27d5Gamor79+9j1KhR8Pb2Fkl8KlSogEWLFmHUqFHIycmBr68vbt26JbIv09PTsWDBAi4Z79OnD5o1ayYxpvT0dEydOhWhoaFQUlKCg4MDatSogR8/fuDWrVuIiYlBcnIyJk+ejA0bNqBJkyaF2ubo6GiMHDmSS2L09fXRrFkzGBoaQk5ODpGRkXjw4AFXAvTgwQNs3rwZs2bNynOZxT2PU1NTMWrUKISFhQEANDU10axZMxgbG0NRURGxsbF49OgRAgMDAeQmzosXL8Z///3HLaOw13J+Ll26hAULFnAPy3p6emjZsiUMDQ0RHx+Phw8f4uvXr8jIyMCWLVsQHR2d7/5JTU2Fq6srgoODoaGhgVatWsHY2BiJiYnw9fXlkvqTJ0/C3NwcPXv2FJn/+fPnWLp0KRcPn89H/fr1oa6ujtjYWDx58gRfvnxBdnY2duzYgcqVK3OlruQvxIhMvX//nvH5fO6/Hz9+lPg6tm3bxi2/WbNm7NatW2LT/Pjxg7m6unLTtWvXjsXFxYlMEx4eLhKrjY0NO336tNiyQkJCWMeOHbnpdu3aJTL+27dvrFGjRtx6wsLCJMbTu3fvPJfBGOPGOTk5lcryd+zYwY0/e/as2HjGGLt9+zY3jYODA/Pz8xObJi0tja1atYqbztnZmWVkZIhMU1L7ljHGrl+/LrKckydPik0TFBTEHB0duem8vLy4cQcPHuSGu7m5SdxuxhiLi4tjtra23DYVVkZGBuvSpQu3rmHDhrHIyEix6Z4+fcpat27NTbd48WKJy3NycuKmKY5169Zxy+nfvz8LDQ0VmyY6OpqNHDmSm27hwoUSl7Vx40ZuGkdHR5aUlCRxPT169GCpqali848ePVrkvOjSpQv7+vWryDQpKSnMzc1NZJr09HSRaZ48ecKNX7Bggdh6/v33X2785MmTWVpamtg0mZmZbPXq1SL3kl+nK8nzePv27dz4wYMHs4SEBLFpGGNs7969IuuUdA5Jcy0L7+vw8HCRcV+/fuXOdT6fz5YuXcpSUlJEpsnJyWGHDx9mNjY23HQXL17Mdz18Pp9NnTqVJSYmikyTmZkpcky6d+8utpzx48dz448fPy42Picnh23atCnfZZC/BzXQkLGoqCju3woKCiX+NYy4uDgcOnSI+3vp0qVwcHAQm05HRwfr1q1DnTp1AOS+6hOeT5Jhw4ahe/fuYsONjY0xbtw47u/Hjx+LjH///j1Xmb59+/YS6xfq6OhgxowZ3N8fPnzIN5bfuXwBxhi2bt0KILcF9bp16ySWsCorK2PmzJlcaUtwcLBIiZgkRd23AERKGV1dXbn6nMJMTU2xZMkS7u+TJ09y/+7YsSNX9+nevXtITk6WGOP169e5T08VpVTv3LlzCA8PBwBUqVIFmzdvRqVKlcSms7a2xsaNG7mYzp07h+Dg4EKvTxrR0dFcXTs9PT1s27ZNYn0nAwMDbNiwgas2cfHiRbHXqwAwfvx41KhRA0DuK8lt27YBAF68eIHDhw8DyL3uly1bVmD1DRUVFWzduhXVq1cXGV6hQgUsX74c5ubmAHJfDZ45c0bqbU5NTcWNGzcA5J6rCxYskPjqXkFBAVOmTOFeWaekpBR4HIpzHgvXtfv333/zLNkfMmQIt4+Bol3LBfH09OTO9datW2PevHli1Ql4PB769esHV1dXbtj27dvz/TybsbExVqxYIVYNQEFBAbNnz+ZKi0NCQhAZGSkyzdu3bwEAGhoa6NWrl9iyeTweJk6cyNUfjImJ4b4qQ/4+lOzJmHB3Edra2iW+/Lt373LrsLa2RsuWLfOcVlFRUeT119mzZ/Nddu/evfMcJ/w6+vv37yLjhCtRv3//Ps+bobW1NY4cOYJ79+4Vqv/A0l6+wOvXr7n6TdbW1gX26zZq1Cju35Lqggkr6r6NiorC+/fvAeSeT/369ct3OTY2NmjcuDFatGiB1NRUALmJcNOmTQHkvj708fGROL8gYeXxeOjYsWO+2yOJcF3V0aNHQ11dPc9pLS0t4ejoCCC3PuL58+cLvT5pXLhwgTtfevXqle81qaGhwe3fnJwciQm8kpIS3N3duXPy+PHjePnyJdzd3bkHkvHjx3MPWfnp06cPjI2NJY5TUFAQqZN169atApcnkJWVhRkzZmDYsGEYM2ZMnvV+gdx7RLVq1bi/f/78me+yi3oeZ2ZmYsyYMRg1ahSGDh2ab7UHACLjC4qpsNLS0rhrgMfjidwjJRk4cCAMDQ0B5DaeePLkSZ7Tdu3aNc86saqqqiJ1ifO6j6akpIjV+RPg8XjYsWMHrl69inv37knVGIaUT5TsyZhwYvJrJduSIHyjya/ulYCtrS20tLQAALGxsQgJCZE4XaVKlWBgYJDncoR/JH9ttGBpaclV5H/16hVGjBiB8+fPS7yZmZmZFbpCfmkvX0C4U2dpGnjUrVuXi+vNmzd5JqHF2beCeklAbj3OghpM7NixA9u2bcPs2bNF9oPwt0OvXr0qNl9ERAT3Ob8GDRrk2fo7L2lpaXjz5g2A3B8kSaXNv2rXrh337+fPnxdqfdIq7DG1srLi/i2pEQGQe9yHDRsGIDcpdHFx4UoBra2tMWTIEKlia9++fb7j7e3tudbez58/F2sUkRcNDQ306NEDrq6uXJx5iYiIEHlAza/UqjjnsaKiIrp27Yrx48dj0qRJ+cb0/ft3xMfHSxVTUbx+/RoZGRkAAHNz83xbtgKAnJycyL02v3O1oE+3Cb/pEcQgIKhTnZ2djdGjR2Pnzp34+PGjWAM8Y2NjSvIINdCQNeHi+8TERGRnZ4t1H1AcgtdkALjXPAWpXbs2lySGhYXBxMREbJqCbh7CicOvNx9dXV0MHToUXl5eAIB3797h3bt34PF4qF27Nuzs7GBvbw8rK6sife+3tJcvIKgYDuS2xhX++klB0tPTERcXJ/HHsDj7VrhagDStfvPSokULaGpqIjExEY8ePUJcXJzID8+VK1e4dRflFW5MTAz3cFOlShWx11iS1K5dm/u3oNJ+SRM+plOmTCnUvL++ZhM2evRo3L17FwEBAVxio66uDnd3d8jJFfzMraCgUGDplpKSEoyMjBAUFITs7GzExMTkWRJYkOjoaISEhCAsLAyhoaEIDAzEx48fRc4vQPz8E1ac81iSHz9+IDg4GGFhYQgLC0NgYCD8/f3FzgVpllUYRbmHCk8nPP+vCtpHwq/2hfuRBIBx48bh0aNHSE1NRWJiIjw8PODh4QFdXV3Y2dmhSZMmsLe35x7eyd+Nkj0ZE74ZM8bw48ePfJ+GC0u4iwBpW7MK3xx+/ai8QGG6h5F08x03bhwqVKiAnTt3cj9+jDH4+/vD398fe/fuhba2Ntq3b4+hQ4fm22+VJKW9fABi3S8UVlJSksRjXZx9K/z9T2kSqLwoKSmhXbt2OHnyJLKzs3Hjxg2RV3KCV5aC6QpLuCRG2h8jac7L4irOMc0vJkVFRbi5uYm8anV2duZe9xVEU1NTqgcT4Wv8x48fhUr2fvz4gb179+LKlSv51u2Sl5cX685HkuLeI4DcPu0OHTqE8+fP55s0SRtTURT3HprfOVWcfWRmZobt27fD3d1d5CHlx48fuHTpEi5dugR5eXnY2tqif//+sLe3l3pdpPyhZE/GqlatypWgALmvgory4/nmzRtkZmaKvMIERG8QkvppkkT4CVKaUoei4PF4GDZsGJydnXHjxg34+vri6dOnIq9z4uPjcezYMZw7dw5r1qzh6pGVheUDEPlx6dKli0glcWmUdGMcACX6g+fk5MQ13Lhy5QqX7Pn7++Pr168AgObNmxcrqQTK1nkpvP/Gjx9fqC9x5NcfISDaCAbI7Uy9b9++UiV80pZAC8dfmD4PX758iWnTpoklJkpKSjA2NoaZmRksLS1hZ2eH5cuX/5bvUgcGBsLV1ZXr7kVAXl4eRkZGqFWrFurVqwdbW1scPnw4386Ti6Os3kOB3Corx44dw6NHj3Dr1i3cv39fpPRV8N30hw8fonv37pg/f77U20DKF0r2ZExOTg42Nja4efMmAMDPz69IyZ6HhwcePnwIFRUVjBo1iuvQU/gJU7g0JT/C0+VXab4kaGlpoWfPnujZsycyMjLw+vVrPH78GPfu3YO/vz+A3Ppdc+fOxYULFwodT2kuX/gpv379+hJbvf5uwvEXt6K6lZUVjI2NERoailevXiE6OhoVK1YUqcPn5ORUpGUL77uydF5qampydTvbtWsHU1PTElmu8HereTweGGNITk7G4sWLsW3btgJ/gKU9lsKli9LW04qPj4ebmxuX6Jmbm6Nfv36oX78+jI2NxaqVSFsXsDgyMzPh5ubGJXpGRkYYOHAgGjZsiGrVqoklsqUZU3HvocV9GCqInJwcmjRpwrX2DwwMxJMnT+Dn5wc/Pz/uAffMmTPg8/lFvmbJn40aaJQBHTp04P7t4+PDtYqU1rdv37iuC9LS0kR+oIRf4wQEBBS4LMaYyJcMCqqMXJKUlJTQqFEjuLi44NChQ/D09ISamhqA3Feed+/eLVPLF26UIOgGoSDS/lgUlfDxCgoKKnD68+fPY+nSpfD29pbYjYagPh5jjNs/gs6qtbS0Cl0aKlC5cmXuBzsiIoLrVDk/guQcKL3zUviYvnv3rsDpMzMz8+yaRiAuLg4rVqzg/l68eDG3nsePH+P48eMFriclJUWsvtyvUlNTuVedqqqq+baqFXbmzBnu9X+dOnWwZ88edO3aFdWqVZNYfzguLo77d0nXjxPw8fHhXk1WqlQJ+/fvR58+fWBmZiaxxLI0YxI+16S5hwKi52phGy8VV/Xq1dGnTx+sX78ely9fFmn1XFAvAKT8omSvDGjRogV3Q0lISBD5fJI0tm/fzr2+EXxzUqBBgwbcvwWlh/l59OgR98Oro6NT5Are+fH29saoUaPQpk0bvHr1Ks/p+Hw+190GkFtp/Hcuv6DSFuEvjNy+fbvAJN3f3x9t2rRBs2bNMHjw4BJvNQiItg599OhRga91L126hNOnT2PLli0i9f0EOnfuzO0HX19fhIeHcz/CRf08GpD7ylPwST7GWJ7duwgTPn+Ft7MkCXefI9w1TF6OHz+OFi1aoHXr1li+fLnEaVauXMnt2zZt2qBTp06YM2cON37Tpk1SNTi5f/9+vuPv3r3LvT4UbplbEEGraCD3eOf36joiIgIRERHc3782GigpwjG1bds237pyaWlpIg9bkpK94ry6tLS05Palv7+/xP4UheXk5Iicz6Vxrr569QpTp05Ft27d8jzvgNwHMhcXF+5vae+hpPyhZK8MUFBQEOleYO/evbh06ZJU8x47dkzkaW3cuHEiP8Bt27blWr09f/4cvr6+eS4rMzMTW7Zs4f52dHQslfod379/x4sXLxAfH19g58LCCYi0DVdKavnCdW0k/ajZ2NhwnQAnJCTA09Mz33UJ9m1qaiqqVKlSrJbAealZsybXEjA2NjbfvhIDAwO5uld6enoSu4GoUqUKlwA9ffoU165d48YVpRWuMOHuXTw9PfN9Vfnu3Ttcv36d+1s4SS9Jwsnt/fv3802wEhMTsWfPHgC5x79WrVpi01y7do3rsFhdXR1ubm4AgCZNmnAl+qmpqXB3dy+wRGr//v15vq7MzMzkWp8DBXfT8uu8AgWVPP/6fd/SeGABRLsZKSimbdu2idTFlRRTQddyfipUqIA2bdoAyE0kN2/enO/0hw8f5kphdXR0YGtrW6j1SUNFRQV37txBWFgYbt++nW/psvA9rmLFiiUeC/kzULJXRrRp04braT4nJwf//vsvli9fjpiYGInTx8fHY+XKlVi1ahU3rH379iI/oEBuHaQBAwZwf8+fPx+3b98WW15CQgLc3Ny43uf19PQwcuTIYm6VZN26deP+feLECZw9e1biD93Nmze5V4YVKlSQ+pVhSS1f8IoXgEhphoCioqJIR8l79+7Fzp07xX5s0tPTsWbNGu7bxPLy8iLzlTThZa9du1ZiB7vfvn3DrFmzuJK/QYMG5VlKJ6jjk56eDm9vbwC5X+CwtLQsVpxOTk5ciXZERARcXV0lvqp88eIFpkyZwsXatWtXqTohLooaNWqIJEpz5syR+IAUGxuL6dOnc/X7KleuLHLeAbkPHStXruT+njx5ssgDxYwZM7j6YM+fP+e+qJGXkJAQzJw5U+yVd1JSEtzc3EQ6+Jam30IB4S5dTpw4IbHkKj4+HrNnzxYrgS2tunLC3ezcuHFDpKRPIDU1FatXr8bBgwcLjKmga7kgI0aM4Eo8b968iWXLlomV5DPGcOLECZFv806ZMqVQjXykZW5uzj3Uff/+HfPnz5dYFeL79+8i8UjT1yopn6iBRhkyd+5cpKWlca+PTp48yVWqrVu3LjQ0NJCSkoKAgAA8efJE5Gm2VatWcHd3l7jcMWPGcB+UT0lJwfTp01GvXj00atQIqqqqCAkJga+vL3ezUFJSwpIlS6Su81NYZmZm6NmzJ06ePAnGGBYvXowjR47AysoKFStWRGpqKl6/fo2nT59y84wbN07qL4yU1PKF69ocOHAAmZmZUFdXB5/P50q7evTogRcvXnAlsR4eHrhw4QKaN28OXV1dREVF4c6dOyJJu6ura4F9phVH69at0atXL5w4cQLp6elwc3ODlZUVrK2tUaFCBQQGBuLWrVvcjyKfzxd5IPhV27ZtsXr1aqSnp3MlCMUt1QNyX+WuXr0ao0ePRnJyMl6/fo0ePXqgRYsWqFGjBrKysvD69Ws8efKES9bNzMwwc+bMYq87P3PnzsWnT5/w9etXJCcnY9q0adz1oqysjODgYPj4+HDXn7KyMpYtWybWGnfZsmVco4eGDRvC2dlZZLyOjg6mTJnCXbdbtmyBvb19no1CFBQUcP/+fXTv3h1t2rRB5cqVERkZiZs3b3KlX7q6upg3b16hSuR79OiBw4cPIz09HfHx8ejTpw9at24NU1NTZGRkICgoCPfv3+dK2xQUFLgHmuJ2P5SX9u3bY8eOHfjx4wfS09MxcuRI7rzg8XgIDQ0V+ZRfQTFJcy3np1atWpg5cyaWLVsGxhhOnToFX19ftGrVCpUrV0ZiYiIePHjAJdxA7kPnrw/fJcnNzQ1jx45FdnY27ty5gy5duqBFixbcW4OQkBCRUr+6deuia9euYsvp3Lkz1xBmzJgxGDt2bKnFTGSHkr0yRF5eHsuWLYO1tTV27NiB79+/Izs7G0+ePMnzkztqamoYN24c+vXrl2cTfwUFBWzevBkrV67EuXPnwBjD27dvJTYqMDExwcqVK6XuPLSo3NzckJ6eznWXEBAQILHys5KSEkaPHo1Bgwb99uXb2trCyMgIYWFhSE9Px759+wAA/fr1E/mBcHd3R+XKlbFv3z5kZWUhPDwcR44cEVuesrIyJk2alO8nzErK7NmzoaWlhT179iA7OxuvXr2SWH+xZcuWWLx4cb6vlNXV1dGqVSuuFW5RP48mibm5OXbv3o3Zs2cjMDAQaWlpIq+KhXXu3FnsSx+lQV1dHbt378aCBQu4kt+8rpdKlSphyZIlInVjgdyK8IISQSUlpTwTsK5du+LixYtct0CLFi3Crl27JF7LixYtwpo1axAfHy/WjQuQ+wp/48aNqFKlSqG2t2rVqli6dCnmz5+P9PR0ZGRkSKyvyOPx4OzsDAsLCyxbtgxA6XyHFshtwbp27VpMnToVCQkJyM7Oho+Pj8S6nQ4ODnBycuK+dS0pJmmv5fw4OztDXV0dK1asQEJCAr5//y7xOCgqKsLV1RUDBw4szCYXWsOGDbFixQq4u7sjOTkZSUlJeTbAsLW1xfLly0ullJH8GSjZK4N69OiBjh07wtfXF/fv30dAQACio6ORnJwMRUVF6OjowNzcHHZ2dujYsaNU3VAoKSlhwYIF6Nu3L86ePYunT58iKioKqamp0NbWRp06ddC2bVt07NixyJXuC0NRURHu7u7o3r07Lly4gDdv3iAyMhJpaWnQ1NSEoaEhmjZtii5duhSp5WVJLF9FRQWenp7YsmULHj16hISEBGhqaop91k5OTg4TJkxAt27dcPr0aTx+/Bjh4eH4+fMnVFVVYWJiAjs7u0J1oltcPB4PLi4u6NSpE06dOoVHjx5x26+rqwtLS0t069ZN6o5WO3XqxCV7Rfk8Wn5q1aqFo0eP4urVq/Dx8cG7d+8QHx8PxhgMDQ1hbW2Nrl27Fvu1cWFoaGhgw4YNXKnt8+fPERMTg/T0dGhqasLMzAwtW7ZEly5duI/VC8TExIh8a3nEiBGoXr16nuuaN28e+vXrh/T0dLx+/RoHDhyQ+Ak1KysrHD9+HPv378ft27cRFRUFZWVlmJubo2PHjnBycirytdu6dWscPXoUhw4dwuPHj/Ht2zdkZ2dDTU0NRkZGqFevHrp16wZzc3PExMRATk4OOTk5uH37Ntzc3EolAbeyssLRo0dx+PBhPHjwAOHh4UhPT4eamhoMDQ1hYWEBJycn8Pl8ZGRkQENDA0lJSXj27BmioqK4+rSA9NdyQdq1awc7OzucPn0a9+/fR2BgIBISEqCsrAwTExM0adIEPXr0+G3XeZs2bWBlZYWzZ8/Cz88PgYGBSEpKgpKSEvT19VG/fn20a9cOzZo1+y3xkLKLx0qr7TwhpNw4d+4c97px/vz5Yq8kSekYM2YM14jm/PnzhS61I4QQgBpoEEKkIKiTqKKiUqROvwkhhMgOJXuEkHwFBgZyjVnatm1b6l9VIYQQUrIo2SOEiEhJSeFavwYGBmLWrFnc37+jcQkhhJCSRQ00CCEizp07hy1btkBJSUmkG4t27drBwsJChpERQggpCkr2CCEiBH0RCncaa2JiglmzZskwKkIIIUVFr3EJISJq1qyJWrVqQUlJCQYGBujRowd27doFHR0dWYdGCCGkCKjrFUIIIYSQcoxK9gghhBBCyjFK9gghhBBCyjFK9gghhBBCyjFK9gghhBBCyjFK9gghhBBCyjFK9gghhBBCyjFK9gghhBBCyjFK9gghhBBCyjFK9gghhBBCyjFK9gghhBBCyrEiJ3vW1tawtrbGuXPnCpz23Llz3PTlmWAbHz16VKrr8fDwgLW1NUaMGCEyvHPnzrC2tsbp06dLdf3k91q4cCGsra0xf/58WYdSZKmpqYiIiBAZJrgvdOzYUUZRlY7MzExs27YNXbp0gZ2dHdq2bQsPDw9Zh/XbREREcPfC0NBQbnh+xzs2Nhbz589Hu3btYGdnhw4dOuDBgwcAgAsXLqB///5o2rQpWrZsiYkTJ/62bfldsrKyEBwcLOswiiUhIQGxsbEiw/L6rZKVkr7npKSkYPfu3Rg4cCCaN2+OJk2aoGvXrli8eDG+fPlSIusoKVSyRwgpVZcvX0aPHj1K/SGorNiwYQN27dqFiIgIVKlSBRUrVoShoaGswyqzcnJy4OrqisuXLyMhIQE1atSAhoYGDA0NcfPmTSxcuBABAQHQ0NCAiYkJqlatKuuQS9TDhw/Rp08fXLx4UdahFNmhQ4fQvXv3MpfglKbo6GgMGjQIW7duxcePH6GhoQFjY2NERkbi7NmzGDhwYJk6pgqyDqA8OXHiBACgcuXKpbqePn36oH379lBRUSnV9RBSErZu3Yro6Gix4Q4ODrC0tISCQvm6DV2/fh0AMGzYMLi6uso4mrIjr+MdHByMgIAAAMDGjRvRtGlTbpygRLRBgwbw8PAod+cKAHh7e//xpXrr1q2TdQi/3Zw5cxAcHAwDAwMsX74cfD4fABAXF4clS5bA19cX7u7uqFGjBiwsLGQcLZXslajq1aujevXqqFChQqmuR0dHB9WrV6fSAvJH09DQQPXq1WFsbCzrUEpUfHw8AJT7aiuFldfxFuwvAGjUqJHEcQ0aNCiXiR75Mz1//hwvX74EkFvNRpDoAbm/zytXrkTNmjWRnZ2N/fv3yyhKUZTsEUJICcrJyQEAKCkpyTiSP0N2djb371/3Ge1LUhbdv38fAFC1alU0adJEbLySkhLat28PAPj48eNvjS0vZeJRKTo6GocOHcK9e/cQEREBOTk5GBsbw8HBAf3794eGhgYAgDGGTp06ITo6GkuXLhWrZHnp0iX8+++/AICjR4+iVq1aIuPXr1+PgwcPom/fvpg5c2aBcQUGBmLfvn14+/YtIiIiIC8vDyMjI9jb26N///7Q1dUVmV7wJL9t2zY0btwYQG6FUHd3d3Ts2BGzZ8/G7t27cePGDcTExEBHRwctW7bEhAkToK6ujoCAAHh5eeHZs2dITk5G1apV0aNHDwwYMAA8Ho9bj4eHB3bu3AkrKyvs3r1bqn3s7++P48eP48WLF4iJiUF6ejo0NTVhYWGBrl27om3btiLTC+Ju3749+vbti1WrViEwMBBaWloYMmQIBg4cWOA6Y2JicOzYMTx69AihoaFITk6GmpoaqlWrhtatW6N3794ir6IjIiLQpUsX6Onp4eDBg1iyZAmePn0KZWVlNGnSBMuXL+emff78OY4cOYKXL18iISEBmpqasLS0RL9+/WBrayvVPvnV7du3cerUKbx//x5JSUnQ0dEBn8/H4MGDRYrhGWMYP348njx5Aj09PRw/fhxaWloiy1q4cCEuXLgAAwMDHD58GDo6Otxx69+/P4YOHYrNmzfj4cOHSE5ORpUqVdC+fXuR810axdnHV69exdmzZ3Hq1CkEBgYCAGrWrIkePXqgS5cuIuecQGHOI8H2CixduhRLly7FmDFjMHbsWO4cq1ixIi5fviy2rsePH+P48eN49eoVEhISoK6ujrp168LZ2RmtW7cWm75z58749u0bTpw4gR8/fmDv3r14+/YtUlNTUaVKFbRr1w5DhgyBqqqqyHzZ2dk4deoUrl+/juDgYCQkJEBLSwv16tVDt27d0KJFC6mOhWD9AmPHjgWQe1/YuXMntz+GDh0KS0tLbN68GREREdDX14erqyscHR0BAGlpaTh58iSuXbuGwMBAZGZmwsDAAHZ2dhg0aBBMTExE1vv06VOMHTsWVlZW8PDwwP79+3Hx4kVERERAQ0MDdnZ2cHV1hYGBASIiIuDh4YGHDx8iMTERFStWRIcOHTBq1KhCJ1QfP37Evn378PLlS8THx8PIyAi9evUSeQ0r7NfjLTgXhQnuoZ07d8aFCxe44Tt37uTOpWfPnnHDf/78icOHD8PHxwehoaHIyclB1apV0bp1awwcOFDsWpL2vpadnY1Lly7hwoULCAgIQGpqKgwMDNC4cWMMGTJE7BgU5boSxCKwa9cu7Nq1C507dxYZLklpHvPv37/jwIEDuHv3Lve7V61aNbRv3x59+vSBsrIyN63gPifg4uLCDe/atavIcuPi4uDt7Q1fX19ERUVBU1MTDRo0wLBhw1C3bl2J2xkcHIyDBw/i0aNHiIqKgpKSEqpXr4727dujZ8+eeVZlunXrFo4dO4aAgABkZmbCwsICw4cPz3efvnnzBocOHYK/vz8iIyOhpKQEU1NTtGrVCn369IGamho3rbOzMywtLfOtSiUYp6iomO96fxeZJ3uPHz+Gm5sbfv78CQUFBdSsWRNZWVn4/PkzAgICcObMGfz3338wMzMDj8dD8+bNcfLkSTx8+FAs2ROuAP7kyROxZO/u3bsAgJYtWxYY1+vXr+Hi4oLU1FRoaGjA1NQUGRkZ+Pz5M/z9/XHhwgV4e3tLXT8vLi4OgwcPRkhICKpVq4bKlSsjJCQEx44dw8ePHzFs2DDMmjULcnJyMDU1RWxsLIKCgrB+/Xr8+PGjWHV/jh8/jtWrVyMnJweampowMjJCeno6IiIicP/+fdy/fx8jRozAhAkTxOYNCgqCq6sr5OTkUKNGDQQFBaFGjRoFrvPNmzdwdXVFUlISlJWVYWRkBENDQ4SHh+P169d4/fo1fH194eHhAXl5eZF5MzIyMGHCBAQHB6NmzZqIjIxElSpVuPGbNm3C3r17AQCampowMzNDdHQ0fH194evri6FDh2LSpElS75+srCwsWrSISzh0dXVRu3ZthIeH4+rVq7hx4wamT5+Ovn37AgB4PB7c3d3Rr18/fP/+HWvWrMHSpUu55V27dg0XLlyAnJwcFi9eDB0dHZH1RUdHY/DgwYiJiYGJiQn09PTw5csXeHh44Nq1a9i6dSsqVapUqvuYMYaFCxfi4sWLXMX38PBwvHnzBm/evEFQUJDYPizseVS5cmVYWVnhw4cPyMjIgLGxMXR1daW6ZlavXo2jR48CALS0tGBubo7o6Gg8ePAADx48QLt27bBkyRKJN9LTp0/j0KFDUFJSgomJCRITExEUFARPT088fvwYnp6e3P5gjGHOnDm4efMmAMDY2BgVK1bEt2/fcPv2bdy+fRujRo3C+PHjC4y5bt26qFixIl69egUg9wdeXV1d7D70/PlzHDhwAJqamqhevTq+fv0Kc3NzAEBUVBRcXFwQFBQEADA1NYWqqiq+fv2KkydP4sKFC1i0aBFXaiAsPT0dY8eOxatXr1C1alUYGRkhODgYFy9exMuXL7Fo0SJMmTIF6enpMDU1hYKCAsLDw7Fr1y6EhYWJPEwV5NKlS3B3d0dWVhY0NTVRs2ZNREREYNWqVVK/vlZSUoKVlRV+/vzJVey3srLittvKygqfP39GcnIyKlWqJHbeBAYGYtKkSVxCUrVqVaioqODLly/w9PTEhQsXsHnzZlSvXl1s3fnd11JSUjBjxgzu96RixYqoWrUqQkJCcPr0aVy6dAlLly6V+MBRmOtKT09P4jaamppKeRRK/pi/fPkS06ZNQ0JCAhQUFGBqagrGGD58+ID379/j0qVL2Lx5M/T19UWO06/nvJ6enshyY2NjMXDgQERFRcHIyAgmJiYIDg7GzZs34evri82bN4s9pF+6dAlLlixBRkYGlJWVUatWLaSkpODt27d4+/Ytzp07h02bNondK1euXInjx48DACpVqoQqVarg7du3mDhxYp7n5q1btzB79mxkZ2dDW1sbNWrUQHJyMt69e4e3b9/i8uXL8Pb25hI+IyMjGBkZ5XlcMjIycP78eQBlqDoHKyI+n8/4fD47e/ZsgdOePXuWm15YREQEa9asGePz+Wzq1KksNjaWGxcaGsqGDRvG+Hw+69SpE0tMTGSMMXbv3j3G5/NZ+/btxdbj6OjIrWfq1Kki44KDgxmfz2ctW7ZkGRkZBcY8ZMgQxufz2erVq1l6erpIXN27d2d8Pp8tW7ZM4j7x8/OTuO3t27dnb9++lTiuUaNGbO7cuSwpKYkxxlhmZiZzd3dnfD6fNWnShKWmpnLz7dixg/H5fDZ8+HCR9Ts5OTE+n89OnTolst22traMz+czLy8vkW2Pj49ns2bNYnw+n9na2rKEhASJsQ0dOpTb/3FxcSwnJyfffZeVlcW6du3K+Hw+mzZtmshyMzIymLe3N7fsO3fucOPCw8O54Q4ODuzLly/cPIL9cuLECe44Xrx4kZs3JyeHXb16ldnb2zM+n89Onz6db4zCNm3axPh8PuvYsSO7f/++yHYcPnyY2djYMGtra/bw4UOR+a5evSq2Hd++fWMtW7ZkfD6fbd26VWR6wXHj8/msVatW7NGjR9y4r1+/MmdnZ8bn89mECRNE5luwYAHj8/ls3rx5JbqPbWxs2KFDh1hWVhZjjLG0tDQ2f/58btyPHz+4+Yp6HjEm+bxk7H/nWIcOHUSG79u3j4vh6NGjLDs7mxt37do17p6xevVqievh8/ls0aJF3Dmbk5PDjh49yo27desWN8/9+/cZn89nbdq0YQEBASL7d9euXVwckZGRTFqC9Tx58kRkuPDxnz59OndfEeznrKws1r9/f8bn85mzszPz9/fn5k1KSmKLFy/m9vHr16+5cU+ePOGW27x5c3bv3j1u3KNHj5i1tTV3jxk/fjyLjo7m9otwTOHh4VJtX2hoKGvSpAnj8/ls3bp13LmQlZXFdu/ezS2Pz+ezkJAQbr68jrdw/L8aPXo04/P5bMeOHSLDU1JSWLdu3bh7vWCbGGMsJiaGTZo0ifH5fNa9e3eRe6c097U5c+YwPp/Pevfuzd68ecPNm5aWxrZs2cLdkz99+sSNK+p1JbyNv94v8lMaxzwqKoo5ODgwPp/PlixZwu0bxhgLCQnhfhNHjhwpFo+k3z7GRM/5zp07i+zPsLAw7p43ePBgkflev37NbGxsuFgE93/GGPv48SM334ABA1hmZiY37uLFi4zP57PGjRuzS5cuccMTExPZzJkzuViEz8Hs7GzWvn17xufz2d69e7njxhhj79+/Z23atGF8Pp/t3r07nyPyPxkZGWz69OmMz+ezFi1asIiICKnmK23FrrPn7u7O9amU1395FUl7e3sjJSUFNWvWxKpVq0SeBoyMjPDff/9BT08PkZGR3FO+jY0NVFVVERsbi0+fPnHTf/nyBTExMWjQoAHk5OTw/Plzrr4H8L9SvWbNmklVrCpYdteuXUWKuo2MjDB16lQ0b9680K1up0+fjn/++Yf7u0uXLjAwMAAAGBoaYvHixVBXVwcAKCgoYPTo0QByn94ET/qF5efnB3l5eVhYWGDkyJEi266lpYUpU6YAyL+fJxcXF+51iLa2tsTXe8ICAgKQkJAAJSUl/Pvvv9DU1OTGKSoqYtiwYVz3CZ8/f5a4jN69e3NP2oqKilBXV0dmZibXOm/BggXo1KkTNz2Px0P79u0xefJkALmvELOysvKNEwB+/PiBQ4cOAchtUSb8CkpeXh79+vXDoEGDwBjDtm3bROZt3749F8OKFSuQlJSEBQsWICkpCVZWVhgzZkye63V3dxd5kq1evTrWrVsHOTk5PHz4EG/evMk37pLYx7169UL//v25Ui5lZWVMnz4dPB4P2dnZePv2LTdtSZxH0khPT8euXbsAAOPGjUOfPn0gJ/e/21S7du24/gaPHz8u1ncfANSuXRsLFizgzlkej4c+ffrAzMwMALhSCABcK9D69etz44HcYz9ixAi0bdsWHTp0QGJiYpG3SZIpU6Zw9xVBye+NGzfg7+8PZWVlbNq0CbVr1+amV1dXx7///oumTZsiKytL7FwUGDFiBOzt7bm/bW1tYWlpCQCoUKECVq1axd1zeDweRowYwR1LaesW7du3D+np6bC2tsa0adO4+eXl5TF8+HCx13el4fTp0wgNDUWdOnWwZs0abpsAQF9fH6tWrYKhoSFCQkK4EpZfSbqvBQQE4OrVq1BRUcGWLVtQr149bnplZWVMmDAB7dq1Q3p6Ory8vCQutzDXVUkoqWO+f/9+JCQkoGXLlpg/f77IK3BjY2OsX78eampqePHiBVdnrTCWLl0qsj+rVq3K/ca9f/8e6enp3DgPDw9kZ2fDzs4O8+fP534XAcDc3BybN2+GsrIyPn78iGvXrnHjBPeOESNGiLz509DQwNKlSyWWmsbFxXH9Azo7O4u8BbGwsICLiwtatWolVlVHkrS0NEyfPh0+Pj5QVlbGmjVrykxDymIneyYmJrCyssr3v1/rNwgIErDevXtLTMA0NTXRrVs3ALn1qYDcon87OzsAuf0TCQiK3B0cHFCzZk0kJSXB39+fG3/v3j0A0r3CBcC1GFu+fDkeP36MzMxMblyLFi2wcePGQnUUyePxxOqy8Hg87kSws7MTe9UmKCoHgOTkZKnXJaxPnz548OBBnjcm4ToHqampYuPl5ORQv379Qq3TwsICt2/fho+PD7S1tcXGZ2RkcBdOWlqaxGU0aNBAbNirV6/w/ft3qKmpoVWrVhLn69ixI+Tk5BAdHS3Vj9e9e/eQkZGRb/N4QUL37t07/PjxQ2TcrFmzYGhoiKioKAwbNgzPnj2DhoYGli1blmfrQWNjY4n1wKpXr8616hKc73kpiX0sKQZtbW0u+UhKSuKGF/c8ktaLFy+QlJQEeXl59OnTR+I07du3R8WKFZGdnc3dQ4Q1a9ZM4gNJtWrVAIhul+DedO/ePezevRuRkZEi86xatQqLFy8WSQSLS09PT+IroDt37gDIPS55vSIS1Cl79uyZyHYINGvWTGyY4B5jZWUlVodNUVGRO3+kvccI7qW/1rcT6NWrl1TLKQ7B9eHo6Ch23wRyz8c2bdoAgMRzJK/7mo+PD4DcV28VK1aUuG7B/eDBgwcijUsECnNdlYSSOuaCbc+rw2E9PT3ut1dwrkpL8Mr6V4LrijGGhIQEALn3j6dPnwIABgwYIHF5VatWhYODA4D/nQthYWFcoYikc1NRURHdu3cXG66trc09LM+bNw+vX78WKSjq0aMH1q1bhx49euS7jYwxzJo1C/fv34eqqir++++/ItcfLw3FrrMnzZPcrxVRgdyTTND3Vn590AjGCZcWtGjRArdu3YKfnx+GDBkCILfkAch9qgkPD8enT5/w5MkTWFhYIDk5GS9evICSkpLIE1B+Jk+ejClTpuDt27cYP348VFVV0bBhQ9jZ2aFZs2Z5JrB5UVdXF3k6ERAkub/W6xIeB+SeSMWhrKyMt2/f4suXLwgLC0NYWBg+f/4sUmIoaR0aGhpF7s9PRUUFISEheP/+PcLCwhAeHo4vX77g8+fP3FNcXtslnOgKCOr1ZGZmYtSoUXmuV05ODjk5OQgKChJ5kpREsMyoqKg8k3fhGIOCgkQa5qirq2PJkiUYM2YMty/nzZuX79OccOnur8zMzPD06VOEhITkG7dAcfZxXj9mggrYkn7IinoeSUuwHBMTE4nXC5D7kFSnTh1ER0dLLEUULuX5NXZAdLtatGgBa2trPHv2DFu3bsXWrVtRrVo1NG7cGE2aNIGtra1IhfSSkFd8gm2X5n6YnZ2NsLAwsWkl1fXM7x4DgHsokea4paWlISoqCgDE6iIK1K5dGzwer9j3rPwISqtPnz6d54PR9+/fAUDiW5G87muC+8GHDx/yvB8IrivBb9iv13pRrqviKIljnpKSwjUu8vT0xOHDhyXOJ5imsG+a8tonwo2lBPs1LCyMK1wp6Fq4cuUKF4vgXqCmppbn/Ve4tFxAXl4erq6uWLZsGVf3WFNTE40aNeJ+76WpQ3369Gncu3cPKioq2LZtG1e6WlbIrIGG8BNFXjd1AFyFyJSUFDDGuEYa8vLyePnyJdLS0iAvL4/nz59DW1sbZmZmsLGxwbFjx/DkyRMMGTIEDx8+RGZmJuzt7cVa4uWladOm2L9/P/bu3Yt79+4hOTmZOxHWrVuHBg0aYN68eVI1VgBQYN97wq+qStqlS5fg6ekplkBUrVoV3bp1y/fzakX9oXvz5g02b94s0nIOyH2Ksre3h7+/P8LDw/OcX9KN+OfPnwByS62EX8XlRZonaMEyk5OTi7xMCwsLGBgYICoqCgoKCgWeE/m9DhCcn9LEXtx9XFB1hl9/rItzHklLcF/I754A/O++IKk0qjDbpaCggK1bt+Lo0aM4f/48l7gGBQXh6NGjUFNTw9ChQzFixIgCqy9IK69rSpptF24RKGnb87vPlET8wudlXutSVFSEiopKsUp4CyK4bkNCQgp8MJJ0LeV1DATL/fHjh1gpfn7TCyvsdVVcJXHMhbdDmq9gFLZ0sjAtvYuSGwDgqlrkVzghXN1FWI8ePWBiYsK1/E1MTMStW7dw69Yt8Hg8NGvWDHPmzMk36RN8OnbgwIFlLtEDZJjsCSddki4YAcEBVFVV5U5cbW1t1K9fHy9evMDz58+hpKSE1NRU7vWNjY0NlwxmZWVxrx3yevWXF3NzcyxfvhyZmZl4+/Ytnj59ikePHuHVq1d4+fIlxo8fjzNnzpR6J8rFcf78eSxatAhAbgIreM1dvXp1aGpqIjMzs8S/pRsYGIixY8ciPT0dNWrUQNeuXVG7dm1Ur16de8IbMWJEvomIJIL9bGFhgQMHDpRIrIJltmnTBqtXry7SMjZu3IioqCjIyckhKysL//77L/bu3ZvnTT+/H0HBtfBrtz6/Kq19nJffdR4J7gv53ROA/90XhJOfolJUVMSgQYMwaNAgREVF4enTp3j69Cnu37+P79+/Y9u2bVBWVsagQYOKva78SLPtwj+yJbHthSX8oJLXa1/GGDIyMko1jgoVKuDnz5/YsGGD1F3jSEOQKAwaNAhTp04tseWWdcK/YZK6LfudhM/rnz9/5nkvFFwLgutGcG4Kkj9JhOsF/qpRo0Zo1KgR0tLSuNzi4cOH+PDhA+7evYuoqCgcOnQozwT669evAAqfZ/wuMutUWV1dnXud8eHDhzynE4z7tdd1wQXu5+fHvd8XvB/X0NBAnTp1kJKSgjdv3uD+/fvg8XhS3xSys7MRGhqK58+fA8j9MWjYsCFGjx4NLy8veHl5gcfjITY2tsx/79Pb2xsA4OTkhM2bN6NHjx6wsrLinnAkfcaquA4fPoz09HRUq1YN+/btw+DBg9G4cWORonzBq6DCEFSuDQkJybPxBWMMT548QUhIiEg9y4KWmd/TbGpqKp49e4awsDCxVzAPHjzA8ePHIScnh40bN0JfXx/+/v7Yvn17nsvLb12CeqYFlQ6W1j7Oy+86jwT16kJCQvJMenJycrj9VNyvbyQmJuLNmzdcXb1KlSrBycmJ6z5DcM+4dOlSsdYjDcG253c/fP/+PYDcEpv8un4oLUpKStwrMuE60cKCgoJK/FXlrwTXreAHVhJB9Ya4uDiplys4BvktNz4+Hi9fvsS3b99K9VX176ShocE1kMxv2z99+gR/f/8Sb7AkzMjIiHvNLM21IKhSJTh2qampeTYSk3TvzczMRGBgINcoTkVFBU2aNMGECRNw4MABrnuagIAAkUahv1JRUYGenp7EOtRlgUy/oNG8eXMAua3qJP0wJyYmch02/lrXTpA9+/n5ca+xhCtDCjo13rNnD378+AFLS0uJ9cAk+fLlC7p3745x48ZxrXSE1a9fn3uaEK7IWRYJWivmVffhzJkz3L9L6gYtKE3K69Nxfn5+3I+rNC1mBfh8PtTV1ZGcnMwVmf/q8uXLGDduHHr27ClW2V6SZs2aQV5eHkFBQVy9z18dOnQIY8aMwYABA0RK5eLi4rjSroEDB8Le3h6zZ88GkNuyTfCw8Kv3799LvGl8+vSJe5UsqFyel9Lax3kpznkkqKIgzQ9jgwYNoKmpiezsbBw7dkziNFevXkVsbKzERk+F5e7ujmHDhnH9NgpTVFTkGsyUdvIC/O8B9s6dO3mWyApajtevX79QnW+XJEH/cqdOnZK4X0r6TYEkgn115swZiQ2QsrKyMG3aNAwePBgbNmyQermC36RHjx5xHSL/avPmzRg5ciTGjh1bIvd/QUmRrBNHQUOPo0ePStyupKQkjBs3DgMGDODOQ4GS3IYKFSpwn837dT0CYWFhXCMRwT2gSpUqqFOnDoD/fadeWE5OjsTfjfv376NXr16YPHmyxBJpQS4B5H8fuHbtGq5duybSJ2xZItNkb+jQoVBTU8OXL18wa9YskToS4eHhmDx5Mr5//46KFSuKtcoxMTGBqakpvnz5gtevX6NKlSoiT7o2NjYACt8KF8itxFmrVi1kZ2dj7ty5IiUkmZmZ2Lp1K5KTk1GhQgU0bNiwSNv+uwiedk6dOiVS+vLz5094eHhgz5493LC8Wm0WdZ1+fn548eIFNzwrKwtXrlzBnDlzirTOChUqcL2gr127FufOnRO5Kd2+fRsrVqwAkNtFhzSlPoaGhlwLrblz54q0MsvJycHp06e57l569+4tUodk2bJl+P79O0xNTblOdx0cHODo6IicnBwsWLBAYukUYwxubm4iT5mfPn3C9OnTwRhD586dJXYEK6y09nFB6yvKeSRIRqVJvoWP8Y4dO3Ds2DGRY3zz5k3uSbtHjx6F6oBWEicnJwDAyZMncfHiRZEfqy9fvuDIkSMAxB82S0Pbtm1hZmaG9PR0uLq6ct3CALmvTJcuXcp1gVOcTtaLa8iQIdDS0sKHDx/g7u7Ovc5ljOH48ePcPitNffr0gb6+PkJDQzFt2jSRL5fExcVh9uzZCAwMhKKiIgYPHiz1chs2bIimTZsiOzsbkyZNEqnHm5GRAS8vL+7BZujQoRJbAheWoOBAeBtkYfjw4VBVVcXLly8xf/58kRLRb9++YfLkyYiPj4e6urpYS/mS3oaxY8dCXl4efn5+WLp0qUiVgYCAAEyaNAnp6emoXbs2OnfuzI2bOHEiAODIkSM4dOgQd+9ITU3F0qVL8e7dO7F12dvbQ1tbGwkJCVi4cCHXKhjIfSUseFioVKlSnq+3BaWDgYGBJd7auqTI9AsaRkZGWLVqFWbNmgVfX1/cv3+f+4JGYGAgcnJyULlyZaxdu1Ziq6KWLVti3759yMrK4pI7gQYNGkBZWZl7R1/Y9+grVqzA8OHD8ezZM3Tt2pXrnT0iIoLrGmLevHl5tnYqK1xcXDB9+nR8/foVXbt25X4cQ0NDkZ6ejqpVq4LH4yEsLKzEXvsNGjQIV65cQXx8PEaNGgUTExOoqakhPDwciYmJUFVVRf369fH69etCv/4bOnQowsLCcPr0abi7u+O///5D1apVER0djZiYGAC53Q0IPpsnjenTpyM6Ohp3797F1KlTYWBggIoVKyIiIoK74bVp04b7FBCQW6Lg4+MDOTk5LFq0SKTCt5ubG548eYJv375h9erVWLx4scj6KlWqhPj4ePTt25d7Xfv161cwxmBjY4MZM2YUGHNp7mNJinMemZub4/Pnz9izZw/u3buH1q1b59uaevDgwQgPD8eJEyewatUqeHh4iB3jNm3aYPr06cXertatW8PZ2RmnT5/GggULsGHDBlSuXBk/f/5EWFgYGGP4559/MHLkyGKvqyAKCgpYv349XF1dERQUhP79+4t8QSM9PR3KysqYO3euTB8y9fX1sXLlSsyYMQMXL17ErVu3UKNGDURFRSE2NhYtW7bEvXv3SrU0VFNTExs2bMCUKVPw6NEjdO3aFdWrV4ecnByCg4ORkZEBeXl5LF++vNDd5ixZsgSTJ0/G27dvMWLECFStWhWampoICwvjfsgHDBiAnj17lsi2mJub486dO7h8+TI+ffqEhg0bcm8IfidjY2OsXLkSc+bMwdWrV3Hz5k3UrFkTmZmZCA4ORnZ2NipUqIBNmzaJ1aMzNzfH8+fPsXr1apw8eRK9e/fmuk0rivr162PBggVYunQp99WSGjVqICUlhXtFW6tWLaxdu1ak8UeTJk0wadIkbN68GevWrcOePXtQuXJlBAUFITk5GQ4ODlwXMwKKiopYtWoVJk6ciGvXrsHX1xdGRkaQk5NDWFgYUlNToaKiAnd39zzrYcfExHBdDkn6VFxZINOSPSD34Bw/fhwDBw5E1apVERQUhKioKJibm2PixIk4cuRInq+OhEvrfu3PRklJieurrVq1alzJhLRq1KiBgwcPolevXqhatSoiIyMRGBjI9f13+PDhPPsjKktatGiBffv2oVWrVtDT00NgYCAiIyNRq1Ytbv8KtkNSf1RFYWhoiCNHjqBXr14wNTVFVFQUgoKCoKenh759++LIkSNc4vT06dNCtdrj8XiYP38+tmzZAgcHB8jLy+Pjx49ISUmBpaUl3Nzc4OHhUahGM8rKytiwYQNWrFiBpk2bIjMzEx8/fkR2djYaNWoEd3d3rFy5knuKDwsLw7p16wAA/fv3F+uvS0dHh/v28sWLF0U6/QRyPyO2b98+tG3bFjExMYiMjETdunUxd+5cbNmyRarXc6W5jyUpznk0depUtGnTBhUqVEBQUFCer8cEeDwe5syZgy1btqBVq1aQl5fn6oe1aNEC69atw+rVq0usS5S5c+di4cKFaNSoEXJycrgOqxs0aIBZs2Zh165dv60xRJUqVXDgwAFMnjwZ//zzD2JjY/H161dUrlwZ/fv3x5EjR0RKMmTF1tYWBw8eRI8ePaCtrY1Pnz5BRUUFY8eOxapVq35LDHXr1sWxY8cwevRomJmZ4du3bwgMDISuri6cnJxw8OBBiZ80K4i2tja8vLwwb948WFtbIykpCQEBAVBQUIC9vT3Wr19fIg8aAkOHDkX37t2hpaWFkJCQfOuFlTZ7e3scO3YMAwcOhLGxMYKCghAaGooqVaqgd+/eOHr0qMT+8hYsWIDGjRtzVWKK07G6QOfOnXH48GE4OztDX18fX758QXx8PKysrDBr1izs27eP6zhe2NChQ+Hh4cG96v/8+TNMTU2xfPnyPL/p3qhRI+zduxdOTk7Q19dHSEgIQkNDUbFiRfTt2xcnTpwQK1D60/CYrCsKEPKX8PDwwM6dO2FlZYXdu3fLOhxCCCF/CZmX7BFCCCGEkNJDyR4hhBBCSDlGyR4hhBBCSDlGyR4hhBBCSDlGDTQIIYQQQsoxKtkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjhBBCCCnHKNkjRAiPx0OrVq1Ehg0bNgw8Hg9BQUEyiam82rNnD3g8Hvbs2SPrUP5qixYtAo/Hw+3bt2UdikyVh/1A1xTJCyV7f4ghQ4aAx+OhcuXKyMrKknU4REpBQUHg8XgYNmyYrEP5K0lK3v82dA6WH3QsSVFRsvcHSExMxMmTJ8Hj8RAVFYWLFy/KOqS/yooVK/DhwwdUrVpV1qEQQkienJ2d8eHDBzg7O8s6FFLGULL3Bzh8+DBSUlIwffp08Hg87Nq1S9Yh/VUMDQ1Rp04dKCoqyjoUQgjJk5aWFurUqQMtLS1Zh0LKGEr2/gC7du2CkpIS5syZA3t7e1y6dAnfvn3jxgcHB0NOTg5t2rSROH9aWhq0tLRQq1YtkeEZGRlYv349+Hw+1NTUoKGhgebNm+PcuXNiyxDUW/v69Ss2bNiAf/75B8rKytzrhIiICCxcuBB2dnaoWLEilJWVUa1aNbi4uCA6OlpiXEFBQejbty90dXWhrq6Oli1b4s6dO/nWnblz5w66dOkCfX19KCsrw8zMDPPnz0dKSoqUezOXl5cX6tWrBxUVFRgbG2PmzJlIS0uTOG1edfZOnjyJli1bomLFitxyOnTogDNnzgDIrT9TvXp1AMDevXvB4/G4/wTbVtj9JhzLtm3bYGFhARUVFZiamsLd3R05OTkSt+HcuXNwdHSEnp4eVFRUUK1aNQwePBhv374Vma4w50RCQgIWLFiAunXrQl1dnfuhGT58OEJDQ/Pb/WJOnz4NGxsbqKqqonLlyhg/fjzi4uIkThsYGIhRo0bBxMQEysrKMDQ0xLBhwxAcHMxNc/v2bfB4PACAr6+vyL7fs2cPXr58CR6PhylTpogs+/jx4+DxeFBTU0NGRobIuMqVK8PCwkJkGGMMu3fvhr29PTQ1NaGqqopGjRph9+7dEmMvzPTC18GxY8fA5/NRoUIFGBoaYtKkSUhNTS1wv0pzDgorzHpK6lp8/fo1+vXrB0NDQygpKcHU1BSurq74/v07N01MTAwMDQ2hpaWFr1+/iswfHR2NSpUqQVtbW+QcELzCDw0NRd++faGnpwc1NTW0atUKDx48kDq+3bt3o1u3bqhWrRpUVFSgq6sLR0dH+Pj4iE0rOO8WLVqE58+fw9HRERoaGtDS0oKzs7PEer+nT59G//79UatWLaiqqkJLSwvNmzfHyZMnRaaT5ljmV2fvwYMHcHJygq6uLlRUVFCnTh0sWrRI4vES7LuYmBiMGDECFStWRIUKFWBnZyfxvPn27RsmT54MMzMzVKhQAbq6urC0tISLiwsSExML3smk9DFSpr1+/ZoBYM7Ozowxxnbu3MkAsBUrVohM16JFCyYnJ8fCwsLElnHkyBEGgC1cuJAblpaWxlq1asUAsIYNGzJXV1c2btw4ZmxszACwzZs3iyxj6NChDADr1KkT09XVZYMHD2YzZ85k69atY4wxdvjwYaampsa6du3KJk2axKZPn85at27NALAaNWqw+Ph4keWFhYUxQ0NDbplz5sxhPXr0YMrKyqxDhw4MAPPx8RGZZ/v27YzH4zFdXV02dOhQNmPGDNayZUsGgDVt2pSlp6dLtU8XL17MALBKlSqxiRMnsqlTpzITExPWuXNnBoC1bNlS4rYHBgZyw7Zt28YAMENDQzZmzBg2Z84cNmzYMFa3bl02dOhQxhhjL168YJMnT2YAmJWVFVu4cCH3n2BZhd1vglh69erF9PX12bBhw9ikSZOYiYkJA8Dmzp0rtr1ubm4MANPV1WUjRoxgs2fPZgMHDmSVK1dmGzZs4KYrzDmRk5PDGjduzAAwe3t7NnXqVDZ9+nTWs2dPpqWlJXbsJPH29mYAmJOTE1NSUmIDBw5ks2fPZk2aNOH2WUpKisg8fn5+TEtLiykoKDBnZ2fm5ubGevfuzRQUFFjFihXZly9fGGOMBQYGsoULFzIAzNTUVGTfv3jxguXk5DBdXV1Wv359keW7uLgwAAwAu3PnDjf8/fv3DAAbP368yD4YMGAAA8Bq167Nxo4dy1xdXVmdOnUYADZ9+nSRZRd2ekH8vXr1YmpqamzAgAFs6tSpzMLCggFgAwYMKHAfS3MOFmU9JXUtnj17likrKzNVVVXWr18/5ubmxpycnBgAZmZmxn78+MFNe+3aNcbj8Vjjxo1ZZmYmt087duzIALDDhw+LLBsAq1+/PjM2Nma2trZs9uzZbPDgwUxJSYkpKSmJnaOC/fDrcBUVFda4cWM2cuRIbhkaGhpMTk6OnTlzRmRaHx8f7pxWVVVlnTp1Ermma9asyVJTU0XmMTc3Z5aWlmzo0KFs9uzZbOTIkczAwIABYJs2bSrUsRRcU97e3iLrOHHiBFNQUGCqqqps+PDhbNasWcza2poBYE2aNGFpaWli+87KyoqZmZkxa2trNmXKFDZgwAAmLy/PlJSU2Js3b7hpk5OTWfXq1RmPx2OOjo7Mzc2NTZ48mXXp0oVVqFBB5L5JZIeSvTJOcHGfOnWKMcZYfHw8U1FRYWZmZiLTeXp6MgBs9erVYssQJDGfPn3ihs2dO5cBYIsWLWI5OTnc8MTERNaoUSOmpKTEwsPDueGCJMPIyIgFBweLrSMqKoolJSWJDd+7dy8DwJYuXSoyfNCgQQwAW7Nmjchwwc3q15vuu3fvmIKCAmvYsCH7/v27yDwrVqxgANjatWvF1v+rT58+MQUFBVa1alUWFRXFDU9ISGDm5uZSJ3t8Pp8pKSmx6OhosXXExsZy/w4MDGQAuATwV4Xdb4JYqlevziIiIrjhMTExTFtbm2loaIj80F68eJEBYJaWliJxMcZYZmYmi4yM5P4uzDnx60OIsLS0NInb9CvhY33jxg2RccOHD2cA2OLFi7lhGRkZrFq1akxDQ4O9fPlSZPq7d+8yeXl51rlzZ5Hhko6ngLOzM+PxeCwmJoYbZmFhwVq1asXk5eWZu7s7N3zr1q0MADt27Bg3TPDgNXLkSC75YIyx9PR01qVLFwaAPX36tMjTC5IPLS0t9vHjR254SkoKq127NuPxeCLXaF4KOgcLu56SuhZjY2OZpqamxHvKoUOHGAA2ceJEkeEzZswQeajZuHFjntsmOLcGDx4scj7fvn2b8Xg8VqtWLZadnS22H35N9r5+/Sq27IiICFalShWx+7Ag2QPAjhw5IjJu8ODBEpNSwQOKsKSkJGZpacm0tLRYcnIyN7ygYykp2UtMTGTa2tpMWVmZvXr1ihsu/PCxZMkSkeUItsHFxUVkH3l5eTEAbOzYsdywc+fOMQBs6tSpYvEkJiZKnfiT0kXJXhmWnp7O9PT0mI6OjsgF07dvXwaA+fr6csPi4+OZsrKyWElFTEwMU1RUZHZ2dtyw7OxspqOjw2rVqiVyExQQXLzCJTmCJOO///4r1Dbk5OQwTU1N1qpVK25YWloaU1ZWZpUqVRK7EeTk5HAlHcI33UmTJjEA7O7du2LryM7OZgYGBsza2rrAeNzd3RkArkRS2P79+wuV7KmpqbG4uLh811fQzTkvkvabcCy7d+8Wm0cw7vXr19ywTp06MQDs1q1b+a6vsOeEINmTpnQpL4Ifpnbt2omNCw8PZ4qKiqxmzZrcsFOnTkn8YRLo0aMHk5OTYwkJCdyw/JK9//77jwFgx48fZ4wxFhkZyQCwDRs2MFtbW5H5evXqxQCIPCDUr1+fqampiZXUMPa//SNcWlfY6QXJx4IFC8SmF4w7d+6cxG0TJm2yJ+16SupaXL9+PQPA9u/fL3E8n89n+vr6IsPS09MZn89ncnJybNOmTUxZWZnVrFmTJSYmis0PgMnLy7OQkBCxcYLSQ+FtyCvZy4urqysDwIKCgrhhgmSvRYsWYtMLxk2bNk2q5a9bt44BYLdv3+aGFSXZ27dvn1iptEBISAhTUFAQuc4Yy913ampqYg9tmZmZTEFBgfH5fG6Y4N4g6a0CKTsUQMqsM2fO4Pv37xg3bhyUlJS44UOGDMHRo0exe/dutGjRAkBuxdwuXbrgxIkTePPmDSwtLQEAR44cQWZmJgYPHszN7+/vj7i4OFSpUgXu7u5i642JiQEAfPz4UWycra1tnvGeOnUKHh4eeP78OeLi4pCdnc2Ni4iIEFl/eno6GjVqJLJdQG5dkSZNmoit28/PDwBw5coV3LhxQ2zdioqKEuP91atXrwAAzZs3FxsnaVhe+vTpg9mzZ6NevXro168fWrVqhWbNmkFbW1vqZQhIu9+E8fl8sWFGRkYAgPj4eG7Y48ePoaysjJYtW+YbQ2HPCQsLC1haWuLQoUMIDQ1F9+7d0bx5c/D5fMjLy+e/wb+QtN+rVKmCmjVr4uPHj0hKSoKGhgZ3Dnz8+BGLFi0SmycyMhI5OTkICAhAo0aNClyvg4MDAMDHxwe9evXi6mA5ODggMjISGzduRFpaGpSVleHr64t//vkHFStWBACkpKTgzZs3qFKlClauXCm27MzMTC7WokwvTNpjXVzSrqekrkXBcvz8/PD582ex8WlpaYiNjUVsbCz09fUBAEpKSjh8+DD4fD4mTZoEBQUFHDp0CBoaGhLXYWpqCmNjY7HhzZs3x8WLF/Hy5Us0a9Ys3zi/fv2KFStW4NatWwgPD0d6errI+IiICJiamooMK8wxi46OxsqVK3H58mUEBweL1ZHM6x4grRcvXgCAxC6IjI2NUbNmTfj7+3PXmYCZmRnU1dVFpldQUEClSpVEtqFFixaoXLkyVqxYgZcvX8LJyQnNmjWDpaUlV2+WyB4le2WYoNK2cKIGAI6OjqhcuTKOHz+OTZs2QVNTk5vuxIkTOHjwIPeDcuDAASgqKqJv377c/D9+/AAAvHv3Du/evctz/cnJyWLDKlWqJHHadevWYcaMGTAwMED79u1hZGSEChUqAAA2btwocoMUVNg1MDCQuCxJ6xDEvGzZsjzjlUZCQgIAcD/aBa03LzNnzoSenh527NiB9evXY926dVBQUECnTp2wceNGriJ1QQqz34RJam2noJB7OQsni/Hx8ahatSrk5PJvi1XYc0JBQQG3bt3CokWLcOrUKUyfPh0AoK+vD1dXV8ybN0/qpE/SsQByj8fHjx+RmJgIDQ0NLsaDBw/muzxJ560k9erVg4GBAZfk+fj4QE9PD/Xr10dkZCRWrVqFBw8ewMDAADExMSLXUFxcHBhjCA8Pl5gc/xpLYacXJu2xLi5p11NS16JgOVu3bs13uuTkZC7ZA3KTEEtLS/j5+cHW1jbfB9D8zi3gf/eDvHz+/Bm2trZITEyEg4MDunTpAk1NTcjJyeH27dvw9fWVeI0WZl/a2NggJCQE9vb2aNu2LbS1tSEvL4+XL1/i7Nmzed4DpCW43+Z1f6tcuTL8/f256yy/bRBsh/A2aGlp4eHDh1i4cCHOnz+PS5cuAchNbufMmQMXF5dixU9KBiV7ZVRoaCiuX78OALC3t89zuiNHjmDMmDEAgI4dO0JfXx+HDh3CihUr8OXLFzx69AjdunWDnp4eN48gOezZsydOnDhRqLgkPallZWVhyZIlqFKlCl6+fCmSxDHGsHr1apHpBesXlBb9KioqSmyYYJ5fb0iFJbiBRUdHiz2NS1pvXng8HkaNGoVRo0bh+/fvuHv3Lg4fPoxjx47h06dPePPmTYHJTmH3W1Foa2tzJV75JXxFOSf09fWxZcsWbN68GR8/fsStW7ewefNmLFy4EIqKipgzZ45Uy8mrtbbgeAhiE/z//Pnz6Ny5s1TLzg+Px0PLli1x4sQJREZG4vbt22jZsiV4PB6aNWsGRUVF+Pj4cAmDoCRQOBZra2s8ffq0wHUVdvqyrKSuRcFy3rx5g3r16kk935o1a+Dn5wc9PT08ePAAnp6eGD16tMRpCzq3CuqiZMOGDYiLi8OBAwcwcOBAkXHjxo2Dr6+v1HFLsmvXLoSEhGDp0qWYN2+eyLiVK1fi7NmzxVo+8L/9nNf97dfrrCiqVauGvXv3Ijs7G2/evMG1a9ewadMmTJgwATo6Oujfv3+Rl01KBnW9UkZ5e3sjJycHzZo1w8iRI8X+E5T2Cfe5p6ioiD59+iA0NBS+vr44cOAAAGDQoEEiy7awsICmpiaePn3KvT4qjtjYWCQkJMDOzk6stO7p06diryXMzc2hrKyMZ8+eiXVvwRjjXu8Ia9y4MQBIHFcYVlZWAIC7d++KjZM0TBp6enro3r07jh49itatW+PDhw/caylBwiepBKaw+60obG1tkZ6eXuCPUnHOCR6PBwsLC0yYMIF7QJHUVUteJO33iIgIfPnyBTVr1uQSCsE58PDhQ6mXLScnl2/pl+DV1sGDBxEQEIDWrVsDANTU1GBra4tbt27Bx8eHSwwFNDQ0YGFhgQ8fPkj1KrWw05ek/M7Boiipa7Eox/PZs2eYP38+LCws8ObNG5iammLKlCnw9/eXOH1wcLDEboAE51yDBg3yXd+XL18AAF27dhUZnpOTg/v370sdd2GXLxyjsKIcy4YNGwKAxC5TwsPD8eXLF9SoUaNYibtwfA0aNMDMmTNx+PBhAIW7F5DSQ8leGcQYg7e3N3g8Hvbt2wcvLy+x//bt24eGDRvi8ePHIn2lCZLAAwcO4ODBg9DW1kaXLl1Elq+goIDx48cjODgYM2bMkPjj/vbt2zyfin8l6IPp+fPnIn02xcXFwdXVVWx6ZWVl9OrVC5GRkdi0aZPIuH379uHDhw9i87i4uEBBQQGurq4Sb97x8fFc3ZT8DBgwAPLy8li/fr3I9iUmJmLp0qUFzi9w9epVsc/WZWZmcq+mBK9idXR0wOPxEBYWJraMwu63opgwYQIAYPLkyVxsAllZWdxTfWHPicDAQLx//15sGsHyBNsvjevXr+PmzZsiw+bPn4/MzEwMHTqUG9atWzeYmJhg/fr1uHPnjthyMjMzce/ePZFhurq6Eve9gKC0btWqVSJ/C/795MkT+Pj4wNLSUqR0HAAmTZqElJQUjB49WuLr18DAQJF+1Qo7fUnJ7xwsipK6FocPHw4NDQ3MmzdPYtWBlJQUkYQyOTkZAwYMAI/Hw6FDh2BoaIgDBw4gPT0dAwYMEHtwBHKTonnz5oExxg3z9fXFpUuXUKtWLTRt2jTfGAWl/7+eV6tWrRLro7Io8lr+oUOHuNehwopyLLt16wYtLS14e3uL7GfGGObMmYPMzMxifX7t7du3Iv0bChTlXkBKD73GLYNu3ryJoKAgODg45Fv3a/jw4Xjx4gV27dqFDRs2AADs7OxgZmaGffv2ITMzE6NHj4aysrLYvO7u7nj+/Dk2bdqEixcvomXLljAwMEB4eDjevHmDV69e4eHDh3nWeREmJycHFxcXrFu3DlZWVujSpQsSExNx+fJlmJqaokqVKmLzrFixAjdu3ICbmxt8fHzQoEED+Pv748KFC+jQoQOuXLki8tqxXr162LZtG8aPHw9zc3N06tQJNWvWRGJiIr5+/QpfX18MGzYMO3bsyDfWWrVqYcGCBVi4cCHq16+PPn36QEFBASdPnoSlpWWeJQS/6tu3L1RVVdGsWTOYmpoiMzMT169fx/v379G3b1+YmJgAANTV1WFjY4M7d+5g+PDhMDMzg5ycHAYMGAATE5NC77fC6tSpE2bMmIG1a9fCzMwMzs7OqFixIsLDw3Hz5k3MmDGD61i4MOfEq1ev4OzsDBsbG9SrVw+VK1dGeHg4zpw5A3l5ea4OnzScnJzQqVMn9O7dG8bGxvD19cXDhw9hZWWFGTNmcNMpKyvjxIkT6NixI1q2bIk2bdpwr/9CQkJw9+5d6OnpiTQOaN26NY4dO4ZevXqhYcOGkJeXh5OTE9eAqW7duqhUqRKioqJQqVIl1K1bl5vXwcEBS5cuRXx8vEjSKTB27Fj4+flh7969uH//Ptq2bYsqVaogKioKHz9+xKNHj3Do0CFUq1atSNOXlILOwcIqqWvRwMAAhw8fRu/evWFlZYUOHTqgTp06SEtLQ3BwMHx9fdG0aVNcuXIFQG6yHBAQgPXr13Mlcs2aNcPcuXOxZMkSzJ07F2vXrhVZR/369XH79m3Y2dmhdevWiIiIwJEjR6CoqAhPT88C67KOGzcO3t7e6NGjB9cxs5+fH54/fw4nJ6dif7py8ODBWLVqFVxdXeHj4wNTU1O8fv0aN27cQI8ePXDq1CmR6YtyLDU1NeHp6Yn+/fujcePG6Nu3LwwMDHDz5k08ffoUtra2cHNzK/I23LhxA9OnT4e9vT3q1KkDPT09fP36FefOnUOFChUwceLEIi+blCDZNQQmeenXr1++XRIIxMbGMiUlJaavry/ShYmgexH80j3Lr7KyspiHhwezt7dnmpqaTFlZmZmYmLAOHTqw7du3s58/f3LTSup+RFhGRgZbtmwZMzMz45Yzbdo0lpSUxExNTZmpqanYPF+/fmW9e/dmWlpaTFVVlTVv3pz5+vqyiRMnMgDsxYsXYvM8fvyY9evXj1WpUoUpKioyfX19xufz2ezZs9mHDx/y3V/CPD09Wd26dZmSkhIzMjJiM2bMYCkpKVJ3vbJt2zbWtWtXZmpqylRUVJienh5r3Lgx8/DwEOlDjTHG/P39WadOnZi2tjbj8Xgi3TsUdr/ldxzy6zri5MmTzMHBgWlpaTFlZWVWrVo1NnjwYPb27VuR6aQ9J0JDQ9ns2bOZnZ0dq1ixIlNSUmImJiasV69e7NGjR1IdA+FuIk6dOsWsra2ZiooKq1ixIhs7dqxYH24CYWFhbPLkydw+09TUZBYWFmzUqFHs5s2bItN++/aN9enTh+nr6zM5OTmJHc4KujLq27evyPDU1FSmrKzMALDTp0/nuR1Hjx5lbdu2ZTo6OkxRUZFVrVqVtWrViq1bt06kD7/CTp/f8cyr89y85HcOFnU9JXUtfvz4kY0cOZKZmpoyJSUlpqOjwywtLdmkSZPY48ePGWOMHT9+nOum59eugTIzM5mdnR3j8Xjs2rVr3HDBtRwcHMx69+7NdHR0WIUKFViLFi3YvXv3xOLIaz/4+Pgwe3t7pqGhwbS1tVmnTp3Ys2fPJE4v6F5FuAN7gby6TXn58iVr374909HRYRoaGqxly5bsxo0bee77/I5lfsfrzp07rGPHjkxbW5spKSmx2rVrs3///VfkPv/rvpPk1/vS+/fv2eTJk1nDhg2Znp4eU1ZWZjVq1GDDhg1j79+/l7gM8vvxGBMq3yakDGjWrBkePnyIhIQEsab/hBAiDUE9S0l11Qj521CdPSIzwt/3FTh48CD3iosSPUIIIaT4qM4ekZl69eqhYcOGqFu3Ltev1O3bt6GhoSFW94YQQgghRVPkZC8nJwcRERHQ0NCgXrJJkQwfPhxXrlzB06dPuY5Te/fujZkzZ8LU1JTrDJQQQooiOzub7iOk3GKMISkpCVWqVCmwsVGR6+yFhYVJ/AwNIYQQQgj5PUJDQ7nP8eWlyCV7gg4YAwI+lEhnjKTkqKpqICUlSdZhECF0TMomOi5lEx2XsoeOSdmTlJSE2rUtpMrBipzsCV7damhoFOszK6TkqapqQEGBXq2XJXRMyiY6LmUTHZeyh45J2SVNVTpqjUsIIYQQUo5RskcIIYQQUo5RskcIIYQQUo5RskcIIYQQUo5RskcIIYQQUo5RskcIIYQQUo5RskcIIYQQUo5RskcIIYQQUo5J3alyeno60tPTub/pe4OEEEIIIWWf1MneihUr4O7uLjZcVVUDqqr0ubSyho5J2UPHpGyi41I20XEpe+iYlC1ZWUzqaXmMMammllSyZ2xsjG/fwuhzaWUMfcOw7KFjUjbRcSmb6LiUPXRMyp7ExEQYGhohISGhwDxM6pI9ZWVlKCsrFzs4QgghhBDy+1ADDUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPUIIIYSQcoySPULIX2fMmHHo27e/rMMghJDfgpI9QgghhJByjJI9QgghhJByjJI9Qki5dfr0GdjY2EFPryKMjU3h5NQVycnJ3Pi1a9eiRg0zGBubYurUacjMzOTGHT58BM2atUSlSlVQvXotDBs2AtHRMdz4O3fuQk1NE1euXEHjxk2hq2uAli0d8Pbtu9+6jYQQUhBK9ggh5dK3b5EYNmwEhgwZhOfPn+Dy5Uvo1q0LGGMAcpO1L1++4PLli9i5cwcOHDiEAwcOcvNnZGTi33/nwc/vPo4ePYTg4GCMHTtObD3z5v2L5cuX4s6d2zAwMECfPv1EkkZCCJE1BVkHQAghpSEyMhJZWVno1q0rTExMAAD16v3DjdfW1saWLVuQnp4Cc/Pa6NDBEbdv38bw4cMAAEOHDuamrV69OtauXY0WLRzw8+dPqKurc+PmzJmNNm1aAwB27tyB2rUtcO7cefTs2eM3bCUhhBSMSvYIIeVS/fqWaNWqFWxtm2DQoCHw9t6DuLg4bryFRR3Iy8tzf1eqVAnR0bHc3y9fvkKfPv1Qp84/qFSpCjp0cAIAhIaGiayncWNb7t+6urowMzODv79/aW0WIYQUGiV7hJBySV5eHhcunMXp0ydRp445tm/3QIMG1ggKCgIAKCoqikzP4/HAWA4AIDk5Gd26dYeamhp27fLEnTu3cfhw7ivejIyMAtfN4/FKdmMIIaQYKNkjhJRbPB4PTZrYYf78eXj48B6UlJRw7tyFAucLCAhAbOx3LFniDnv7pjA3r42YmBiJ0z5+/IT7d1xcHD5//ozatWuX2DYQQkhxUZ09Qki59OTJE9y+7Ys2bVrDwMAAT548RWxsLMzNa+Pt27f5zmtkZAwlJSVs3+6BUaNG4P37D1i1arXEaVesWAVdXV1UrFgR7u6Loaenhy5dOpfGJhFCSJFQyR4hpFzS0NDEvXv34ezcC1ZWfCxevAQrViyDo2P7Auc1MNCHh8d2nD59BtbWtli3bj2WL18mcdolSxbBzW0WmjVrgcjISBw7dgRKSkolvTmEEFJkPCboh6CQEhMToaWlhW/fwqCpqVnScZFiUFXVQEpKkqzDIELomJRNxTkud+7cRceOTggPD4G2tnbJBvaXo+ul7KFjUvYkJibC0NAICQkJBeZhVLJHCCGEEFKOUbJHCCGEEFKOUQMNQggpghYtmiM5OVHWYRBCSIGoZI8QQgghpByjkj1CCPmNsnMYnoUkIOZnBgzUlWBtogV5OeqEmRBSeijZI4SQ3+T6h1gsv/oZUYn/+wpHJU0lzHWshXYW+jKMjBBSntFrXEII+Q2uf4jFlOPvRRI9AIhOzMCU4+9x/UNsHnMSQkjxULJHCCGlLDuHYfnVz5DUqalg2IqrX5CdU6RuTwkhJF+U7BFCSCl7FpIgVqInjAGITEzHs5CE3xcUIeSvQckeIYSUspifeSd6RZmOEEIKg5I9QggpZQbq0n0rV9rpCCGkMCjZI4SQUmZtooVKmkrIq4MVHoDKmsqwNtH6nWERQv4SlOwRQkgpk5fjYa5jLQAQS/gEf89xrEn97RFCSgUle4QQ8hu0s9DHxt51UVFT9FVtJU1lbOxdl/rZI4SUGupUmRBC8jB37nxcv34Duro60NHRga6uLnR0tJGQkABHxw7o0sWpUMtrZ6GP1uZ69AUNQshvRckeIYTkoXlze2RkpOPHjzjExMTg1atXCA+PQHZ2Np4+fV7oZA/IfaVrW0275IMlhJA8ULJHCCF56NixI6pUqQpPTy/4+T1Ceno6VFRUoKenh8uXL8g6PEIIkQrV2SOEkF+kpaXh8OEjaN26LZo2bYarV69h0qSJsLS0hJqaGq5cuQgdHR1Zh0kIIVKhZI8QQv5fcHAwFixYBHNzC4waNQYVKqji0KEDePfuNT5+9Ie/vz9OnDgKU1NTWYdKCCFSo9e4hJC/Wk5ODq5fvwFPTy9cuXIVmpqaGDhwAEaNGglz89oAgPXrN+Ls2XM4cuQQrK2tZRwxIYQUDiV7hJC/0vfv37Ftmwe2bduKwMAg1K9fH1u2bELv3r2gpqYmMm3t2mbYt28POncufIMMQgiRNUr2CCF/DcYYnj17hp07vXDixEkwxtCjhzN27fKEra0teDzJXaBQkkcI+ZNRskcIKfdSUlJw/PhJeHp64cWLFzAxMcG8eXMxbtx4qKmpyDo8QggpVZTsEULKrc+fP8PLazcOHDiA+PgEtGvXFidOHEX79u0hLy8PVVUNpKQkyTpMQggpVZTsEULKlezsbFy+fAU7d3ri5s1b0NXVwdChQzFy5HDUqFFD1uERQshvR8keIaRciIqKxr59+7BrlzdCQ0PRqJE1PDy2o2fPHqhQoYKswyOEEJmhZI8Q8sdijOHhQz/s3OmJM2fOQl5eHn369Mbo0SPB5/NlHR4hhJQJlOwRQv44P3/+xJEjR7FzpxfevXuHmjVrYMkSdwwcOAC6urqyDo8QQsoUSvYIIX+MDx8+wsvLCwcPHkZycjI6deqI5cuXonVrB8jJla8PAt24cRNxcfHo3bunrEMhhPzhKNkjhJRpmZmZOH/+Ajw9vXDnzl0YGBhg/PixGDFiOIyNjWUdXqmZMcMNnz59RmTkN0ycOCHPPgAJIaQglOwRQsqkiIgIeHvvwe7dexAZGYmmTZvA23sXunXrCmVlZVmHV+p0dHQAALNnz4W/fwDWr18LJSUlGUdFCPkTUbJHCCkzGGPw9b0DT08vnD9/ASoqKujfvx9GjRoJS8t6sg7vt6tUqRJUVVVx4MBBfP78GQcP7oeenp6swyKE/GHKVyUXQsgfKSEhAdu374C1tQ2cnLrg48ePWLNmFT5/9sd//234KxO9pKSfsLbmIzAwEOvWrcaHDx/QsqUDgoODZR0aIeQPQ8keIURmXr9+A1fXyahVyxyzZ8/FP//8g8uXL+Lp08cYO3YMNDU1ZR2izPz8+RP//PMPatSojjt37sHX1wfGxib48OGDrEMjhPxh6DUuIeS3Sk9Px+nTZ+Dp6QU/v0cwNDTEtGlTMGzYUBgaGso6vDLj588kaGhowMVlPGbNmoPly5fi8uULsg6LEPIHopI9QshvERISgoUL3VG7tgVGjhwNZWUVHDy4Hx8+vMWcObMp0fuFqqoaTE1NMHjwIKirq8PDw1PWIRFC/lBUskcIKTU5OTm4ceMmPD29cOXKVairq2PgwAEYNWok6tQxl3V4ZdrLl8+goqICOTk5DB06BLt378bs2TOhqqoq69AIIX8YKtkjhJS479+/47//NsPKqiGcnXsiJCQU//23AZ8+fcTatasp0ZOCqqoq11H0uHFjkJCQiEOHDss4KkLIn4hK9gghJebZs2fYudMLJ06cRE5ODpydu8PTcycaN7alToGLwdTUFF27dsG2bdsxYsTwcve1EEJI6aI7BiGkWFJTU7F//0E0b94SLVo44M6du5gzZzb8/T9g924v2Nk1pkSvBEycOAH+/gG4ceOmrEMhhPxhqGSPEFIkX758gZfXbuzfvx9xcfFo164tjh8/CkfH9pCXl5d1eOWOnV1j8PkNsWXLVrRv307W4RBC/iCU7BFCpJadnY0rV65i505P3LhxE7q6OhgyZAhGjhyOmjVryjq8co3H42HCBBeMHDka799/QN26FrIOiRDyh6DXuISQAkVHx2DNmnX455/66NOnH+Li4rBjx3YEBHzE8uVLKdH7TXr0cEblypWxffsOWYdCCPmDULJHCJGIMYaHD/0wfPhI1K5dBytXrkKrVi1x544P7ty5jcGDB6JChQqyDvOvoqSkhHHjxuDQocP4/v27rMMhhPwhKNkjhIj4+fMndu/2RpMmzdC2bXs8ffoU7u6L8OnTR+zYsQ3W1tayDvGvNnz4cADA7t3eMo6EEPKnoGSPEAIA+PjRHzNmuMHMrA4mT54KExNjnDlzCq9evcDkya7Q1dWVdYgEgL6+Hvr37wcPD09kZGTIOhxCyB+Akj1C/mKZmZk4ffoMOnbsDGtrGxw/fhJjx47Bu3evcezYEbRr15b6dCuDJkxwwbdv33D69BlZh0II+QNQa1xC/kLfvn2Dt/ce7N69B9++fUOTJnbYvdsL3bt3g7KysqzDIwWwsKiDNm1aY8uWrejTpzf1Y0gIyRc9shPym+zc6Ym6dS2hq2sAe/sWuH//QZ7T3rlzF2pqmmL/+fsHiEx35sxZWFvbQEdHH9bWNjh37nyey2SMwdf3DgYNGgJz87rYuHETOnXqiIcP7+PGjWvo27cPJXp/kAkTXPD8+Qv4+T2SdSiEkDKOkj1CfoOjR49i5szZmDlzBh48uIemTZvA2bknQkND853v5ctn+PLlE/dfrVr/6+Lk0aNHGDJkGPr16wc/vwfo168fBg8eiidPnogsIyEhATt2eKBRI1t06tQZ79+/x6pVK/Dp00ds2rQR9etblso2k9LVrl1b1K5thq1bt8k6FEJIGcdjjDFpJkxPT0d6ejr3d2JiIoyNjfHtWxg0NTVLLUBSeKqqGkhJSZJ1GESIg0Nb1K9vif/+28AN4/MboXPnzli8eJHY9Hfu3EXHjk4IDw+Btra2xGUOGTIMiYmJOHPmFDesWzdnaGtrY+9eb7x58xaenl44cuQo0tLS0LVrF4wePQotWjSn137/70+/Vry8dmHq1Ol49+41TExMZB1OifnTj0t5RMek7ElMTIShoRESEhIKzMOkrrO3YsUKuLu7iw1XVdWAqqpG4aMkpYqOSdmRkZGBZ8+eYfbs2SLHxdGxA548eSrxWKmoqAIA7O1bIC0tDXXr1sX8+fPh4ODATfP48RNMnTpVZP727R2xevVqtG/fEffv34ehoSHc3NwwatQoVK1atRS38s/1J18rI0eOxqJFi+Hl5Y21a9fKOpwS9Scfl/KKjknZkpUlVVkdgEIke3PmzMG0adO4vwUleykpSVBQoFKCsoSewMqWb9++ITs7G1paosdFV1cb375FSDxW2tqa2LJlExo0aICMjHQcPnwEbdq0wZUrl9CsmT0AIDIyEtramkhJSUJoaCh27fLGjh0eSEpKQt26dXHgwD507uwERUVFAKBzQoI//Vrh8YDhw4fBy8sLbm7ToKFRPn6M//TjUh7RMSl7CnM8pE72lJWVqfI2IcXw65tTxlier1Nr1zZD7dpm3N+NGzdGWFg4/vtvE5fsAcDbt+9w8mQ/XL58Berq6rC1tcHdu/dw+fKFUtkGUvaMGzcG//23CQcPHsK4cWNlHQ4hpAyiBhqElDI9PT3Iy8sjKipaZHh0dAwqVqwo9XJsbW3w5csX/PjxA5s2bQFjOVi/fgOCgoKxceN6fPr0Ee3atUWlSpVKehNIGVa1alU4O3fHtm3bkZOTI+twCCFlEPWzR0gpU1JSgrW1NW7duoWuXbtww318fODk5CT1cm7f9kV8fALMzOogOzsbhoaGMDQ0xK1bN7gSwps3b6FxY9sS3wZStk2c6IJWrdrgypWr6NSpo6zDIYSUMZTsEfIbTJs2DYMHD0bDhnw0bmyL3bu9ERoahlGjRgAAFixYhIiICHh57QQAbNmyFaampqhevTouXboEDw9PREZGQk9PD7Nnz8SQIUMQGBiI9u07YP36jejc2QkXLlyEj89t3LhxVZabSmTAxsYGtrY22LJlGyV7hBAxlOwR8hv07dsX376FY+XKVYiMjETdunVx6tQJrruMyMhIhIWFcdNHRkZi+fKVSEhIAABoa2th9uxZmDt3NuTl5QEAlSpVxN693li8eAmWLFmKGjWqY9++PbCxsfn9G0hkbuLECRgyZBjevHkLS8t6sg6HEFKGSN3P3q8SExOhpaVF/eyVQdRqquyR5phkZ2fj2rVr2LnTC9ev34C2thYGDRqEUaNGoFatWr8p0r9LebpWsrKy8M8/9eHg0Ao7dvzZHS2Xp+NSXtAxKXsK088eNdAgRMZiYmKxdu161KtnhV69+iImJhbbtm1FQMBHrFy5nBI9IhUFBQWMHTsGR48eQ3R0jKzDIYSUIZTsESIDjDE8evQII0aMQu3adbB8+Qq0aNEcd+744N49XwwZMgiqqqqyDpP8YYYPHwoFBQXs2rVL1qEQQsoQSvYI+Y2Sk5Ph7b0HTZs2R+vW7fD48WMsXLgAnz59hIfHdlhbW8s6RPIH09HRwaBBA7Bzp5fI5y0JIX83SvYI+Q0+fvyIGTNmwsysDlxdJ8PIqCpOnz6J169fYsqUSdDT05N1iKScGD9+PKKjo3H8+AlZh0IIKSOoNS4hpSQrKwsXL+Z2m+Lr6wt9fT2MGjUSI0cOh6mpqazDI+VU7dpmcHRsj61bt2PgwAF5fqWFEPL3oGSPkBL27Vsk9uzZg9279yAiIgJ2do1x4MABdOrkSJ8cJL/FxIkT0KVLN9y7dx/NmzeTdTiEEBmjZI+QEsAYw7179+Hp6YWzZ89BSUkJffv2wejRo2BlVZ+6LSC/lYNDK1hYWGDLlq2U7BFCKNkjpDgSExNx+PAReHp64cOHj6hd2wwrVizDgAH9oa2tLevwyF+Kx+Nh4kQXTJw4CV+/fkWNGjVkHRIhRIaogQYhRfD27TtMnjwVtWqZw81tFmrXro2LF8/j+fOncHEZT4kekbm+fftAT08X27d7yDoUQoiMUbJHiJQyMjJw/PgJtG/fAY0bN8H58xcwadJEfPjwFocOHUCrVi2pMjwpMypUqICRI0dg37793Gf3CCF/J0r2CClAaGgo3N0Xo3ZtCwwbNgLy8vLYv38v/P3fY/78eahataqsQyREotGjRyE9PR379u2XdSiEEBmiOnuESJCTkwMfn9vw9PTCxYuXoKamhgED+mHUqFGoW9dC1uERIhVDQ0P07NkD27d7wMVlPOTl5WUdEiFEBqhkjxAhcXFx2Lx5Cxo2tEbXrt3x5ctXbNiwDp8+fcT69eso0SN/nIkTXRAcHIwLFy7KOhRCiIxQyR4hAF68eImdOz1x/PgJZGVloXv3bti+fRuaNLGjenjkj9awYUPY2zfF1q3b0K1bV1mHQwiRAUr2yF8rLS0NJ0+egqenF548eQojIyPMnDkDQ4YMQeXKlWQdHiElZsIEFwwYMAgvXrxAw4YNZR0OIeQ3o2SP/HUCAwPh5bUb+/fvx/fvP9CmTWscPXoYHTo4QkGBLglS/nTu7ARTU1Ns3bodXl47ZR0OIeQ3ozp75K+QnZ2NK1euwNm5JywtG2DPnr3o378/Xr58hnPnzqBzZydK9Ei5JS8vj/Hjx+LEiZP49i1S1uEQQn4zSvZIuRYTE4t16zbA0rIBevbsg+joGGzdugWfPn3EqlUrYGZmJusQCfkthgwZDGVlZXh6eso6FELIb0ZFGaTcYYzhyZMn2LnTCydPngKPx0PPnj2wd+9uNGrUiBpckL+SlpYWBg8ehF27dsPNbQYqVKgg65AIIb8JleyRciM5ORl79uyFvX0LODi0xcOHfliw4F8EBHyEp6cHbGxsKNEjfzUXl3H4/v0Hjh49JutQCCG/ESV75I8XEPAJbm6zYGZWBxMnToKhYWWcOnUCb968xNSpk6GvryfrEAkpE2rUqAEnp07YsmUbGGOyDocQ8pvQa1zyR8rKysKlS5exc6cXfHx8oKeni5EjR2DkyOGoVq2arMMjpMyaMMEFHTs6wcfnNlq3dpB1OISQ34CSPfJHiYyMwp49e7BrlzciIiLQuLEtvLx2wtm5O1RUVGQdHiFlXvPmzWBpaYmtW7dRskfIX4KSPVLmMcZw//4DeHp64syZc1BUVETfvn0watRINGzYQNbhEfJH4fF4mDjRBWPHjkdAwCfUrk0t0gkp76jOHimzEhMTsXOnJ2xs7ODo2BGvXr3G8uVL8fmzP7Zu3UyJHiFF1Lt3LxgYGGD79u2yDoUQ8htQskfKnHfv3mPKlKkwM6uD6dPdYGZWC+fPn8WLF88wYYILtLW1ZR0iIX80ZWVljBkzCgcOHEJcXJyswyGElDJK9kiZkJGRgRMnTsLRsSNsbe1w9ux5TJzogg8f3uLw4YNo3dqBuk0hpASNHDkSWVlZ8PbeK+tQCCGljJI9IlNhYWFYvHgJzM3rYujQ4QCAvXu94e//Hv/+Ox9GRkYyjpCQ8qlSpYro27cPduzwQGZmpqzDIYSUIkr2iqBDh05wc5sFALCwqIctW7bKOKI/S05ODm7d8kH//gNhYVEPW7duR/fuXfH4sR+uXr2MXr16QklJSdZhElLuubiMR3h4OM6dOy/rUAghpYha4xbTnTu3oaamKusw/ghxcXE4ePAQvLx24dOnz7CwsMD69WvRr19faGhoyDo8Qv469etbokWLFti6dRt69uwh63AIIaWEkr1iMjDQl3UIZd7Ll6/g6emFo0ePITMzE927d8WWLZthb9+U6uERImOurhPQu3dfPHnyBDY2NrIOhxBSCug1bjH9+hpXTU0Tu3btRs+evaGvXwl8fiM8evQIX758QYcOnWBgUBkODm3w9etXkeVcunQZ9vYtoKtrgH/+qY/ly1cgKyvrd29OiUlLS8OhQ4fh4NAG9vbNcf36Dbi5TYe//wfs3bsHzZrZU6JHSBnQoYMjatSoji1btsk6FEJIKaFkrxSsXLkaAwb0x8OH91C7dm0MHz4Krq5TMH36NNy96wsAmDZtBjf99es3MHLkaIwfPxbPnj3Gpk0bceDAIaxevUZWm1BkQUFBmD9/AWrXroPRo8dCTU0dhw8fxPv3bzBr1kxUrlxJ1iESQoTIycnBxWU8Tp8+g/DwcFmHQwgpBZTslYLBgweiZ88eMDMzw7RpUxAcHIy+ffugXbu2qFPHHC4u43H37j1u+jVr1mLatKkYNGggqlevjjZtWuPff+dh1y5vGW6F9LKzs3HlylX07Nkb9epZYfdub/Tr1w8vXjzDhQtn0bVrFygoUI0BQsqqQYMGQk1NDTt27JR1KISQUkC/wKWgXr163L8rVqz4/8PqigxLS0tDYmIiNDU18eLFSzx79hxr1qzlpsnOzkZaWhpSUlKgqlo2G4DExn7Hvn37sWvXbgQFBaF+/frYsmUTevfuBTU1NVmHRwiRkoaGBoYNGwpvb2/Mnj2Trl9CyhlK9kqBoqIi929BvTQFBfFhOTk53P/nzZuLbt26iC1LRUWlNEMtNMYYnj59ip07vXDy5CkwxtCzZw94e3vBxsaG6uER8ocaN24MtmzZisOHj2DUqJGyDocQUoIo2SsDGjSwwqdPn1CzZk2ZxpGSkgLGmMSn+pSUFBw/fgI7d3rh5cuXMDU1xfz58zB48CBqkUxIOWBqaoquXbtg27btGDFiOOTkqJYPIeUFJXtlwOzZs9CrVx8YGVWFs7Mz5OTk8PbtW7x79w4LFy74LTFERkbBwaENevXqiSVL3Lnhnz59gqfnLhw8eAgJCQlo374dTp48hnbt2kFeXv63xEYI+T0mTHBBu3aOuH79Bhwd28s6HEJICaFHtzKgXbu2OHHiGG7d8kGLFq3g4NAGmzdvgYmJyW9Zf3JyMnr37oOMjAyMHTsaWVlZOH/+Arp06YYGDaxx5MgRDB8+DG/evMSpUyfQoUMHSvQIKYeaNLEDn98QW7dSNyyElCc8xhgryoyJiYnQ0tLCt29h0NTULOm4SDGoqmogJSVJqmmzs7PRv/9A3L7ti8OHD+Lp06fYtcsb4eHhsLFphNGjR6Fnzx5lru7gn6Ywx4T8PnRcxB05chQjR47GkyePULeuhUxioONS9tAxKXsSExNhaGiEhISEAvMwKtn7y82aNQeXL19BgwZW6NmzN9asWYe2bdvg3j1f3L59CwMHDqBEj5C/SI8ezqhcuTK2bdsu61AIISWEkr2/2LRpM7B9+w7k5OTgy5cvGDZsCE6fPoHZs2eKdB9DCPl7KCkpYdy4MTh8+AhiY7/LOhxCSAmgZO8v9ubNGygpKUFOTg6RkVHw9NyFDh2cYGFRD+PHT5B1eIQQGRk+fDgAwNv7z+jYnRCSP2qN+xe7fv0qgNx+/pKSkvDjxw/ExcXhx484mJvXlnF0hBBZ0dfXQ//+/eDh4YnJkydBSUlJ1iERQoqBSvb+UNk5DI+D4nHxbTQeB8UjO6dI7WwA5H4bU0tLC9WrVwefz0fbtm1gbGxcgtESQv40Li7j8e3bN5w6dVrWoRBCiolK9v5A1z/EYvnVz4hKzOCGVdJUwlzHWmhnQR0cE0KKr25dC7Rp0xpbt25D37596Os4hPzBqGTvD3P9QyymHH8vkugBQHRiBqYcfw8ff6pQTQgpGRMmuOD58xfw83sk61AIIcVAyd4fJDuHYfnVz5D0wlYwbN3NwN8ZEiGkHGvXri1q1zbDli1bZR0KIaQYKNn7gzwLSRAr0RPGAEQn5T2eEEIKQ05ODhMmuODcufMIDg6WdTiEkCKiZO8PEvOTEjlCyO/Vv38/aGlpYseOnbIOhRBSRJTs/UEM1Kn7A0LI76Wmpobhw4dj7959SEqiz2UR8ieiZO8PYm2ihUqaSsirTRwPQEUNSggJISVr7NjR+PnzJw4cOCjrUAghRUDJ3h9EXo6HuY61AEAs4RP8Pb1N9d8aEyGk/DMyMoKzc3ds27YdOTk5sg6HEFJIlOz9YdpZ6GNj77qoqClagldJUxkbe9eFg7mejCIjhJRnEye64OvXQFy5clXWoRBCCok6Vf4DtbPQR2tzPTwLSUDMzwwYqCvB2kQL8nLU6SkhpHTY2NjA1tYGmzdvRadOHWUdDiGkECjZ+0PJy/FgW01b1mEQQv4iEya4YOjQ4Xj9+g3q17eUdTiEECnRa1xCCCFS6d69G4yMjLBt23ZZh0IIKQRK9gghhEhFQUEBY8eOwdGjxxAdHSPrcAghUqJkjxBCiNSGDx8KBQUFeHl5yToUQoiUKNkjhBAiNR0dHQwaNAA7d3ohPT1d1uEQQqRAyR4hhJBCGT9+PGJiYnD8+AlZh0IIkQIle4QQQgqldm0zODq2x5Yt28AYk3U4hJACUNcrRCI7u6b4+NEfVatWQZUqVaCvr////+mhY8cOsLW1lXWIhBAZmjDBBV27dsfdu/fQokVzWYdDCMkHJXtEInt7e7x58xbBwSFQU1ODiooKQkJCERsbi4yMTEr2CPnLtW7tAAsLC2zduo2SPULKOEr2iESrV6/Ew4d+iIgIR0DAJyQnp2Dt2lXo2JF6zieEADweDxMnumDixEn4+vUratSoIeuQCCF5oDp7RCJ5eXls3boZ37//wPjx41CzZg306tUXffr0Q3BwsKzDI4SUAX379oGeni62bdsh61AIIfmgZI/kqWHDBpg4cQJ27vTEhg3rcODAPrx48RLW1rZYs2YtdbtAyF+uQoUKGDlyBPbvP4CEhARZh0MIyQMleyRf8+fPRcWKFTFv3r9wdu6O58+fYMyY0Vi6dDkaN26CW7d8ZB0iIUSGRo8ehfT0dOzbt1/WoRBC8kDJHsmXmpoa9u/fg+bNmwEANDQ0sHz5Ujx8eB+VKlVCly7dMHToMERERMg4UkKILBgaGqJnzx7Yvt0D2dnZsg6HECIBJXukQI0aNcKECS4iw+rWtcCVK5fg6ekBX9+7aNiwETZv3oKsrCwZRUkIkZWJE10QHByMCxcuyjoUQogElOyRIuPxeBgwoD9evnyGQYMGYO7c+WjatPn/tXfvcTnfj//Hn1elkIoc26JhGBtzdT4QJeczyVk5la4yh82cZo5zGpvRdSURkUOR08i5nCodL5tNG3MY+oTEClkp/f7Y59NvvsxC9bqu9/W832794XJ19bhu75mn6/C+kJCQKDqNiCqRXC6Hi4szlEqV6BQiegmOPXprNWvWxMqVK3D69ElUq1YVnTt3hZ+fP+7ezRadRkSVJCBAgfj4BKjVatEpRPR/cOxRuZHL2yIu7gTWrPkOBw8ehFxug9DQ9XwdD5EO6NWrJ6ysrBAUxEf3iDQNxx6VKz09PYwZMxrnz6vRt28fTJ48FR07uiM9PV10GhFVIH19fUyY4Ifo6N3IysoSnUNEf8OxRxWiTp3aUKmCcOLEMTx9WgRXVzdMmjQFDx48EJ1GRBXE23skjIyMEBq6XnQKEf0Nxx5VKEdHB5w9ewrLly9FZGQU2ra1wZYtW/Hs2TPRaURUzszMzDBy5Ahs2BCGJ0+eiM4hov/i2KMKZ2BgAIXCH2p1Gtzd3TBhgj+6dOmGCxd+Ep1GROVMoZiAnJz7iIyMEp1CRP/FsUeVxsKiATZu3ICYmAN48OABXFzaY/r0mcjLyxOdRkTlpEmTJujZsweCglQoKSkRnUNE4NgjATp0cEViYjzmzv0SYWEbIZfbYteuaP7FQCQRAQEKZGRkIC7upOgUIgLHHgliaGiITz+dgvT0FNjb28HbezR69+6HS5cui04jorfUvn07tG7dGkFBStEpRASOPRKsYcOG2L59K6Kjd+L69Wuwt3fEvHkLkJ+fLzqNiN6QTCZDQIACR44c5T/giDQAxx5phG7duiIlJQnTpn2K1avXwMbGHgcPxojOIqI35OXlibp16yI4OFh0CpHO49gjjVGtWjXMnj0LKSnn0KJFc3h5DYGnpxeuX78uOo2IXpORkRF8fcchImIb7t+/LzqHSKdx7JHGadq0Kfbsica2bRG4cOEn2NjYY+nSZSgoKBCdRkSvYezYsSgqKsKmTZtFpxDpNI490kgymQx9+/ZBenoKFAp/LFmyDPb2jjh+/IToNCIqo/r162HwYC+sXRuCp0+fis4h0lkce6TRjI2NsXDhfJw7l4B33nkHffv2x4gRo5CZmSk6jYjKQKHwR2ZmJvbt2y86hUhnceyRVmjZ8gPExBxAWNh6xMcnQC63xapVq/loAZGGa9OmNVxdXaFUqkSnEOksjj3SGjKZDIMHe+H8+TSMGjUSc+Z8CSendjh7Nl50GhG9QmCgAsnJKUhOThadQqSTOPZI65iZmWHFiuU4c+YUTExqoGvX7hg3zhd37twVnUZEL9G9ezc0adIYSiVPw0IkAsceaa22bT/GiRPHoFIF4ejRo5DLbRASsg7FxcWi04job/T09KBQ+GPPnr24deuW6BwincOxR1pNT08P3t6joFanYcCA/pg69TO4urohJSVFdBoR/c2IEcNhbGyMkJBQ0SlEOodjjyShdu3aCApajbi44ygpKYGbmwcmTpyEnJwc0WlEBMDExATe3qOwceNGPH78WHQOkU7h2CNJsbe3x5kzJ7FixXJER++GXG6D8PDNePbsmeg0Ip3n7++H3Nw8bNu2XXQKkU4p89grKChAXl7ec19EmkhfXx8TJvhBrU5Dly5doFAEwsOjC3744UfRaUQ6zcrKCn369IZKFcx/gBFVIllJSUlJWa44b948zJ8//4XLc3NzYWpqWu5hROXl1KlTUCgU+OWXXzBx4kQsWLCA/80SCXL27Fm0b98eMTEx6N69u+gcIq2Vl5cHMzOzMu2wMo+9goKC5z6bNC8vDw0bNkRW1i3+xalhqlc3QX7+Q9EZGuXp06cIClJhyZKlqFGjBpYuXYxBgzwhk8kq5efzmGgmHpfKV1JSAlfXjqhVqxb279/70uvwuGgeHhPNk5eXBwsLyzKNvTI/jWtkZARTU9Pnvoi0RZUqVTBlyiSkp6fAyckRo0ePRY8evfHLL7+KTiPSKTKZDAEBCpw4EYuLFzNE5xDpBL5Bg3SKpaUltm7dgr17dyMz8xYcHZ0xZ85cvjuQqBINGNAfDRo0gErFkywTVQaOPdJJnTt7IDn5HGbM+BwqVTBsbOyxf//3KOOrGojoLRgaGsLPbzy2b9+Be/d4eiSiisaxRzqratWqmDFjOlJTk/Dhh60wdOhwDBjgiatXr4pOI5K8MWPGAADCwsIElxBJH8ce6bzGjRtj164oREZuR0bGL7C1dcDixUvw559/ik4jkqw6dWpj6NAhCAkJRWFhoegcIknj2CPCXy8a79WrJ9LSkjFxYiCWL18BOzsHHDlyVHQakWQpFP64ffs2du/eIzqFSNI49oj+xtjYGPPnz0VSUiIaNmyEAQM8MWzYCH54O1EFaNWqJTp1codSqeLrZYkqEMce0Uu0aNEcBw/ux6ZNYUhKSoa1tR2++WYVn24iKmcBAQqkp6uRmHhOdAqRZHHsEf0DmUyGQYM8oVanwsfHG/PmzYeTkwtOnz4jOo1IMjp39kDz5s2gVKpEpxBJFsce0b8wNTXF8uVLcfbsadSsWRPdu/fEmDHjcPv2HdFpRFpPT08PCoU/9u//Hr///rvoHCJJ4tgjKqM2bVrj2LEjCA5W4cSJE5DLbRAcvBZFRUWi04g03rp1oWjVqjXMzevCxcUV8fEJpb83bNhQmJmZIjg4BADg4+MDY2PTF75sbe1Lv+fixQwMGzYCLVt+BGNjUwQFKSv9PhFpC449otegp6eHUaNGQK1Ow6BBnpg2bTrat++I5ORk0WlEGmvXrmh8/vkMfP75Z0hIOAtnZyf07z8QN2/eBPDXG6NGjx6N8PDNePjwIb777jtcuXK59OvSpQyYm9dC//79Sm/zyZN8vPfee1iwYB7q168v5H4RaQuOPaI3YG5ujtWrV+HUqVjo6+vDzc0DCkUgPw2A6CXWrAmCt/co+Ph444MPWuDrr5fB0vJdhIZuKL2On994PH78GBERW2FmZoYGDeqXfqWnq/HgwR8YOXJE6fVtbGywePEiDBrkCSMjIxF3i0hrcOwRvQUbGxucOhWLVau+wb59+yGXW2Pjxk149uyZ6DQijVBYWAi1+jw6dXJ/7nJ3d3ckJSWV/trS0hL9+/eFShX8wp+f8PDNcHPriEaNGlVCMZH0cOwRvSV9fX2MHz8OanUaunfvjsDAT+Du7oHz538QnUYkXE5ODoqLi1GvXr3nLq9fvx7u3Hn+TU6BgQG4evUaDhw4UHpZVtZtHD16DD4+3pXSSyRFHHtE5aRevbpYt24tjh49jMeP89G+fQd89tk05Obmik4jEk4me/7XJSUlkP2fC+3s7GBvb4dVq1aVXhYRsRU1a5qhd+9elVBJJE0ce0TlzMXFGQkJZ7Bo0UJs2bIVbdvaICIigp8QQDqpdu3a0NfXx507d5+7/O7d7Bce7QP+OslyXFwcfvzxAkpKSrBlyxYMGTIEhoaGlZVMJDkce0QVoEqVKpg0aSLU6lS0b98OI0eORPfuPXHxYoboNKJKZWhoCLm8LWJjY5+7PC4uDg4ODi9cv1+/vmjYsCGUShXOnDmLK1euwtt7VGXlEkkSxx5RBXrnnXewefMmHD16FFlZWXBycsHs2XPw6NEj0WlElWbixEBs2rQZ4eFb8Msvv+Lzz2fg5s1bGDduDADgyy/nYdw4XwCAgYEBAgMDERW1EyEh62BnZ4sPP2z1wm0WFhbihx9+xA8//IjCwkL85z9Z+OGHH3HlypVKvW9E2oBjj6gSdO7cGcnJ5zB79kysXRsCa2s77N27j0/tkk7w9ByI5cuXYunSZXByckF8fAJ2795V+u7a27dv49atW6XXHzduHPT19XHgwMF/fFQvKysLzs7t4OzcDrdv38Z3362Gs3M7BARMrJT7RKRNZCVv+LdNXl4ezMzMkJV1C6ampuXdRW+henUT5Oc/FJ1Bf/P3Y3L9+nVMmzYdMTGH4OHRCStXfo33339fcKFu4p8VzVS9ugl8fcdh7979+PXXizyPngbgnxXNk5eXBwsLS+Tm5v7rDuMje0SV7L333sPOnZHYuTMSly//Bjs7Ryxa9BWePHkiOo1IYygUCmRnZyMqapfoFCKtx7FHJEiPHt2RmpqEKVMmYeXKb2Fr64DDhw+LziLSCM2bN0PXrl2gVKr4cgeit8SxRyRQ9erV8eWXc5CcnIjGjRtj4EAvDBkyDDdu3BCdRiRcQIACFy5cwJkzZ0WnEGk1jj0iDdCsWTN8//1ebN68CampabC2tsOKFd+gsLBQdBqRMO7ubmjZsiWCgpSiU4i0GscekYaQyWQYOHAA1OpUjBs3FgsWLISjozNOnjwlOo1ICJlMhsBABWJiDvGUKkRvgWOPSMOYmJhg6dLFSEg4i9q1a6Nnz97w8RmDrKzbotOIKt3gwV4wN6+F4OAQ0SlEWotjj0hDffTRhzh69DDWrVuLuLiTkMttEBSkRFFRkeg0okpTrVo1jB07Blu2RPBzponeEMcekQaTyWQYPnwYzp9Pw9ChgzFjxiy4uLgiMfGc6DSiSuPrOx4FBQUID98iOoVIK3HsEWmBWrVq4dtvv8Hp03EwMjKEh0cXTJigQHb2PdFpRBXOwsICAwcOQHDwWj6yTfQGOPaItIi1tTXi4k5g9epVOHDgAORya2zYEIbi4mLRaUQVKjBQgRs3buDgwRjRKURah2OPSMvo6+tj7NgxUKvT0atXL3zyyWS4uXWCWq0WnUZUYeRyOVxcnHkaFqI3wLFHpKXq1q2DtWtVOH78KAoKCtG+fUdMmTIVDx48EJ1GVCECAhRISEhEenq66BQircKxR6TlnJwcER9/GkuXLsb27ZFo29YGW7du40dMkeT06tUTVlZWUCqDRacQaRWOPSIJMDAwQGBgANTqVHTs2AG+vhPQtWt3/PzzRdFpROVGX18fEyb4ITp6N7KyskTnEGkNjj0iCbGwsEB4+EYcOLAf2dnZcHJywcyZs/Hw4UPRaUTlwtt7JIyMjLBuXajoFCKtwbFHJEFubh2RlJSIOXO+QGjoesjltoiO3s2ndknrmZmZYeTIEdiwIQxPnjwRnUOkFTj2iCTK0NAQ06Z9ivT0FNja2mDUKB/06dMPly9fFp1G9Fb8/f1w//4DREZGiU4h0goce0QS16hRI+zYsQ3R0VG4evUa7O2dMH/+AuTn54tOI3ojTZs2RY8e3REUpOKj1URlwLFHpCO6deuG1NQkfPrpFKxatRq2tg6IiTkkOovojQQGBiAjIwOxsXGiU4g0HscekQ6pVq0avvhiNlJSzqFZs/cxaNBgeHkNwe+//y46jei1tG/fDq1bt4ZSqRKdQqTxOPaIdND777+PvXt3IyJiM9Tq87Cxscfy5V+joKBAdBpRmchkMgQEKHDkyFFcusTXoRK9CscekY6SyWTo378f1OpU+Pn54quvlsDBwYlPi5HW8PLyRN26daFS8dE9olfh2CPScTVq1MBXXy1EYmI86tevj969+2LUKB/85z//EZ1G9EpGRkbw9R2HrVu34/79+6JziDQWxx4RAQBatWqJw4djsH79Opw5cxZyuS1Wrw7C06dPRacR/aOxY8eiqKgImzZtFp1CpLE49oiolEwmw9ChQ6BWp2LEiGGYPfsLODu3R3x8gug0opeqX78evLwGYe3aEP7DhOgfcOwR0Qtq1qyJlStX4PTpkzA2ro4uXbrB13cC7t7NFp1G9IKAAAUyMzOxb99+0SlEGoljj4j+kVzeFrGxxxEUtBqHDh2CXG6D0ND1KC4uFp1GVKpNm9ZwdXXlaViI/gHHHhG9kp6eHkaP9oFanY6+fftg8uSp6NjRHWlpaaLTiEoFBiqQnJyC5ORk0SlEGodjj4jKpE6d2lCpghAbewxFRcXo0MEdkyZN4bsgSSN0794NTZo05qN7RC/BsUdEr8XBwQFnzpzE8uVLERW1E3K5DTZvjsCzZ89Ep5EO09PTg0Lhjz179uHWrVuic4g0CsceEb02AwMDKBT+SE9PRadOneDvr0CXLt1w4cJPotNIh40YMRzGxsYICQkVnUKkUTj2iOiNWVg0QFjYesTEHMCDBw/g4tIen38+A3l5eaLTSAeZmJjA23sUNm7ciMePH4vOIdIYHHtE9NY6dHBFYmI85s2bi40bN0Eut8XOnbtQUlIiOo10jL+/H3Jz87Bt23bRKUQag2OPiMqFoaEhpk6djPT0FDg42MPHZwx69uyDX3+9JDqNdIiVlRX69OkNlSqYryMl+i+OPSIqVw0bNsS2bRHYsycaN2/egIODE+bOnY/8/HzRaaQjAgIUuHTpMo4dOy46hUgjcOwRUYXo0qUzUlKS8Pnnn2HNmiDY2NjjwIGDfGqXKpyTkyOsreUIClKKTiHSCBx7RFRhqlatilmzZiI1NQkffNACgwcPhaenF65duyY6jSRMJpMhIECB2Ng4XLyYITqHSDiOPSKqcE2aNMHu3buwfftW/PTTz7C1dcDSpcvw559/ik4jiRowoD8aNGgAlSpYdAqRcBx7RFQpZDIZ+vTpjfT0FCgU/liyZBns7R35uiqqEIaGhvDzG4/t23fg3r0c0TlEQnHsEVGlMjY2xsKF85GUlIh337VEv34DMGLEKGRmZmLdulC0atUa5uZ14eLiivj4hFfeVkjIOlhb26J27Xpo29YaW7due+E6e/fug42NHWrVqgMbGzvs3/99Rd010jBjxowBAISFhQkuIRKLY4+IhPjggxaIifkeYWHrkZCQiNat2+Kzzz7Hp59OQULCWTg7O6F//4G4efPmS78/NHQ95s6dX/qawNmzZ2Hq1M8QE3Oo9DpJSUkYNcoHQ4YMwblzCRgyZAhGjvRGSkpKZd1NEqhOndoYOnQIQkJCUVhYKDqHSBiOPSISRiaTYfBgL6jVqTAzM0NxcTGCg0OQnZ2Nr79eBkvLdxEauuGl37t9+w6MGTManp4D0bhxYwwa5IlRo0bim2++Lb2OUhkMd3c3TJv2KVq0aI5p0z5Fx44dEBSkqqy7SIIpFP64ffs2du/eIzqFSBiOPSISrlq1asjJycGSJV/B1NQE3br1wNix4+Ho6IikpKSXfk9BQSGqVjV64XZSU9Pw9OlTAEBSUjI6dXJ/7joeHp2QlJRcMXeENE6rVi3h7u4GpVLF0/6QzuLYIyLhcnJyUFxcDHt7exw/fhQqlRLHjh3Djh2R+PXXSyguLn7hezw8OmHTps1Qq9UoKSlBeno6Nm/egqdPn5a+IP/OnTuoV6/ec99Xr1493Llzp1LuF2mGwMAApKerkZh4TnQKkRAce0SkMWQyQE9PD97eI6FWp+HDDz9EdnY2XF3dXnid3YwZn6NLl87o2LETzMzM4eU1FCNGDAcA6Ovr/+02Zc99X0lJyQuXkbR17uyB5s2bQank0/ekmzj2iEi42rVrQ19fH3fu3H3uMgcHe3z8cRuUlJTAzc0DgYGfICfnr0ftqlWrhrVrVbh37w4yMn7Cr79ehJVVI5iYmKBOndoAgPr167/wKF52dvYLj/aRtOnp6UGh8Mf+/d/j999/F51DVOk49ohIOENDQ8jlbREbG/vc5XFxcfDw8MCZMyexcuXX2L17D+RyG4SHby79kPsqVarg3Xffhb6+Pnbtika3bl2hp/fX/9ocHOwRGxv33G2eOBELBwf7yrhbpEGGDRsKMzNTBAeHiE4hqnQGogOIiABg4sRAjBvnC7ncGg4O9ggL24ibN29h3Lgx0NfXR2bmf+Du7oaqVatCoQjE2rUh6NevHwYO7I8//vgDa9YE4eLFi1i3bm3pbSoU/ujSpRtWrvwWvXr1xIEDBxEXdxLHjx8ReE9JBGNjY4wePRrr12/A7NkzYWJiIjqJqNLwkT0i0giengOxfPlSLF26DE5OLoiPT8Du3bvQqFEjAMDt27dx7949rF+/DkeOHMKjR4+xYMFC2NjYo1evvvjzzwKcOHEcVlZWpbfp6OiA8PCNiIiIgIODE7Zu3YrNmzfBzs5O1N0kgfz8xuPx48eIiNgqOoWoUslK3vC96Hl5eTAzM0NW1i2YmpqWdxe9herVTZCf/1B0Bv0Nj0n5e/r0KZTKYCxevAQ1atTA4sWLMHiw12u9+YLHRTNV5HHx9vZBeroaP/ygLn26n/4d/6xonry8PFhYWCI3N/dfdxj/SycirVSlShVMnvwJ1OpUuLg4Y+zY8ejRoxcyMn4RnUYaLDAwAFevXsOhQ4dFpxBVGo49ItJq7777LrZsCce+fXuQmZkJR0dnzJkzF48fPxadRhrIzs4O9vZ2/BQV0ikce0QkCR4enZCcfA4zZ06HShUMa2s77Nu3n5+aQC8ICFDg9OnT+PHHC6JTiCoFxx4RSUbVqlUxY8Z0pKYm4aOPPsSwYSMwYIAnrl69KjqNNEi/fn1haWnJkyyTzuDYIyLJady4MXbtikJk5Hb88suvsLV1wFdfLcaff/4pOo00gIGBAfz8fBEVtfO5E3kTSRXHHhFJkkwmQ69ePZGWloxPPpmIr79eCTs7Bxw5clR0GmkAH59RMDAwwIYNG0SnEFU4jj0ikrTq1atj3rwvkZSUiEaNrDBggCeGDh2Omzdvik4jgczNzTF8+FCsW7ceBQUFonOIKhTHHhHphBYtmuPAgX0ID9+I5OQUWFvbYdmyZSgsLBSdRoIoFApkZ2cjKmqX6BSiCsWxR0Q6QyaTwdNzINTqVIwZMxqzZ8+Gk5MLTp06LTqNBGjevBm6du0CpVLFd22TpHHsEZHOMTU1xbJlS5Ceno5atWqhR49eGD16LLKybotOo0oWEKDAhQsXcObMWdEpRBWGY4+IdFabNm1w9OhhrF0bjNjYWFhb20KpVKGoqEh0GlUSd3c3tGzZEkFBStEpRBWGY4+IdJqenh5GjhwOtToNXl6DMH36TLRr1wFJSUmi06gSyGQyBAYqEBNzCFeuXBGdQ1QhOPaIiPDXuzO/++5bnDoVCwMDA7i7d4ZCEYh793JEp1EFGzzYC+bmtRAcHCI6hahCcOwREf2NjY0NTp2KxapV32Dfvv2Qy60RFrYRz549E51GFaRatWoYO3YMtmyJQG5urugconLHsUdE9H/o6+tj/PhxUKvT0KNHD0ycOAnu7h5Qq8+LTqMK4us7HgUFBQgP3yI6hajccewREf2DevXqIiQkGMeOHUF+/hO4unbE1Kmf4o8//hCdRuXMwsICAwcOQHDwWr5BhySHY4+I6F84OzshPv40Fi9ehK1bt6NtWxts27ad52aTmMBABW7cuIGDB2NEpxCVK449IqIyqFKlCiZODIRanYoOHdpj/Hg/dOvWAz//fFF0GpUTuVwOFxdnnoaFJIdjj4joNbzzzjsID9+E77/fhzt37sDZuR1mzfoCjx49Ep1G5SAgQIGEhESkp6eLTiEqNxx7RERvwN3dDUlJifjii1lYty4Ucrktdu/ew6d2tVyvXj1hZWUFpTJYdApRueHYIyJ6Q0ZGRpg27TOkpSVDLm+LkSO90bdvf/z222+i0+gN6evrY8IEP0RH70ZWVpboHKJywbFHRPSWrKysEBW1Azt3RuK3367Azs4RCxcuwpMnT0Sn0Rvw9h4JIyMjrFsXKjqFqFxw7BERlZMePbojNTUJU6ZMwjffrIKtrQMOHTokOotek5mZGUaOHIENG8I42EkSOPaIiMpR9erV8eWXc5CcnIimTZvA03MwBg8eihs3bohOo9fg7++H+/cfIDIySnQK0Vvj2CMiqgDNmjXDvn17sGVLONLT1bC2tsPXX69AQUGB6DQqg6ZNm6JHj+4IClLxTTek9Tj2iIgqiEwmw4AB/ZGengJf3/FYuPArODo6Iy7upOg0KoPAwABkZGQgNjZOdArRW+HYIyKqYCYmJli8eBESE+NRt25d9OrVB97ePny3p4Zr374dWrduDaVSJTqF6K2UeewVFBQgLy/vuS8iIiq7Dz9shSNHDiE0NASnTp2BXG6LNWuC+FmsGkomkyEgQIEjR47i0qXLonOI3pispIwvRpg3bx7mz5//wuW5ubkwNTUt9zAiIin7448/8MUXX0ClUuGjjz6CSqVCu3btRGfR/1FQUIBGjRph4MCBUKn4CB9pjry8PJiZmZVph5V57BUUFDz3wuK8vDw0bNgQWVm3OPY0TPXqJsjPfyg6g/6Gx0QzacJxUavVmDx5KlJT0zBixHAsXLgA9erVFdokmiYcl79bvHgJvv32O/z660WYm5uLzhFC044J/bXDLCwsyzT2yvw0rpGREUxNTZ/7IiKityOXyxEXdwJr1nyHgwcPQi63wfr1G1BcXCw6jf5r7NixKCoqwqZNm0WnEL0RvkGDiEgwPT09jBkzGmp1Ovr06Y1Jk6agY0d3pKeni04jAPXr14OX1yCsXRuCp0+fis4hem0ce0REGqJu3ToIDlbixIljKCx8CldXN0yePAUPHjwQnabzAgIUyMzMxL59+0WnEL02jj0iIg3j6OiA+PjTWLZsCXbsiELbtjaIiNjKk/sK1KZNa7i6uvI0LKSVOPaIiDSQgYEBAgIUUKvT4O7uBj8/f3Tp0g0//fSz6DSdFRioQHJyCpKTk0WnEL0Wjj0iIg1mYdEAGzduwMGD3yMnJwfOzu0wffpMPHzId0ZWtu7du6FJk8Z8dI+0DsceEZEW6NixA86dS8DcuV8iLGwj5HJb7NoVzad2K5Genh4UCn/s2bMPt27dEp1DVGYce0REWsLQ0BCffjoFaWnJsLW1gbf3aPTu3Y+f7lCJRowYDmNjY4SEhIpOISozjj0iIi3TqFEj7NixDdHRO3H9+jXY2zti3rwFyM/PF50meSYmJvD2HoWNGzfi8ePHonOIyoRjj4hIS3Xr1hUpKUmYNu1TrF69BjY29jh4MEZ0luT5+/shNzcP27ZtF51CVCYce0REWqxatWqYPXsWUlLOoUWL5vDyGgJPTy9cv35ddJpkWVlZoU+f3lCpgvHs2TPROUT/imOPiEgCmjZtij17orFtWwR+/PECbGzssWzZ8uc+05zKT0CAApcuXcaxY8dFpxD9K449IiKJkMlk6Nu3D9LTU+DvPwGLFy+Fvb0jjh8/ITpNcpycHGFtLUdQkFJ0CtG/4tgjIpKYGjVqYNGiBTh3LgEWFhbo27c/Ro70RmZmpug0yZDJZAgIUCA2Ng4XL2aIziF6JY49IiKJatnyAxw6dBAbNoTi7Nl4yOW2WLVqNZ4+fSo6TRIGDOiPBg0aQKUKFp1C9Eoce0REEiaTyTBkyGCo1akYNWoE5sz5Ek5O7XD2bLzoNK1naGgIP7/x2L59B+7dyxGdQ/SPOPaIiHRAzZo1sWLF1zhz5hRq1DBG167dMW6cL+7cuSs6TauNGTMGABAWFia4hOifcewREemQtm0/RmzscSiVa3DkyBHI5TYICVmH4uJi0WlaqU6d2hg6dAhCQkJRWFgoOofopTj2iIh0jJ6eHnx8vKFWp6N//36YOvUzuLq6ISUlRXSaVlIo/HH79m3s3r1HdArRS3HsERHpqDp1akOpXIO4uOMoKSmBm5sHJk6chPv374tO0yqtWrWEu7sblEoVSkpKROcQvYBjj4hIx9nb2+PMmZNYsWI5du2Khlxug/DwLfx0iNcQGBiA9HQ1EhPPiU4hegHHHhERQV9fHxMm+EGtToOHhwcUigB07twVP/54QXSaVujc2QPNmzeDUqkSnUL0Ao49IiIq1aBBfWzYEIpDhw4iNzcXLi7tMW3adOTl5YlO02h6enpQKPyxf//3+P3330XnED2HY4+IiF7g6toeiYnxWLBgPjZtCkfbtjaIitrJ16S9wrBhQ2FmZorg4BDRKUTP4dgjIqKXqlKlCqZMmQS1OhVOTo4YPXosevTojV9++VV0mkYyNjbG6NGjER6+GQ8fPhSdQ1SKY4+IiF7J0tISW7duwZ490bh16yYcHZ0xZ85cPH78WHSaxvHzG4/Hjx8jImKr6BSiUhx7RERUJl26dEZKShKmT58GpVIFGxt77N//PZ/a/RtLS0v0798XKlUw381MGoNjj4iIyqxq1aqYOXMGUlOT0KpVSwwdOhwDBnji6tWrotM0RmBgAK5evYZDhw6LTiECwLFHRERvoEmTJoiO3okdO7YhI+MX2No6YPHiJfjzzz9FpwlnZ2cHe3s7BAXxNCykGTj2iIjojchkMvTu3QtpackIDAzA8uUrYGfngKNHj4lOEy4gQIHTp0/zPIWkETj2iIjorRgbG2PBgnlISkpEw4aN0L//QAwbNgK3bt0SnSZMv359YWlpyZMsk0bg2CMionLRokVzHDy4H5s2hSEpKRnW1nb45ptVKCwsFJ1W6QwMDODn54uoqJ24c+eu6BzScRx7RERUbmQyGQYN8oRanQofH2/MnTsPTk4uOH36jOi0SufjMwoGBgbYsGGD6BTScRx7RERU7kxNTbF8+VLEx59BzZo10b17T4wZMw63b98RnVZpzM3NMXz4UKxbtx4FBQWic0iHcewREVGFadOmNY4dOwKVSokTJ05ALrdBcPBaFBUViU6rFAqFAtnZ2YiK2iU6hXQYxx4REVUoPT09eHuPhFqdhkGDPDFt2nS0b98RycnJotMqXPPmzdC1axcolSqefJqE4dgjIqJKYW5ujtWrV+HkyRPQ09ODm5sHFIpA3LuXIzqtQgUEKHDhwgWcOXNWdArpKI49IiKqVLa2tjh9Og7ffrsSe/fug1xujU2bwiX78WLu7m5o2bIlgoKUolNIR3HsERFRpdPX14ev73io1Wno1q0bAgImolOnzjh//gfRaeVOJpMhMFCBmJhDuHLliugc0kEce0REJEz9+vUQGhqCo0cP49Gjx2jfvgM++eQT5Obmik4rV4MHe8HcvBaCg0NEp5AO4tgjIiLhXFyckZBwBosWLcTGjRvRtq0Ntm/fIZk3NVSrVg1jx47Bli0RkhuypPk49oiISCNUqVIFkyZNREZGBtq1c8G4cb7o3r0nLl7MEJ1WLnx9x6OgoADh4VtEp5CO4dgjIiKNYmlpiS1bwrFv3x5kZWXByckFs2fPwaNHj0SnvRULCwsMHDhAp84zSJqBY4+IiDSSh0cnJCefw6xZM7B2bQisre2wd+8+rX5qNzBQgRs3buDgwRjRKaRDOPaIiEhjGRkZYfr0z5GWloyPP26D4cNHol+/Afjtt99Ep70RuVwOFxdnnoaFKhXHHhERabz33nsPO3dGIipqBy5dugw7O0csWvQVnjx5IjrttQUEKJCQkIj09HTRKaQjOPaIiEhr9OzZA2lpyZg8+ROsWPENbG0dcPjwYdFZr6VXr56wsrKCUhksOoV0BMceERFplerVq2Pu3C+RnHwOjRs3xsCBXhgyZBhu3LghOq1M9PX1MWGCH6KjdyMrK0t0DukAjj0iItJKzZs3w/ff78XmzZuQmpoGa2s7rFjxDQoLC0Wn/Stv75EwMjLCunWholNIB3DsERGR1pLJZBg4cADU6lSMGzcWCxYshKOjM06ePCU67ZXMzMwwcuQIbNgQppWvOyTtwrFHRERaz8TEBEuXLkZCwlnUrl0bPXv2ho/PGGRl3Rad9o/8/f1w//4DREZGiU4hiePYIyIiyfjoow9x9OhhhIQEIy7uJORyGwQFKTXyJMZNmzZFjx7dERSk0upzB5Lm49gjIiJJkclkGDFiOM6fT8OQIV6YMWMWXFxckZh4TnTaCwIDA5CRkYHY2DjRKSRhHHtERCRJtWrVwqpV3+L06TgYGRnCw6MLJkxQIDv7nui0Uu3bt0Pr1q2hVKpEp5CEcewREZGkWVtbIy7uBL777lscOHAAcrk1NmwIQ3Fxseg0yGQyBAQocOTIUVy6dFl0DkkUxx4REUmevr4+xo0bC7U6Hb169cInn0yGm1snqNVq0Wnw8vJE3bp1oVLx0T2qGBx7RESkM+rWrYO1a1U4fvwoCgoK0b59R0yZMhUPHjwQ1mRkZARf33HYunU77t+/L6yDpItjj4iIdI6TkyPi409j6dLF2L49Em3b2mDr1m3C3hU7duxYFBUVYdOmzQCAkpISvkOXyg3HHhER6SQDAwMEBgZArU5Fx44d4Os7AV27dsfPP1+s9Jb69evBy2sQ1q4NwdOnTxERsQ3t2nWo9A6SJo49IiLSaRYWFggP34gDB/YjOzsbTk4umDlzNh4+fFipHQEBCmRmZmLfvv347bff+JQulRuOPSIiIgBubh1x7lwC5sz5AqGh6yGX2yI6eneFP526f//38PYejXfffQeurq5QKlV49OghatSoUaE/l3QHxx4REdF/GRkZYdq0T5GWlgwbG2uMGuWDPn364fLlijstynvvvYe4uDh07OiOfv36Ijk5BdeuXYeJCccelQ+OPSIiov/DysoKkZHbER0dhatXr8He3gnz5y9Afn5+uf+sNm1a49SpOBgZGWHevPlo0KA+fvrpJz6yR+WGY4+IiOgfdOvWDampSZg6dTJWrVoNW1sHxMQcKvef07hxY8TGHoeTkyPu3LmLzMz/wMDAoNx/Dukmjj0iIqJXqFatGubM+QIpKefQrNn7GDRoMAYNGozr16+X688xNTXFzp2R8PPzBQDcuXO3XG+fdBfHHhERURm8//772Lt3NyIiNuP8+R9gY2OP5cu/RkFBwXPXO3z48BufpFlfXx8rV36NhQvn48svvyiPbCLISt7wbUZ5eXkwMzNDVtYtmJqalncXvYXq1U2Qn1+5pwygV+Mx0Uw8LppJG47Lo0ePsGTJMgQFKdG48XtYuXIFOnVyBwB89FEbtGnTBtu2RQiuLD/acEx0TV5eHiwsLJGbm/uvO4yP7BEREb2mGjVq4KuvFiIxMR7169dHnz790KjRe2jQ4F3cvZuNffv2Y8OGsNLrZ2ZmwtvbB5aWjVC3bgO0a9cBKSkpuHTpMoyNTfHrr5eeu/3Vq4PQsuVH/BQNKhcce0RERG+oVauWOHw4BhMm+OHp0yIUFxdj9Ggf1KlTB1Onfobc3Fw8evQIXbt2R1bWbURFReLcuXhMmTIJz549Q/PmzSCXyxEZGfnc7UZF7YSX1yDIZDJB94ykhGOPiIjoLchkMqxc+TUyMn7CqFEjoFIFw9TUBEVFRZg69TNERe3EvXs52LFjG5ydndC0aVMMHDgADg4OAIDBgwchKmpn6e1dvnwZarUaQ4YMFnWXSGI49oiIiN7SF1/MgYODM7Zu3Q49PT1cu3YdALBjRyRiYmLw8cdtYG5u/tLv9fT0xI0bN5GcnAwAiIyMQps2bdCy5QeVlU8Sx7FHRET0lrZu3YbHjx+jdu3aqFmzJvT0/v9fr6mpaa/8XguLBnB1dS19dG/nzl18VI/KFcceERHRW8jJycHdu9mIjNyOn3/+Eb//fhWHDh0EACxbtgSzZs3Ejz9ewP379//xNgYP9sKuXbuRlJSEq1evYdCggZWVTzqAY4+IiOgt1KpVC7VrmyMsbCOuXLmCkydPYebMWQD++tg1Hx9v1K9fD0OGDENi4jlcu3YNe/fuQ1JSUult9O3bGw8fPsSkSVPh6uqKd955R9TdIQni2CMiInoLenp62LRpI86fPw87O0dMnz4TX321qPT3DQ0NsX//XtStWxcDBnjC3t4JK1d+A319/dLrmJqaokeP7rhw4QIGD/YScTdIwnhSZQniyS81D4+JZuJx0Uw8LpqHx0Tz8KTKRERERASAY4+IiIhI0jj2iIiIiCSMY4+IiIhIwgxEBxAREdHrKX5WgrQbuch+VIi6NQxh08gM+nr8HF16OY49IiIiLXIs4x4WH/kNd/IKSy+rb2qIWV3fR+eWdQSWkabi07hERERa4ljGPUzeefG5oQcAd/MKMXnnRRzLuCeojDQZxx4REZEWKH5WgsVHfsPLTo77v8uWHLmC4mdvdPpckjCOPSIiIi2QdiP3hUf0/q4EwO28AqTdyK28KNIKHHtERERaIPvRPw+9N7ke6Q6OPSIiIi1Qt4ZhuV6PdAfHHhERkRawaWSG+qaG+KcTrMgANDA1gk0js8rMIi3AsUdERKQF9PVkmNX1fQB4YfD979czuzbl+fboBRx7REREWqJzyzpYNagV6pk+/1RtfVMjrBrUiufZo5fiSZWJiIi0SOeWdeDeojY/QYPKjGOPiIhIy+jryWD/Xk3RGaQl+DQuERERkYRx7BERERFJGMceERERkYRx7BERERFJGMceERERkYRx7BERERFJGMceERERkYSV+Tx7BQUFKCgoKP11Xl5ehQQRERERUfkp89hbsmQJ5s+f/8Ll1auboHp1k3KNorfHY6J5eEw0E4+LZuJx0Tw8JpqlqKikzNeVlZSUlOnaL3tkr2HDhsjKugVTU9PXr6QKU726CfLzH4rOoL/hMdFMPC6aicdF8/CYaJ68vDxYWFgiNzf3X3dYmR/ZMzIygpGR0VvHEREREVHl4Rs0iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCSMY4+IiIhIwjj2iIiIiCTM4E2/saSkBADw8OHDcouh8lFUVIL8fB4XTcJjopl4XDQTj4vm4THRPP/bX//bY6/yxmMvJycHANC8ecs3vQkiIiIiegs5OTkwMzN75XXeeOyZm5sDAG7cuPGvP4QqT15eHho2bIibN2/C1NRUdA6Bx0RT8bhoJh4XzcNjoplyc3PRqFGj0j32Km889vT0/nq5n5mZGQ++BjI1NeVx0TA8JpqJx0Uz8bhoHh4TzfS/PfbK61RCBxEREREJwrFHREREJGFvPPaMjIwwd+5cGBkZlWcPvSUeF83DY6KZeFw0E4+L5uEx0Uyvc1xkJWV5zy4RERERaSU+jUtEREQkYRx7RERERBLGsUdEREQkYRx7RERERBLGsUdEREQkYRx7RERERBLGsUdEREQkYRx7RERERBL2/wBnW3q2sHsZYgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABLYAAAGbCAYAAADZbBnaAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8o6BhiAAAACXBIWXMAAA9hAAAPYQGoP6dpAABt+0lEQVR4nO3deZyN9f//8eeZfTcMso99y74vMYSUXZ+UJWsb8RGp5FMyKFQS7YWIQqEkJLK1WJqSpUiSpT74KtvYMzPv3x9+cz6OmWEOc5brmsf9dpvbzbmu65zrdV3nPK/rnJdrcRhjjAAAAAAAAACLCfB1AQAAAAAAAMD1oLEFAAAAAAAAS6KxBQAAAAAAAEuisQUAAAAAAABLorEFAAAAAAAAS6KxBQAAAAAAAEuisQUAAAAAAABLorEFAAAAAAAAS6KxBQAAAAAAAEuisQXAMmbOnCmHw5Hl39q1a31dYo4oWbKk+vTp4+syMvXPP/+of//+Kly4sAIDA1WjRg1fl5TBvn375HA4NHPmTF+XIklav369EhMTdeLEiQzjmjVrpmbNmnm9piv16dPHL+rwZ4mJiXI4HL4u44Z8+OGHuvnmmxUeHi6Hw6EtW7b4uqQcsXbtWkvuAxwOhxITE52P0/dx+/btc+t1xo0bp0WLFuVobVbw9ddfKzQ0VPv373cOa9asmapUqXLV53388cfq1q2bypYtq/DwcJUsWVI9evTQ7t27PV2y1/36668KCQnR5s2bfV0KAHhUkK8LAAB3zZgxQxUrVswwvHLlyj6oJnd588039fbbb+vVV19V7dq1FRUV5euS/N769es1evRo9enTR7GxsS7j3njjDd8UBbfdf//9uv32231dxnX766+/1LNnT91+++164403FBoaqvLly/u6rBxRq1YtbdiwwfL7gLZt22rDhg0qXLiwW88bN26c7rrrLnXq1MkzhfkhY4yGDBmiBx54QPHx8W499/nnn1ehQoX01FNPqXTp0vrjjz80btw41apVSxs3btTNN9/soaq9r3z58urRo4eGDh2qdevW+bocAPAYGlsALKdKlSqqU6eOr8vIlX766SeFh4dr0KBBvi7FFqz+Qzw3OHv2rCIiIlSsWDEVK1bM1+Vct19//VUXL17Uvffeq4SEhBx5zfR14ysXL16Uw+FQTEyMGjRo4LM6ckqBAgVUoEABX5dhCcuXL9fmzZs1Z84ct5/72WefqWDBgi7Dbr31VpUsWVIvv/yypk2bllNlXrfU1FSlpKQoNDT0hl9r0KBBqlOnjtavX69GjRrlQHUA4H84FRGA7cybN08Oh0Ovvfaay/BRo0YpMDBQK1eudA4bPXq06tevr3z58ikmJka1atXS9OnTZYxxeW7JkiXVrl07LVmyRDVr1lR4eLgqVaqkJUuWSLp0CkmlSpUUGRmpevXq6fvvv3d5fp8+fRQVFaWff/5ZLVq0UGRkpAoUKKBBgwbp7Nmz11ym5ORkPfbYYypVqpRCQkJUtGhRDRkyRGfOnHGZbv78+apfv77y5MmjiIgIlS5dWv369bvm658/f14jRoxwef2BAwe6nD7ncDg0bdo0nTt3znn657VO9/vyyy/VokULxcTEKCIiQo0bN9aqVauc43fv3q2YmBh16dLF5XmrV69WYGCgRo4c6RyW/h588sknqlatmsLCwlS6dGm98sor11y+3377TX379lW5cuUUERGhokWLqn379tq+fbvLdOmnNM2dO1dPPfWUihQpopiYGLVs2VK7du1ymXblypXq2LGjihUrprCwMJUtW1YPPfSQ/v77b+c0iYmJevzxxyVJpUqVynDabGanIh47dkwPP/ywihYtqpCQEJUuXVpPPfWULly44DKdw+HQoEGDNHv2bFWqVEkRERGqXr268zOZ7q+//tKDDz6o4sWLKzQ0VAUKFFDjxo315ZdfXnO9ZWbOnDlq2LChoqKiFBUVpRo1amj69Oku07z77ruqXr26wsLClC9fPnXu3Fk7d+50mSY9E7/88otat26tyMhIFS5cWBMmTJAkbdy4UbfccosiIyNVvnx5vffeey7PTz9ta+XKlerbt6/y5cunyMhItW/fXr///rvLtNl5r6T/nW64efNm3XXXXcqbN6/KlCnjMu5yq1evVrNmzRQXF6fw8HCVKFFC//rXv1wy7Q/vZ58+fXTLLbdIku655x45HA6Xz93ixYvVsGFDRUREKDo6Wq1atdKGDRuyvW6utHXrVjkcjgyfC0n6/PPP5XA4tHjxYknuZ3P27NkaNmyYihYtqtDQUP32229ZnoqYneXq06ePSpYsmaHOzN7v692+Jicn64EHHlBcXJyioqJ0++2369dff80wXWanIv74449q166dChYsqNDQUBUpUkRt27bVn3/+KenS5+bMmTN67733nNuX9Pf2r7/+0sMPP6zKlSsrKipKBQsW1K233qqvv/7aZb7pp29PnDhRkyZNUqlSpRQVFaWGDRtq48aNGerctGmT2rdvr7i4OIWFhalMmTIaMmSIyzS7d+9W9+7dnXVXqlRJr7/+uss0aWlpevbZZ1WhQgWFh4crNjZW1apV05QpU665Tt98803VrVtXFSpUuOa0V7qyqSVJRYoUUbFixfTHH39c8/nppzsmJSWpSZMmzs/ChAkTlJaW5jLtgQMHdO+997qsh5deeslluvT1/8ILL+jZZ59VqVKlFBoaqjVr1jg/h9u2bVOXLl2UJ08e5cuXT48++qhSUlK0a9cu3X777YqOjlbJkiX1wgsvZKi3du3aqlSpkt566y231xUAWIYBAIuYMWOGkWQ2btxoLl686PKXkpLiMm3//v1NSEiISUpKMsYYs2rVKhMQEGCefvppl+n69Oljpk+fblauXGlWrlxpxo4da8LDw83o0aNdpouPjzfFihUzVapUMXPnzjXLli0z9evXN8HBweaZZ54xjRs3Nh9//LH55JNPTPny5c1NN91kzp4963x+7969TUhIiClRooR57rnnzIoVK0xiYqIJCgoy7dq1yzCv3r17Ox+fOXPG1KhRw+TPn99MmjTJfPnll2bKlCkmT5485tZbbzVpaWnGGGPWr19vHA6H6dq1q1m2bJlZvXq1mTFjhunZs+dV12taWppp3bq1CQoKMiNHjjQrVqwwEydONJGRkaZmzZrm/PnzxhhjNmzYYNq0aWPCw8PNhg0bzIYNG8yRI0eyfN3Zs2cbh8NhOnXqZD7++GPz2WefmXbt2pnAwEDz5ZdfOqebN2+ekWSmTJlijDHm0KFD5qabbjIJCQku72t8fLwpWrSoKVGihHn33XfNsmXLTI8ePYwk8+KLLzqn27t3r5FkZsyY4Ry2bt06M2zYMLNgwQKzbt0688knn5hOnTqZ8PBw88svvzinW7NmjZFkSpYsaXr06GGWLl1q5s6da0qUKGHKlSvnUs+bb75pxo8fbxYvXmzWrVtn3nvvPVO9enVToUIF888//xhjjPnjjz/Mv//9byPJfPzxx871dvLkSWOMMQkJCSYhIcH5mufOnTPVqlUzkZGRZuLEiWbFihVm5MiRJigoyLRp08Zl/abXWa9ePfPRRx+ZZcuWmWbNmpmgoCCzZ88e53StW7c2BQoUMO+8845Zu3atWbRokXnmmWfMvHnzsv5QZGHkyJFGkrnzzjvN/PnzzYoVK8ykSZPMyJEjndOMGzfOSDLdunUzS5cuNbNmzTKlS5c2efLkMb/++qtzuvRMVKpUyUyZMsWsXLnS9O3b10gyI0aMMOXLlzfTp083X3zxhWnXrp2RZL7//nvn89O3B8WLFzf9+vUzn3/+uXnnnXdMwYIFTfHixc3x48fdeq+MMWbUqFFGkomPjzfDhw83K1euNIsWLXIZl27v3r0mLCzMtGrVyixatMisXbvWfPDBB6Znz57OefvL+/nbb7+Z119/3Ugy48aNMxs2bDA///yzMcaYDz74wEgyt912m1m0aJH58MMPTe3atU1ISIj5+uuvs7VuMlOzZk3TuHHjDMPvvvtuU7BgQXPx4kVjjPvZLFq0qLnrrrvM4sWLzZIlS8zRo0ed49asWeOcPrvL1bt3bxMfH5+hzivf7xvZvjZv3tyEhoY6t/2jRo0ypUuXNpLMqFGjnNOmf6b37t1rjDHm9OnTJi4uztSpU8d89NFHZt26debDDz80/fv3Nzt27DDGXNouh4eHmzZt2ji3L+nv7S+//GIGDBhg5s2bZ9auXWuWLFli7rvvPhMQEOCyrtK3mSVLljS33367WbRokVm0aJGpWrWqyZs3rzlx4oRz2uXLl5vg4GBTrVo1M3PmTLN69Wrz7rvvmq5duzqn+fnnn02ePHlM1apVzaxZs8yKFSvMsGHDTEBAgElMTHRON378eBMYGGhGjRplVq1aZZYvX24mT57sMk1mLly4YMLDw80TTzyRYVxCQoK5+eabr/r8zOzZs8cEBASYoUOHXnPahIQEExcXZ8qVK2feeusts3LlSvPwww8bSea9995zTnfkyBFTtGhRU6BAAfPWW2+Z5cuXm0GDBhlJZsCAAc7p0td/0aJFTfPmzc2CBQvMihUrzN69e52fwwoVKpixY8ealStXmieeeMJIMoMGDTIVK1Y0r7zyisv2c+HChRlqHjBggMmfP7/z+wIA2A2NLQCWkf6lP7O/wMBAl2nPnz9vatasaUqVKmV27NiRaaPkSqmpqebixYtmzJgxJi4uzuULYHx8vAkPDzd//vmnc9iWLVuMJFO4cGFz5swZ5/BFixYZSWbx4sXOYb1793Zp3qR77rnnjCTzzTffuMzr8sbW+PHjTUBAgLNJl27BggVGklm2bJkxxpiJEycaSS4/QrJj+fLlRpJ54YUXXIZ/+OGHRpJ55513XJYjMjLymq955swZky9fPtO+fXuX4ampqaZ69eqmXr16LsMHDBhgQkJCzIYNG8ytt95qChYsaA4ePOgyTXx8vHE4HGbLli0uw1u1amViYmKc70Fmja0rpaSkmH/++ceUK1fO5YdM+g/kK5sOH330kZFkNmzYkOnrpaWlmYsXL5r9+/cbSebTTz91jnvxxRddfqxe7srG1ltvvWUkmY8++shluueff95IMitWrHAOk2Ruuukmk5yc7Bx2+PBhExAQYMaPH+8cFhUVZYYMGZLlusiu33//3QQGBpoePXpkOc3x48edP7Ivd+DAARMaGmq6d+/uHJaeict/hF28eNEUKFDASDKbN292Dj969KgJDAw0jz76qHNY+vagc+fOLvP69ttvjSTz7LPPZlrj1d6r9B+RzzzzTIbnXdnoSM/flZ/Hy/nT+5n+2Z4/f75zWGpqqilSpIipWrWqSU1NdQ4/deqUKViwoGnUqJFz2NXWTWZeeeUVI8ns2rXLOezYsWMmNDTUDBs2LMvnXSubTZs2zXLZ0ps17ixXdhtb17t9/fzzz6+67b9aY+v77783kq7aQDTGmMjISJd9RlZSUlLMxYsXTYsWLVxyk77NrFq1qss+8rvvvjOSzNy5c53DypQpY8qUKWPOnTuX5Xxat25tihUr5mzgpxs0aJAJCwszx44dM8YY065dO1OjRo1r1n2lTZs2GUmZNnOvp7F18eJF06xZMxMTE2MOHDhwzekTEhKMJLNp0yaX4ZUrVzatW7d2Pn7yyScznW7AgAHG4XA4s5G+/suUKePSaDfmf5/Dl156yWV4jRo1nP9hcvlyFChQwNx5550Zap46daqRZHbu3HnN5QMAK+JURACWM2vWLCUlJbn8bdq0yWWa0NBQffTRRzp69Khq1aolY4zmzp2rwMBAl+lWr16tli1bKk+ePAoMDFRwcLCeeeYZHT16VEeOHHGZtkaNGipatKjzcaVKlSRdOi3h8uvMpA+//E5N6Xr06OHyuHv37pKkNWvWZLm8S5YsUZUqVVSjRg2lpKQ4/1q3bu1y+k3dunUlSXfffbc++ugj/fe//83yNa9cB5Iy3ImxS5cuioyMdDl1MLvWr1+vY8eOqXfv3i41p6Wl6fbbb1dSUpLLaZQvv/yybr75ZjVv3lxr167V+++/n+kFlG+++WZVr17dZVj37t2VnJx81bs+paSkaNy4capcubJCQkIUFBSkkJAQ7d69O8MpcpLUoUMHl8fVqlWT5PqeHjlyRP3791fx4sUVFBSk4OBg50WMM3vN7Fi9erUiIyN11113uQxPf2+ufC+aN2+u6Oho5+ObbrpJBQsWdKmzXr16mjlzpp599llt3LhRFy9evK7aVq5cqdTUVA0cODDLaTZs2KBz585l+CwVL15ct956a4b6HQ6H2rRp43wcFBSksmXLqnDhwqpZs6ZzeL58+TIsV7orM9WoUSPFx8e7ZMrd9+pf//pXlsuYrkaNGgoJCdGDDz6o9957L8Ppj5J/v5+StGvXLh08eFA9e/ZUQMD/vhJGRUXpX//6lzZu3JjhVOnsrBvp0vsSGhrqcrry3LlzdeHCBfXt29c5zN1sZmf+17Nc13K929f0z2FW2/6rKVu2rPLmzavhw4frrbfe0o4dO9yqWZLeeust1apVS2FhYc7P/qpVqzJdt23btnXZR1653fv111+1Z88e3XfffQoLC8t0fufPn9eqVavUuXNnRUREuGz/27Rpo/PnzztPb6xXr562bt2qhx9+WF988YWSk5OztUwHDx6UlPkphe4yxui+++7T119/rVmzZql48eLZel6hQoVUr149l2HVqlVzyerq1atVuXLlDNP16dNHxhjnvjddhw4dFBwcnOn82rVr5/K4UqVKcjgcuuOOO5zD0refmW0n09dVdj+3AGA1NLYAWE6lSpVUp04dl7/atWtnmK5s2bJq0qSJzp8/rx49emRolHz33Xe67bbbJElTp07Vt99+q6SkJD311FOSpHPnzrlMny9fPpfHISEhVx1+/vx5l+FBQUGKi4tzGVaoUCFJ0tGjR7Nc3v/7v//Ttm3bFBwc7PIXHR0tY4zzOkFNmzbVokWLlJKSol69eqlYsWKqUqWK5s6dm+Vrp887KCgow0WLHQ6HChUqdNXarlazJN11110Z6n7++edljNGxY8ec04eGhqp79+46f/68atSooVatWmX6uunrK7NhV6vz0Ucf1ciRI9WpUyd99tln2rRpk5KSklS9evUM77OkDO9T+gV806dNS0vTbbfdpo8//lhPPPGEVq1ape+++875gy2z18yOo0ePqlChQhmu7VOwYEEFBQVlWMYr60yv9fL5f/jhh+rdu7emTZumhg0bKl++fOrVq5cOHz7sVm1//fWXJF31Aurp9WXWlCxSpEiG+iMiIjL8QA4JCcmQqfThV2ZKyvozkT6v63mvsnNXujJlyujLL79UwYIFNXDgQJUpU0ZlypRxuT6QP7+f6fVJWb9faWlpOn78uMvw7N6xL1++fOrQoYNmzZql1NRUSZeuIVWvXj2Xu865m83szP96lutabnT7mtW2/2ry5MmjdevWqUaNGvrPf/6jm2++WUWKFNGoUaOy1dCcNGmSBgwYoPr162vhwoXauHGjkpKSdPvtt1/Xdi+724CUlBS9+uqrGbb96U3s9H3WiBEjNHHiRG3cuFF33HGH4uLi1KJFiwzXqLxSej1ZNdeyyxij+++/X++//75mzpypjh07Zvu52cnq0aNHs/wMpo+/3NU+25l9z8hq+5nZdjJ9uuvdNwGAv+OuiABsa9q0aVq6dKnq1aun1157Tffcc4/q16/vHD9v3jwFBwdryZIlLl8OFy1a5JF6UlJSdPToUZcvxOk/RjP7kpwuf/78Cg8P17vvvpvl+HQdO3ZUx44ddeHCBW3cuFHjx49X9+7dVbJkSTVs2DDT58fFxSklJUV//fWXS3PLGKPDhw87j1RwR3pNr776apZ3K7vpppuc//7pp5/0zDPPqG7dukpKStKkSZP06KOPZnhOZj/es7MO33//ffXq1Uvjxo1zGf73338rNjb2mstzpZ9++klbt27VzJkz1bt3b+fw3377ze3XulxcXJw2bdokY4xLM+TIkSNKSUlxea+zK3/+/Jo8ebImT56sAwcOaPHixXryySd15MgRLV++PNuvk/7Z+PPPP7M8qiH9PTh06FCGcQcPHryu+q8lq89E2bJlJV3fe3VlIyorTZo0UZMmTZSamqrvv/9er776qoYMGaKbbrpJXbt29ev3U7r2+xUQEKC8efO6DM/uupGkvn37av78+Vq5cqVKlCihpKQkvfnmmy7TuJvN7MzfneUKCwvLcCH/9Plf6Ua2r1lt+6+latWqmjdvnowx2rZtm2bOnKkxY8YoPDxcTz755FWf+/7776tZs2YZ1vmpU6eyNe8rXb4NyErevHkVGBionj17Znl0Z6lSpSRd+s+eRx99VI8++qhOnDihL7/8Uv/5z3/UunVr/fHHH1necTM9N5f/54i70ptaM2bM0PTp03Xvvfde92tlJS4uLsvPoKQM+XcnW+5KX1ee2AYDgD/giC0AtrR9+3YNHjxYvXr10tdff61q1arpnnvucflfeofDoaCgIJdTL86dO6fZs2d7rK4PPvjA5XH6rcqvvDPe5dq1a6c9e/YoLi4uw5FqderUyfSOXqGhoUpISNDzzz8v6dKdtbLSokULSZd+BF1u4cKFOnPmjHO8Oxo3bqzY2Fjt2LEj05rr1KnjPLLtzJkz6tKli0qWLKk1a9Zo0KBBevLJJzOcXipJP//8s7Zu3eoybM6cOYqOjlatWrWyrMfhcGS4bfrSpUuv+7SM9B8gV77m22+/nWHaK496uJoWLVro9OnTGZqrs2bNco6/ESVKlNCgQYPUqlWrq566mZnbbrtNgYGBGX4kX65hw4YKDw/P8Fn6888/tXr16huuPzNXZmr9+vXav3+/M1PuvFfXKzAwUPXr13fe9S193frz+ylJFSpUUNGiRTVnzhyXO8GeOXNGCxcudN5R8HrddtttKlq0qGbMmKEZM2YoLCxM3bp1c5kmp7MpubdcJUuW1JEjR5xHmUrSP//8oy+++CLL13dn+9q8eXNJWW/7s8vhcKh69ep6+eWXFRsb6/J+X3mk0OXPuXLdbtu2LcOdIbOrfPnyKlOmjN59991Mm4HSpaMwmzdvrh9//FHVqlXLdNuf2X9CxMbG6q677tLAgQN17NgxlztDXin9dP89e/Zc13IYY/TAAw9oxowZevvtt11Ojc1JLVq00I4dOzJkc9asWXI4HM7Phjf8/vvvCggIuK67SAKAFXDEFgDL+emnn5SSkpJheJkyZVSgQAGdOXNGd999t0qVKqU33nhDISEh+uijj1SrVi317dvX+SOzbdu2mjRpkrp3764HH3xQR48e1cSJEzP8EMgpISEheumll3T69GnVrVtX69ev17PPPqs77rhDt9xyS5bPGzJkiBYuXKimTZtq6NChqlatmtLS0nTgwAGtWLFCw4YNU/369fXMM8/ozz//VIsWLVSsWDGdOHFCU6ZMUXBwsBISErJ8/VatWql169YaPny4kpOT1bhxY23btk2jRo1SzZo11bNnT7eXNSoqSq+++qp69+6tY8eO6a677lLBggX1119/aevWrfrrr7+cDZL+/fvrwIED+u677xQZGamXXnpJGzZsUNeuXfXjjz+6HLVRpEgRdejQQYmJiSpcuLDef/99rVy5Us8///xVf4C3a9dOM2fOVMWKFVWtWjX98MMPevHFF696Ss3VVKxYUWXKlNGTTz4pY4zy5cunzz77TCtXrswwbdWqVSVJU6ZMUe/evRUcHKwKFSq4XEspXa9evfT666+rd+/e2rdvn6pWrapvvvlG48aNU5s2bdSyZUu36jx58qSaN2+u7t27q2LFioqOjlZSUpKWL1+uO++8063XKlmypP7zn/9o7NixOnfunLp166Y8efJox44d+vvvvzV69GjFxsZq5MiR+s9//qNevXqpW7duOnr0qEaPHq2wsDCNGjXKrXlmx/fff6/7779fXbp00R9//KGnnnpKRYsW1cMPPyzJvffKHW+99ZZWr16ttm3bqkSJEjp//rzzqMr098mf309JCggI0AsvvKAePXqoXbt2euihh3ThwgW9+OKLOnHihCZMmOD2a14uMDBQvXr10qRJkxQTE6M777xTefLkcZkmp7Pp7nLdc889euaZZ9S1a1c9/vjjOn/+vF555RXn6ZPprnf7etttt6lp06Z64okndObMGdWpU0fffvtttv4DZcmSJXrjjTfUqVMnlS5dWsYYffzxxzpx4oTL6dpVq1bV2rVr9dlnn6lw4cKKjo5WhQoV1K5dO40dO1ajRo1SQkKCdu3apTFjxqhUqVKZ7kOz4/XXX1f79u3VoEEDDR06VCVKlNCBAwf0xRdfOJt3U6ZM0S233KImTZpowIABKlmypE6dOqXffvtNn332mfPaUu3bt1eVKlVUp04dFShQQPv379fkyZMVHx+vcuXKZVlDsWLFVLp0aW3cuFGDBw/OMD45OVkLFizIMLxAgQJKSEjQ4MGDNX36dPXr109Vq1Z1npYsXWoSXn59vxsxdOhQzZo1S23bttWYMWMUHx+vpUuX6o033tCAAQNUvnz5HJlPdmzcuFE1atTIcAQmANiG1y9XDwDX6Wp3RZRkpk6daowx5t577zURERHOW56nmz9/vpFkXn75Zeewd99911SoUMGEhoaa0qVLm/Hjx5vp06dnuItdfHy8adu2bYaaJJmBAwe6DEu/w9GLL77oHJZ+N8Ft27aZZs2amfDwcJMvXz4zYMAAc/r0aZfnX3lXRGMu3fb96aefNhUqVDAhISHOW6kPHTrUHD582BhjzJIlS8wdd9xhihYtakJCQkzBggVNmzZtXG5tn5Vz586Z4cOHm/j4eBMcHGwKFy5sBgwYYI4fP+4yXXbviphu3bp1pm3btiZfvnwmODjYFC1a1LRt29Z5Z7b0OzVdeQfD3377zcTExJhOnTq5rJe2bduaBQsWmJtvvtmEhISYkiVLmkmTJrk8N7O7Ih4/ftzcd999pmDBgiYiIsLccsst5uuvv85wV8LM7hyX1Wvu2LHDtGrVykRHR5u8efOaLl26mAMHDmS405kxxowYMcIUKVLEBAQEuNy97cr5G3PpDoD9+/c3hQsXNkFBQSY+Pt6MGDHCnD9/3mW6zD576esp/fNz/vx5079/f1OtWjUTExNjwsPDTYUKFcyoUaNc7uTpjlmzZpm6deuasLAwExUVZWrWrJnh/Zs2bZqpVq2a87PasWPHDHnM6rOU1V3Nrsxg+vZgxYoVpmfPniY2NtZ5R8bdu3e7PDe771X6Hcj++uuvDPO/8i55GzZsMJ07dzbx8fEmNDTUxMXFmYSEBJe7oRrjP+9nVp9tYy7dybV+/fomLCzMREZGmhYtWphvv/020+XPbN1cza+//urcRq9cuTLD+BvN5uXj0nPlznIZY8yyZctMjRo1THh4uCldurR57bXXMrzfN7J9PXHihOnXr5+JjY01ERERplWrVuaXX3655l0Rf/nlF9OtWzdTpkwZEx4ebvLkyWPq1atnZs6c6fL6W7ZsMY0bNzYRERFGknO9XbhwwTz22GOmaNGiJiwszNSqVcssWrQow50gM9tnpctse7ZhwwZzxx13mDx58pjQ0FBTpkwZlztYpr9mv379TNGiRU1wcLApUKCAadSokcvdSl966SXTqFEjkz9/fhMSEmJKlChh7rvvPrNv375rrtORI0eavHnzZshR+h0LM/tLXy/x8fFZTpPZHTKvlNU2KrM7bO7fv990797dxMXFmeDgYFOhQgXz4osvutyt82rrP6vcubP9PHXqlImIiMhwZ0UAsBOHMZcdow0A8Ig+ffpowYIFOn36tK9LsaySJUuqSpUqWrJkia9LgR+YOXOm+vbtq6SkJNWpU8fX5QDwooMHD6pUqVKaNWuW7rnnHl+X49emT5+uRx55RH/88QdHbAGwLa6xBQAAAMAyihQpoiFDhui5555TWlqar8vxWykpKXr++ec1YsQImloAbI1rbAEAAACwlKeffloRERH673//m+WdWnO7P/74Q/fee6+GDRvm61IAwKM4FREAAAAAAACWxKmIAAAAAAAAsCQaWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsCQaWxYwc+ZMORwOff/999ectk+fPipZsuR1zWft2rVyOBxZ/vXv399l+h9//FGdOnVSkSJFFBERoYoVK2rMmDE6e/bsdc0fsBtvZffQoUN6+umn1bBhQ+XPn18xMTGqXbu23nnnHaWmprpMu2XLFrVt21YlSpRQeHi48uXLp4YNG+r999/P8LrGGL3yyiuqWLGiQkNDVbhwYQ0YMEDHjx+/rjoBK/NWniXp/vvvV5UqVRQbG6vw8HCVL19ejz/+uP7+++8M054+fVpDhgxRkSJFFBYWpho1amjevHmZ1pTZvr1ixYrXXSdgJ97M+KxZs9S1a1dVqFBBAQEBV30tvm8D7vFmliXp77//1iOPPKKSJUsqNDRUN910k+644w4dO3bMZTqy7FlBvi4A/qNWrVrasGFDhuFvvvmmZs2apc6dOzuH7dixQ40aNVKFChU0efJk5c+fX1999ZXGjBmjH374QZ9++qk3SwdytR9++EGzZs1Sr169NHLkSAUHB+vzzz/XgAEDtHHjRr377rvOaU+cOKHixYurW7duKlq0qM6cOaMPPvhAPXv21L59+/T00087p33sscc0efJkPfbYY2rZsqV27NihZ555RklJSdqwYYOCg4N9sbiA7Z05c0YPPvigypYtq7CwMH3//fd67rnntGzZMv34448KCQlxTnvnnXcqKSlJEyZMUPny5TVnzhx169ZNaWlp6t69u8vrhoeHa/Xq1RmGAfCu2bNn6/Dhw6pXr57S0tJ08eLFTKfj+zbg3w4ePKgmTZooKChII0eOVLly5fT3339rzZo1+ueff5zTkWXPo7EFp5iYGDVo0MBlmDFGPXr0UHx8vFq1auUcPmfOHJ0/f14LFy5UmTJlJEm33nqrDh06pHfeeUfHjx9X3rx5vVo/kFs1btxYe/bscWk0tWrVSv/8849ef/11jR49WsWLF5ckNWvWTM2aNXN5frt27bR371698847zsbWf//7X02ZMkUDBw7U888/73zNggULqnv37po5c6YeeOAB7ywgkMvMnTvX5fGtt96q6OhoPfzww/rmm2906623SpKWLVumlStXOptZktS8eXPt379fjz/+uO655x4FBgY6XycgICDDfh6A933xxRcKCLh04ky7du30008/ZTod37cB//bwww/rwoUL+v77712yeOedd7pMR5Y9j1MRLWzmzJmqUKGCQkNDValSJc2aNSvH57FmzRr9/vvv6tu3r3MHLMn5AzpPnjwu08fGxiogIMDlf5MBuMrp7ObNmzfTo6fq1asnSfrzzz+v+Rr58+dXUND//q9j48aNSk1NVZs2bVyma9eunSRp4cKFN1IyYBve2BdLUoECBSTJJaeffPKJoqKi1KVLF5dp+/btq4MHD2rTpk0eqQXITTyR8cu/U18N37eBnJPTWd63b58WL16sBx544JpNKbLseTS2LGrmzJnq27evKlWqpIULF+rpp5/W2LFjM5xiIP3vuhr79u1zez7Tp09XQECA+vbt6zK8d+/eio2N1YABA/T777/r1KlTWrJkid5++20NHDhQkZGR17togK15K7uStHr1agUFBal8+fIZxqWlpSklJUV//fWX3njjDX3xxRcaPny4c3z64dOhoaEuzwsODpbD4dC2bduuqybATjyd55SUFJ05c0bffvutRo4cqVtuuUWNGzd2jv/pp59UqVIll2aXJFWrVs05/nLnzp1ToUKFFBgYqGLFimnQoEEZrgEC4H+8uc/ODN+3gZzhiSx//fXXMsaoSJEi6tatm6KiohQWFqZmzZpluLwPWfY8TkW0oLS0ND311FOqVauWPvnkEzkcDknSLbfconLlyqlIkSIu0wcGBiowMNA5XXadOHFCH3/8sVq1aqUSJUq4jCtZsqQ2bNigzp07Ow+nlKTBgwdr8uTJ17dggM15K7uStGLFCs2ePVuPPPKI4uLiMox/+OGH9fbbb0uSQkJC9Morr+ihhx5yjq9cubIk6dtvv1Xz5s2dw9evXy9jjI4ePep2TYCdeDrPGzduVMOGDZ2P27Rpo3nz5rmcWnj06FGVLl06w3Pz5cvnHJ+uevXqql69uqpUqSJJWrdunV5++WWtWrVKSUlJioqKyuaSA7mDN/fZWeH7NnDjPJXl//73v5IuXZO2efPmWrhwoc6cOaPRo0fr1ltv1aZNm5z/0USWPY8jtixo165dOnjwoLp37+4SuPj4eDVq1CjD9NOnT1dKSori4+Pdms8HH3yg8+fP6/77788wbt++fWrfvr3i4uK0YMECrVu3Ti+88IJmzpyZ6fQAvJfdzZs36+6771aDBg00fvz4TKf5z3/+o6SkJC1dulT9+vXToEGDNHHiROf46tWrq2nTpnrxxRc1f/58nThxQuvXr1f//v0VGBiY7dMoALvydJ6rVq2qpKQkrVu3TlOmTNGPP/6oVq1aZbh70tW+eF8+bujQoRo6dKhatWqlVq1a6dlnn9WsWbP0yy+/aOrUqdmqCchNvLXPvhq+bwM3zlNZTktLkyQVK1ZMCxcuVOvWrXXnnXdq+fLlCggI0AsvvOCclix7HkdsWVD6/8AWKlQow7hChQrl2CHQ06dPV4ECBdSxY8cM45588kklJydry5YtzkMnmzZtqvz586tfv37q1auXEhIScqQOwC68kd30H7/lypXTsmXLMpxKmK5EiRLOIzHTr6M1YsQI9e7d23ktn/nz56tPnz66++67JV06smvo0KH68ssvdeLEiRuuFbAyT+c5MjJSderUkXRp/1q/fn01aNBAb7/9toYOHSpJiouLy/ToyfTTC9OP3MpK586dFRkZqY0bN95QrYAdeev79tXwfRu4cZ7KcvoZES1btnQ5mrpw4cKqXr26Nm/e7BxGlj2P/3K3oPQQHT58OMO4zIZdjx9//FE//vijevXqlelFqbds2aLKlStnOB+4bt26kjJe1wOA57P7448/qmXLloqPj9eKFSsyXKDyaurVq6eUlBT9/vvvzmEFCxbUsmXL9H//93/aunWrjhw5ojFjxujXX39V06ZNb7hewMq8sS++XJ06dRQQEKBff/3VOaxq1arauXOnUlJSXKbdvn27JDlPO7waYwxHYAKZ8HbGM8P3beDGeSrL6acZZubKfStZ9jy+yVhQhQoVVLhwYc2dO1fGGOfw/fv3a/369Tkyj+nTp0uS7rvvvkzHFylSRD///LNOnz7tMjz9QnnFihXLkToAO/Fkdrds2aKWLVuqWLFiWrlypdu3DF6zZo0CAgIyvV5PwYIFVa1aNeXJk0dvvfWWzpw5o0GDBt1QvYDVeWNffLl169YpLS1NZcuWdQ7r3LmzTp8+neEupe+9956KFCmi+vXrX/U1FyxYoLNnz6pBgwY5Xi9gdd7OeGb4vg3cOE9luX79+ipWrJhWrFih1NRU5/CDBw9q69atLvtWsux5nIpoQQEBARo7dqzuv/9+de7cWQ888IBOnDihxMTETA+xvO+++/Tee+9pz5492Trv//z585ozZ44aNWqkSpUqZTrNkCFD1KlTJ7Vq1UpDhw5V/vz5tXHjRo0fP16VK1fWHXfcccPLCdiNp7K7a9cutWzZUpL03HPPaffu3dq9e7dzfJkyZZynFz744IOKiYlRvXr1dNNNN+nvv//W/Pnz9eGHH+rxxx93TifJed2dMmXK6MSJE/r88881ffp0jRs3TrVq1cqRdQJYlafyvGTJEk2dOlUdOnRQfHy8Ll68qO+//16TJ09W2bJlXa7Fcccdd6hVq1YaMGCAkpOTVbZsWc2dO1fLly/X+++/7zw1Yv/+/erevbu6du2qsmXLyuFwaN26dZo8ebJuvvlmru8BZMKT37d37NihHTt2SLp0xMjZs2e1YMECSZdu3pJ+Axe+bwM3zlNZDggI0Msvv6y7775bHTt21IABA3TmzBmNHTtWISEhGjFihHNasuwFBn5vxowZRpJJSkpyGT5t2jRTrlw5ExISYsqXL2/effdd07t3bxMfH+8yXe/evY0ks3fv3mzN74MPPjCSzLvvvnvV6VavXm1uu+02U6hQIRMeHm7Kly9vhg0bZv7++293Fg+wLW9lN30+Wf3NmDHDOe27775rmjRpYvLnz2+CgoJMbGysSUhIMLNnz87wum+//bapVKmSiYiIMFFRUaZJkyZm0aJF17s6AEvzVp537txp7rrrLhMfH2/CwsJMWFiYqVixonn88cfN0aNHM0x/6tQpM3jwYFOoUCETEhJiqlWrZubOnesyzbFjx0znzp1NyZIlTXh4uAkJCTHlypUzTzzxhDlx4sR1rQ/Abrz5fXvUqFFZ7rNHjRrlMi3ftwH3ePu386JFi0zdunVNWFiYyZMnj+nQoYP5+eefM0xHlj3LYcxlx+MBAAAAAAAAFsE1tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tvxIWlqaoqKiNGzYMF+Xck2nT5/WkCFDVKRIEYWFhalGjRqaN29etp67du1aORyOTP82btzo4coBz8stWU73zTffqE2bNsqbN6/Cw8NVrlw5jR071kMVA96XGzLdp0+fLPfN7J9hF7khy5L0448/qlOnTipSpIgiIiJUsWJFjRkzRmfPnvVw1YD35JY8S9J3332n1q1bKzo6WlFRUWrevLm+/fZbD1ZsPUG+LgD/8/PPP+vMmTOqW7eur0u5pjvvvFNJSUmaMGGCypcvrzlz5qhbt25KS0tT9+7ds/Ua48aNU/PmzV2GValSxRPlAl6Vm7I8Z84c9ezZU3fffbdmzZqlqKgo7dmzRwcPHvRC9YB35IZMjxw5Uv37988wvH379goNDbXEsgPXkhuyvGPHDjVq1EgVKlTQ5MmTlT9/fn311VcaM2aMfvjhB3366adeXArAc3JDniUpKSlJTZs2Vb169TR79mwZY/TCCy+oRYsWWrNmjRo2bOilpfBzBn5j2rRpRpL57bfffF3KVS1dutRIMnPmzHEZ3qpVK1OkSBGTkpJy1eevWbPGSDLz58/3ZJmAz+SWLP/5558mMjLSDBgwwJNlAj6XWzJ9pbVr1xpJ5umnn87JMgGfyQ1ZfuqppzJdxgcffNBIMseOHfNIzYC35YY8G2NM69atzU033WTOnDnjHJacnGzy589vGjVq5JGarYhTEX1k6tSpqlq1qsLCwlSlShV98cUX+u6775Q3b16VKVPG1+Vd1SeffKKoqCh16dLFZXjfvn118OBBbdq0yUeVAd6Xm7M8bdo0nTlzRsOHD/dkmYBX5eZMX2n69OlyOBzq169fTpYJeEVuzXJwcLAkKU+ePC7DY2NjFRAQoJCQkJwvGPCw3JpnSfr222/VrFkzRUREOIdFR0eradOmWr9+vQ4dOuSRuq2GxpYPDBkyRIMHD1anTp30+eefa+DAgerdu7c+//xz1alTxyPzNMYoJSUlW3/X8tNPP6lSpUoKCnI9k7VatWrO8dkxcOBABQUFKSYmRq1bt9Y333zj/oIBPpTbs/zVV18pX758+uWXX1SjRg0FBQWpYMGC6t+/v5KTk69/IQEfye2ZvtzJkye1YMECtWjRQqVKlXJvoQAfy81Z7t27t2JjYzVgwAD9/vvvOnXqlJYsWaK3335bAwcOVGRk5I0tKOBluTnPkvTPP/8oNDQ0w/D0Ydu3b8/uYtmbT48Xy4UWLFhgJJl58+a5DB83bpyRZP7zn/8YY4zZvXu3CQwMNOfOnXOZ7vz586ZPnz6mWLFiJjo62tSvX998++2315xv+ul/2fnbu3fvVV+rXLlypnXr1hmGHzx40Egy48aNu+rzN2/ebB555BHzySefmK+++sq8++67plKlSiYwMNAsX778mssC+AOybEyFChVMWFiYiY6ONuPGjTNr1qwxL7zwggkPDzeNGzc2aWlp11wewF+QaVdvvvmmkWTmzp2b7ecA/oAsG7Nz505TsWJFl3kOHjyY/TIshzwbU6NGDVO+fHmTmprqHHbx4kVTunTpTE9xzK24eLyXjR07VnXr1tU999zjMrxy5cqS5Ow6b9u2TRUqVFBYWJjLdCkpKSpVqpS+/fZbFStWTLNnz1aHDh104MABl8MTr1S7dm0lJSVlq8YiRYpccxqHw3Fd4ySpZs2aqlmzpvNxkyZN1LlzZ1WtWlVPPPGEWrduna06AV8iy5fuRnP+/HmNGjVKTz75pCSpWbNmCgkJ0ZAhQ7Rq1Sq1bNkyW7UCvkamXU2fPl1xcXHq3Llztp8D+IPcnuV9+/apffv2uummm7RgwQIVKFBAmzZt0rPPPqvTp09r+vTp2aoR8Ae5Pc+S9O9//1v33XefBg0apKeeekppaWkaPXq09u/fL0kKCOAkPIm7InrV4cOHtXXrVr388ssZxv3555+S5Lyrw9atW1W9evUM00VGRuqZZ55xPu7du7eGDh2q3bt3Zzp9uqioKNWoUSNbdV55mOSV4uLidPTo0QzDjx07JknKly9ftuZzudjYWLVr105vvfWWzp07p/DwcLdfA/AWsvy/5+/evTtDM/qOO+7QkCFDtHnzZhpbsAQy7Wrbtm36/vvv9cgjj2R6+gPgr8iy9OSTTyo5OVlbtmxxnnbYtGlT5c+fX/369VOvXr2UkJCQrToBXyLPl/Tr109//fWXnn32Wb355puSpIYNG+qxxx7T888/r6JFi2arTrujvedF6QEsXLhwhnFz5sxRoUKFVKxYMUmXwpl+3u3V/PLLLzp37tw1L5q3bt06BQcHZ+tv3759V32tqlWraufOnRnOKU4/v7dKlSrXrDszxhhJ7v2PMuALZPmSrJYrPcv8DxKsgky7Sj+i4/7778/W9IC/IMvSli1bVLly5QzX0kpvALhzrT3Al8jz/wwfPlx///23tm/frn379mn9+vU6fvy4IiMjVbt27Ws+PzfgiC0vKlCggKRLO5TLD6dcsGCB1q9fr3bt2jmHbdu2TQ899NBVX+/s2bPq2bOnnn76aUVFRV112pw8nLJz586aOnWqFi5c6LIc7733nooUKaL69etnaz6XO378uJYsWaIaNWpkOIQU8Ddk+ZJ//etfeuedd/T555+7nF68bNkySVKDBg2yVSfga2T6fy5cuKD3339f9erVu+7/qAJ8hSxfeu2ffvpJp0+fdql5w4YNkuRsBAD+jjy7Cg0Nde6XDxw4oA8//FAPPPAAZzql8/VFvnKTtLQ0U7duXRMZGWmmTJli1qxZY0aPHm3y5ctnJJnRo0cbY4w5efKkcTgc5r///W+Wr/XPP/+Ytm3bml69evnkQpCtWrUyefPmNe+8845ZvXq1eeCBB4wk8/7777tMt3btWhMYGOhcNmOM6datmxk+fLiZP3++WbNmjXnnnXdMhQoVTFBQkFm5cqW3FwVwG1n+n/bt25vQ0FAzduxYs3LlSjN+/HgTFhZm2rVr583FAG4Imf6fefPmGUnmnXfe8WbZQI4gy8Z8+umnxuFwmAYNGpgPP/zQrFq1yjz33HMmKirKVK5c2Vy4cMHrywJcD/J8yfbt201iYqJZsmSJWblypZk4caLJnz+/qVOnjjl16pS3F8Vv0djysr1795rbb7/dREVFmdjYWNO+fXszffp0I8ksXbrUGGPM119/beLi4rJ8jdTUVNO1a1fToUMHc/HiRW+V7uLUqVNm8ODBplChQiYkJMRUq1Yt0zsnpd9RYtSoUc5h48ePNzVq1DB58uQxgYGBpkCBAqZz587mu+++8+ISADeGLF9y9uxZM3z4cFO8eHETFBRkSpQoYUaMGGHOnz/vpSUAcgaZvqRVq1YmMjLSJCcne6liIGeRZWNWr15tbrvtNlOoUCETHh5uypcvb4YNG2b+/vtvLy4BcOPIszG7du0yTZs2Nfny5TMhISGmbNmy5umnnzanT5/24hL4P4cx//9iKPAbb7zxhj766CMtX77cOSwgIEAhISGSpAceeEC7d+/W8uXLOW0P8GNkGbAXMg3YA1kG7IM8Q+Li8X5p69atWrduncLDw51///rXvyRJ+/fv17Rp07Rp0yblz59fUVFRioqK0tdff+3jqgFciSwD9kKmAXsgy4B9kGdIEkdsAQAAAAAAwJI4YgsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlhTk6wIkKS0tTQcPHlR0dLQcDoevywE8yhijU6dOqUiRIgoIsF9vmTwjNyHPgD3YPcsSeUbuYfc8k2XkJtnNs180tg4ePKjixYv7ugzAq/744w8VK1bM12XkOPKM3Ig8A/Zg1yxL5Bm5j13zTJaRG10rz37R2IqOjpYk/frrTue/4b6IiGidPXvK12XYiifW6alTp1S+fCXbftZzY57Jnm/4w3onz7iSP3wu4T67Z1nKXXkmh/7N0++P3fOcm7LsL9imuCcn11d28+wXja30Qyijo6MVExPj42qsKyIiWkFBHI6akzy5Tu166HBuzDPZ8w1/Wu/kGen86XMJ99k1y1LuyjM59G/een/smufclGV/wTbFPZ5YX9fKs/1OOgYAAAAAAECuQGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJYU5OsC3BHxabyvS/BfQdFSl/3ZmjRxdpKHi7GH0OBAje2X4OsybMs2eXYjezeK7P4P+fQvtsnzjfLi9gDwBFtk2cI5zA37efbf3mOLPPsDD25T7Jh5X2WcI7YAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJQb4uwB1nO+73dQl+LSKb0yX2rOvROoDssFOes5u9G0V24a/slOcb5a3tAeAJdsmyVXPIfh45yS559gee2qaQ+ZzDEVsAAAAAAACwJEsdsXU9Ij6N93UJ3hEULXWxb1c+cXaS1+cZGhyosf0SvD7f3MQW+bR59m6Up7JLPv2TLTJ9I/xge+CL/aUtpJz3dQWWYImM+0EOrc6T2xH23/7HErn2JT/fpvjbft9XGeeILQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWFKQrwvwtLMd9/u6BK+J8HUBHpTYs66vS4AH2CWfds7ejSK7uYtdMn0jfL09IHPXJzk5WS8O8nUV/s8qGfd1Dq2O7UjuYpVc+5I/b1PI6yUcsQUAAAAAAABLsv0RW9kV8Wm8r0u4MUHRUhfvdtsTZyd5dX7eFhocqLH9EnxdRq5kqTz6IHu+5g/ZJ5/WZ6mcZ5efbA/8IaOWk3Le1xVYnt9k2k9y6Gv+uh1g/w3AEzhiCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlhTk6wL8xdmO+31dwg2L8PL8EnvW9fIckVtYLY/ezp6vkX3kBKvlPLv8YXtARt2XnJysFwf5ugpr86dM+0MOfY3tAIDchCO2AAAAAAAAYEkcseXHIj6Nz/7EQdFSF//5nzKrSJydlOW40OBAje2X4MVq4O8yzSTZ86r0zJJP+MI198tsDwCPI4fWcuV3bfbfgL2Nn7fZJxnniC0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFhSkK8LQNbOdtzv1vQRHqrDzhJ71vV1CbCQrDJJ9ryHzMKXsrNfZnsAeBY5tBb220DuMqJrLZ/MlyO2AAAAAAAAYEk0tgAAAAAAAGBJnIpoMRGfxmc+Iiha6uLeqYuQEmcnZTkuNDhQY/sleLEaWEGGDJK9G3a1HGaFfMJXstwPS2wPAB9xySU59DuX7+fZfwO5w/h5m3XhYqrXTkfmiC0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWFKQrwuAe8523J/luAgv1mEXiT3r+roEWExmGSR7N4Ycwkquth+W2B4AvnBlLsmhf2E/D+Q+I7rW8ur8OGILAAAAAAAAlkRjCwAAAAAAAJbEqYgWF/Fp/KV/BEVLXa5+egQylzg7KdPhocGBGtsvwcvVwCrInn8YP2+zLlxMdRnGKQ/wBuc24HJsDwCfYb9sLZfvv9lvA/aTnnFv5ZsjtgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSUG+LgA35mzH/c5/R/iwDitL7FnX1yXAgsiefxjRtZavS0Audfk24HJsDwDfYL9sLey/AXvzdsY5YgsAAAAAAACWRGMLAAAAAAAAlsSpiDYQ8Wm8FBQtdcn8tAhkT+LsJJfHocGBGtsvwUfVwArInu+Nn7eZ0xngUxGfxv/vAdsDwKfYL/uny79j8/0ayB3Gz9usCxdTvXbZH7eP2Hrvvfe0dOlS5+MnnnhCsbGxatSokfbvZycCWAl5BuyBLAP2QZ4B+yDPgHe43dgaN26cwsPDJUkbNmzQa6+9phdeeEH58+fX0KFDc7xAAJ5DngF7IMuAfZBnwD7IM+Adbp+K+Mcff6hs2bKSpEWLFumuu+7Sgw8+qMaNG6tZs2Y5XR8ADyLPgD2QZcA+yDNgH+QZ8A63j9iKiorS0aNHJUkrVqxQy5YtJUlhYWE6d+5czlYHwKPIM2APZBmwD/IM2Ad5BrzD7SO2WrVqpfvvv181a9bUr7/+qrZt20qSfv75Z5UsWTKn6wPgQeQZsAeyDNgHeQbsgzwD3uH2EVuvv/66GjZsqL/++ksLFy5UXFycJOmHH35Qt27dcrxAAJ5DngF7IMuAfZBnwD7IM+Adbh+xFRsbq9deey3D8NGjR+dIQQC8hzwD9kCWAfsgz4B9kGfAO9w+YkuSvv76a917771q1KiR/vvf/0qSZs+erW+++SZHiwPgeeQZsAeyDNgHeQbsgzwDnuf2EVsLFy5Uz5491aNHD23evFkXLlyQJJ06dUrjxo3TsmXLcrxIXN3ZjvslSRE+rsPqEnvW9XUJXkeebwzZ870RXWv5ugS/QJZ9J307kI7tAW4Ueb5+7Jf9U278jp2OPCO38vZ3dLeP2Hr22Wf11ltvaerUqQoODnYOb9SokTZv3pyjxQHwLPIM2ANZBuyDPAP2QZ4B73C7sbVr1y41bdo0w/CYmBidOHEiJ2oC4CXkGbAHsgzYB3kG7IM8A97h9qmIhQsX1m+//Zbh9qTffPONSpcunVN1wQ0Rn8ZLQdFSl/3XnhjXlDg7SZIUGhyosf0SfFyNZ5HnG0P2fG/8vM26cDFVUu4+1YEs+1bEp/GX/sH2ADmAPF8/9svWcfn++0p22p+TZ+RW3v6O7vYRWw899JAeeeQRbdq0SQ6HQwcPHtQHH3ygxx57TA8//LAnagTgIeQZsAeyDNgHeQbsgzwD3uH2EVtPPPGETp48qebNm+v8+fNq2rSpQkND9dhjj2nQoEGeqBGAh5BnwB7IMmAf5BmwD/IMeIdbja3U1FR98803GjZsmJ566int2LFDaWlpqly5sqKiojxVIwAPIM+APZBlwD7IM2Af5BnwHrcaW4GBgWrdurV27typfPnyqU6dOp6qC4CHkWfAHsgyYB/kGbAP8gx4j9vX2Kpatap+//13T9QCwMvIM2APZBmwD/IM2Ad5BrzD7cbWc889p8cee0xLlizRoUOHlJyc7PIHwDrIM2APZBmwD/IM2Ad5BrzD7YvH33777ZKkDh06yOFwOIcbY+RwOJSamvltWwH4H/IM2ANZBuyDPAP2QZ4B73C7sbVmzRpP1AHAB8gzYA9kGbAP8gzYB3kGvMPtxlZCQoIn6sANONtxvyQpwsd12EViz7q+LsFryPONIXu+N6JrLV+X4BfIsm+lbwsktge4ceT5+rFfto7csv8mz8itvJ1xtxtbX3311VXHN23a9LqLAeBd5BmwB7IM2Ad5BuyDPAPe4XZjq1mzZhmGXX6+MOcJA9ZBngF7IMuAfZBnwD7IM+Adbt8V8fjx4y5/R44c0fLly1W3bl2tWLHCEzXiGiI+jVfE0iq+LsNWEmcnafy8zb4uw+PI840he743ft5mJc5O8nUZPkeWfY/tAXIKeb5+5BD+hjwjN0icneT889VvaLeP2MqTJ0+GYa1atVJoaKiGDh2qH374IUcKA+B55BmwB7IM2Ad5BuyDPAPe4fYRW1kpUKCAdu3alVMvB8CHyDNgD2QZsA/yDNgHeQZylttHbG3bts3lsTFGhw4d0oQJE1S9evUcKwyA55FnwB7IMmAf5BmwD/IMeIfbja0aNWrI4XDIGOMyvEGDBnr33XdzrDAAnkeeAXsgy4B9kGfAPsgz4B1uN7b27t3r8jggIEAFChRQWFhYjhUFwDvIM2APZBmwD/IM2Ad5BrzD7WtsrVu3ToUKFVJ8fLzi4+NVvHhxhYWF6Z9//tGsWbM8USMADyHPgD2QZcA+yDNgH+QZ8A63G1t9+/bVyZMnMww/deqU+vbtmyNFAfAO8gzYA1kG7IM8A/ZBngHvcLuxZYyRw+HIMPzPP//M9HamAPwXeQbsgSwD9kGeAfsgz4B3ZPsaWzVr1pTD4ZDD4VCLFi0UFPS/p6ampmrv3r26/fbbPVIkru5sx/2SpAgf12EniT3r+roEjyLPOYPs+d6IrrV8XYJPkWX/wfYAN4o83zhyCH9BnpGb+MNv52w3tjp16iRJ2rJli1q3bq2oqCjnuJCQEJUsWVL/+te/crxAADmPPAP2QJYB+yDPgH2QZ8C7st3YGjVqlCSpZMmSuueee7iTA2Bh5BmwB7IM2Ad5BuyDPAPele3GVrrevXt7og7coIilVaQu+31dhi2Nn7fZtqc7kecbE/FpvBQUTfa8LHF2kkKDAzW2X4KvS/EbZNn32B4gp5DnG8N3Yv+UODtJknLd/ps8w+7Ss53OVxl3u7GVmpqql19+WR999JEOHDigf/75x2X8sWPHcqw4AJ5FngF7IMuAfZBnwD7IM+Adbt8VcfTo0Zo0aZLuvvtunTx5Uo8++qjuvPNOBQQEKDEx0QMlAvAU8gzYA1kG7IM8A/ZBngHvcLux9cEHH2jq1Kl67LHHFBQUpG7dumnatGl65plntHHjRk/UCMBDyDNgD2QZsA/yDNgHeQa8w+3G1uHDh1W1alVJUlRUlE6ePClJateunZYuXZqz1QHwKPIM2ANZBuyDPAP2QZ4B73C7sVWsWDEdOnRIklS2bFmtWLFCkpSUlKTQ0NCcrQ6AR5FnwB7IMmAf5BmwD/IMeIfbja3OnTtr1apVkqRHHnlEI0eOVLly5dSrVy/169cvxwsE4DnkGbAHsgzYB3kG7IM8A97h9l0RJ0yY4Pz3XXfdpWLFimn9+vUqW7asOnTokKPFAfAs8gzYA1kG7IM8A/ZBngHvcLuxdaUGDRqoQYMGOVELAB8jz4A9kGXAPsgzYB/kGfAMt09FlKTZs2ercePGKlKkiPbv3y9Jmjx5sj799NMcLQ7Zd7btT74uwbZGdK3l6xI8ijxfv7Md95M9H0jsWdf2ubweZNm32B4gJ5Hn60cO/VNiz7q5dv9NnmFn6dn2dcbdbmy9+eabevTRR9WmTRudOHFCqampkqTY2FhNnjw5p+sD4EHkGbAHsgzYB3kG7IM8A97hdmPr1Vdf1dSpU/XUU08pMDDQObxOnTravn17jhYHwLPIM2APZBmwD/IM2Ad5BrzD7Wts7d27VzVr1swwPDQ0VGfOnMmRouC+iKVVpC77fV0GLIY835iIT+OloGiyB58jy77H9gA5hTzfGL4Tw5+QZ9hV4uykTIeHBgdqbL8EL1dzHUdslSpVSlu2bMkw/PPPP1flypVzoiYAXkKeAXsgy4B9kGfAPsgz4B1uH7H1+OOPa+DAgTp//ryMMfruu+80d+5cjR8/XtOmTfNEjQA8hDwD9kCWAfsgz4B9kGfAO9xubPXt21cpKSl64okndPbsWXXv3l1FixbVlClT1LVrV0/UCMBDyDNgD2QZsA/yDNgHeQa8I1unIi5evFgXL150Pn7ggQe0f/9+HTlyRIcPH9Yff/yh++67z2NFAsg55BmwB7IM2Ad5BuyDPAPel63GVufOnXXixAlJUmBgoI4cOSJJyp8/vwoWLOix4gDkPPIM2ANZBuyDPAP2QZ4B78tWY6tAgQLauHGjJMkYI4fD4dGiAHgOeQbsgSwD9kGeAfsgz4D3ZesaW/3791fHjh3lcDjkcDhUqFChLKdNTU3NseIA5DzyDNgDWQbsgzwD9kGeAe/LVmMrMTFRXbt21W+//aYOHTpoxowZio2N9XBpADyBPAP2QJYB+yDPgH2QZ8D7sn1XxIoVK6pixYoaNWqUunTpooiICE/WBcCDyDNgD2QZsA/yDNgHeQa8y2GMMb4uIjk5WXny5NGhQ38qJibG1+VYVkREtM6ePeXrMmzFE+s0OTlZhQsX08mTJ235ec+NeSZ7vuEP650840r+8LmE++yeZSl35Zkc+jdPvz92z3NuyrK/YJvinpxcX9nNc7YuHg8AAAAAAAD4m2yfigj/FrG0itRlv6/LsIXE2UmSpNDgQI3tl+DjauDvyJ5vjZ+3WRcueu7Cq4k963rstWE/bA8A3yOH/m38vM18vwZsIP0385V89RuaI7YAAAAAAABgSTS2AAAAAAAAYEk51tj6v//7P40ZMyanXg6AD5FnwB7IMmAf5BmwD/IM5Kwca2wdPnxYo0ePzqmXA+BD5BmwB7IM2Ad5BuyDPAM5K9sXj9+2bdtVx+/ateuGiwHgHeQZsAeyDNgHeQbsgzwD3pXtxlaNGjXkcDhkjMkwLn24w+HI0eIAeAZ5BuyBLAP2QZ4B+yDPgHdlu7EVFxen559/Xi1atMh0/M8//6z27dvnWGEAPIc8A/ZAlgH7IM+AfZBnwLuy3diqXbu2Dh48qPj4+EzHnzhxItOONAD/Q54BeyDLgH2QZ8A+yDPgXdlubD300EM6c+ZMluNLlCihGTNm5EhRADyLPAP2QJYB+yDPgH2QZ8C7HMYPWsXJycnKkyePDh36UzExMb4ux7IiIqJ19uwpX5dhK55Yp8nJySpcuJhOnjxpy897bswz2fMNf1jv5BlX8ofPJdxn9yxLuSvP5NC/efr9sXuec1OW/QXbFPfk5PrKbp4DcmRuAAAAAAAAgJdl+1RESTp37px++OEH5cuXT5UrV3YZd/78eX300Ufq1atXjhaI7IlYWkXqst/XZVhe4uwk579DgwM1tl+CD6vxLPKcM8ieb42ft1kXLqZmOi6xZ10vV+MbZNl/sD3AjSLPN44c+o/Lv1ens/v368uRZ+RmV/uOLuX89/RsH7H166+/qlKlSmratKmqVq2qZs2a6dChQ87xJ0+eVN++fXO0OACeQZ4BeyDLgH2QZ8A+yDPgXdlubA0fPlxVq1bVkSNHtGvXLsXExKhx48Y6cOCAJ+sD4AHkGbAHsgzYB3kG7IM8A96V7cbW+vXrNW7cOOXPn19ly5bV4sWLdccdd6hJkyb6/fffPVkjgBxGngF7IMuAfZBnwD7IM+Bd2b7G1rlz5xQU5Dr566+/roCAACUkJGjOnDk5XhwAzyDPgD2QZcA+yDNgH+QZ8K5sN7YqVqyo77//XpUqVXIZ/uqrr8oYow4dOuR4cQA8gzwD9kCWAfsgz4B9kGfAu7J9KmLnzp01d+7cTMe99tpr6tatm4wxOVYYAM8hz4A9kGXAPsgzYB/kGfCubDe2RowYoWXLlmU5/o033lBaWlqOFAXAs8gzYA9kGbAP8gzYB3kGvCvbjS0AAAAAAADAn9DYAgAAAAAAgCVl++Lx8G9n2/6kCF8XYQOJPev6ugRYDNnzrRFda/m6BMCJ7QHge+TQf/C9Gsi9vP0dnSO2AAAAAAAAYEkcsQVcw/h5m3XhYqok/ucJGUUsrSJ12e/rMnIt8gkAuBz7ZWu4fP+dGfbpgLV5O+PX1djatWuXXn31Ve3cuVMOh0MVK1bUv//9b1WoUCFHiwPgeeQZsAeyDNgHeQbsgzwDnuf2qYgLFixQlSpV9MMPP6h69eqqVq2aNm/erCpVqmj+/PmeqBGAh5BnwB7IMmAf5BmwD/IMeIfbR2w98cQTGjFihMaMGeMyfNSoURo+fLi6dOmSY8UB8CzyDNgDWQbsgzwD9kGeAe9w+4itw4cPq1evXhmG33vvvTp8+HCOFAXAO8gzYA9kGbAP8gzYB3kGvMPtxlazZs309ddfZxj+zTffqEmTJjlSFADvIM+APZBlwD7IM2Af5BnwDrdPRezQoYOGDx+uH374QQ0aNJAkbdy4UfPnz9fo0aO1ePFil2kB+C/yDNgDWQbsgzwD9kGeAe9wGGOMO08ICMjeQV4Oh0OpqVnf3vFyycnJypMnjw4d+lMxMTHulIPLRERE6+zZU74uw1YiIqI18t11zluV5sRtSZOTk1W4cDGdPHnS55938nzj0m8rTva8zxP5dJe/5NkTWZZyX55zAvtia/KXLEvk+UaxX/Z/V+6/M3Mj+3S75zm3ZNmfsG93T05mPLt5dvuIrbS0NHefAsBPkWfAHsgyYB/kGbAP8gx4h9vX2AIAAAAAAAD8gdtHbEnSunXrNHHiRO3cuVMOh0OVKlXS448/zgXwYEsjutbydQkeRZ5vzNm2PynC10XkYnbPpzvIMmAf5Pn6sV+2hty0/ybPyI28nXG3j9h6//331bJlS0VERGjw4MEaNGiQwsPD1aJFC82ZM8cTNQLwEPIM2ANZBuyDPAP2QZ4B73D74vGVKlXSgw8+qKFDh7oMnzRpkqZOnaqdO3e6XQQXwMsZXNTu+iTOTsp0eGhwoMb2S8jxdepPF7QkzzeOi9T6xvh5mz2ST3f5S549kWUp9+U5J7AvtiZ/ybJEnnMCOfRvnr75i93znJuy7C/YpmT9m/lKOf0bOrt5dvuIrd9//13t27fPMLxDhw7au3evuy8HwIfIM2APZBmwD/IM2Ad5BrzD7cZW8eLFtWrVqgzDV61apeLFi+dIUQC8gzwD9kCWAfsgz4B9kGfAO7J98fh+/fppypQpGjZsmAYPHqwtW7aoUaNGcjgc+uabbzRz5kxNmTLFk7UCyCHkGbAHsgzYB3kG7IM8A96V7cbWe++9pwkTJmjAgAEqVKiQXnrpJX300UeSLp07/OGHH6pjx44eKxRAziHPgD2QZcA+yDNgH+QZ8K5sN7Yuv8Z8586d1blzZ48UBMDzyDNgD2QZsA/yDNgHeQa8y61rbDkcDk/VAcDLyDNgD2QZsA/yDNgHeQa8J9tHbElS+fLlrxnQY8eO3VBBALyDPAP2QJYB+yDPgH2QZ8B73GpsjR49Wnny5PFULQC8iDwD9kCWAfsgz4B9kGfAe9xqbHXt2lUFCxb0VC0AvIg8A/ZAlgH7IM+AfZBnwHuy3djiHGHYVWLPur4uwevIc8452/YnRfi6iFxoRNdavi7BL5BlwD7IM3ITu+/HyTPsxt9/M2f74vGX39kBgLWRZ8AeyDJgH+QZsA/yDHhXto/YSktL82QdgN9InJ0kSQoNDtTYfgk+rsYzyDOsLHF2kq3z6Q6yDNgHeQbsgzwjtxs/b7MuXEy95nQ5dSRYto/YAgAAAAAAAPwJjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWFKQrwsA/E1iz7q+LgHAVZBRAAAAwH+N6FrLq/PjiC0AAAAAAABYEkdsIddLnJ2U6fDQ4ECN7Zfg5WoAuGP8vM1e/x8hAAAAILfI6vdyZnz1G5ojtgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYElBvi4A8LXEnnV9XQKA6zSiay1flwAAAADYlhV+L3PEFgAAAAAAACyJI7aA/y9xdpLL49DgQI3tl+CjagCkuzKbEvkEAMCKxs/bzP4b8KDMvjd7k6++o3PEFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALCnI1wUA/iKxZ11flwAgE2QTAAB7GNG1lq9LAGwtt35v5ogtAAAAAAAAWBJHbAHXMH7eZl24mJqtaXNrhxxSxNIqOtv2J1+XkWuMn7dZY/sl+LoMIFMRS6tIKad0tuN+X5cCAH7pyu/XfIeGv3PnN2FuFhoc6JPv6ByxBQAAAAAAAEuisQUAAAAAAABLorEFAAAAAAAAS6KxBQAAAAAAAEuisQUAAAAAAABLorEFAAAAAAAAS6KxBQAAAAAAAEuisQUAAAAAAABLorEFAAAAAAAASwrydQGAvxvRtZavS4AFnG37k69LyFXIJfwZ2wMAuDr247AaPrP+jSO2AAAAAAAAYEkcsWUzEUur8D/FOWz8vM26cDE129Mn9qzrwWrgr8ieb1wrn+QRvhCxtIqUckpnO+73dSkA4Jfc/X59JfbvAC7HEVsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALCkIF8XgJx1tu1Pvi7BdkZ0reXrEmABZM83yCf8EdsDALg69t8AchJHbAEAAAAAAMCSaGwBAAAAAADAkjgV0WYillaRUk5lGH62434fVJMzEmcn+WS+ocGBGtsvwSfzhvVklT13WTmrnnb5toB8wp/l1PYgM2wjgOzxZA6zy8p59dT3b/bfADyBI7YAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYElBvi4AOets2598XUKOS+xZ19clANdkx+z5G7YFsAq2B4DvkcMbwz4XgJVwxBYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALCnI1wVIkjFGknTq1CkfV2JtKSlGZ8+yDnOSJ9Zp+uc8/XNvN7kxz2TPN/xhvZNnXMkfPpdwn92zLOWuPJND/+bp98fuec5NWfYXbFPck5PrK7t59ovGVnqx5ctX8nElgPecOnVKefLk8XUZOY48Izciz4A9HD161JZZlsgzch/2zYB9XCvPDuMHrey0tDQdPHhQ0dHRcjgcvi7HkpKTk1W8eHH98ccfiomJ8XU5tuCpdWqM0alTp1SkSBEFBNjvbODclmey5xv+st7JMy7nL59LuO/kyZMqUaKEjh8/rtjYWF+X4xG5Jc/k0L954/1h34ycxDbFPTm9vrKbZ784YisgIEDFihXzdRm2EBMTQ+BymCfWqR3/9yhdbs0z2fMNf1jv5BlX8ofPJa6PHX8Ep8tteSaH/s3T7w/7ZuQ0tinuycn1lZ0823fvDQAAAAAAAFujsQUAAAAAAABLorFlE6GhoRo1apRCQ0N9XYptsE6RHXxOfIP1Dn/E59K6eO/sg/fSv/H+wGr4zLrHV+vLLy4eDwAAAAAAALiLI7YAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYsok+fPurUqZOvy7CsZs2aaciQIZKkkiVLavLkyT6tB9ZB9ryDjMIK2B4AvkcO/Qv7b8DerJLxIF8XAHhbUlKSIiMjfV0GgCyQUQAArIf9N2Bv/pxxGlvIdQoUKODrEgBcBRkFAMB62H8D9ubPGedURD+zYMECVa1aVeHh4YqLi1PLli115swZ5/iJEyeqcOHCiouL08CBA3Xx4kXnuPfff1916tRRdHS0ChUqpO7du+vIkSPO8WvXrpXD4dDSpUtVvXp1hYWFqX79+tq+fbtXl9HXrjyE0uFw6O2331a7du0UERGhSpUqacOGDfrtt9/UrFkzRUZGqmHDhtqzZ4/L63z22WeqXbu2wsLCVLp0aY0ePVopKSleXhrkFLLnP8gofI3tgb0sX75ct9xyi2JjYxUXF6d27dq5bC/+/PNPde3aVfny5VNkZKTq1KmjTZs2adeuXXI4HPrll19cXm/SpEkqWbKkjDHeXpRchRxaD/tvWAn7Bvf5c8ZpbPmRQ4cOqVu3burXr5927typtWvX6s4773SGY82aNdqzZ4/WrFmj9957TzNnztTMmTOdz//nn380duxYbd26VYsWLdLevXvVp0+fDPN5/PHHNXHiRCUlJalgwYLq0KGDy5eB3Gjs2LHq1auXtmzZoooVK6p79+566KGHNGLECH3//feSpEGDBjmn/+KLL3Tvvfdq8ODB2rFjh95++23NnDlTzz33nK8WATeA7Pk/MgpvYXtgP2fOnNGjjz6qpKQkrVq1SgEBAercubPS0tJ0+vRpJSQk6ODBg1q8eLG2bt2qJ554QmlpaapQoYJq166tDz74wOX15syZo+7du8vhcPhoieyPHNoH+2/4K/YNOcNvMm7gN3744Qcjyezbty/DuN69e5v4+HiTkpLiHNalSxdzzz33ZPl63333nZFkTp06ZYwxZs2aNUaSmTdvnnOao0ePmvDwcPPhhx/m4JL4n4SEBPPII48YY4yJj483L7/8snOcJPP00087H2/YsMFIMtOnT3cOmzt3rgkLC3M+btKkiRk3bpzLPGbPnm0KFy7smQWAR5E93yOj8BdsD+zvyJEjRpLZvn27efvtt010dLQ5evRoptNOmjTJlC5d2vl4165dRpL5+eefvVVurkQOrYP9N+yCfUPmrJJxjtjyI9WrV1eLFi1UtWpVdenSRVOnTtXx48ed42+++WYFBgY6HxcuXNjlsOoff/xRHTt2VHx8vKKjo9WsWTNJ0oEDB1zm07BhQ+e/8+XLpwoVKmjnzp0eWiprqFatmvPfN910kySpatWqLsPOnz+v5ORkSdIPP/ygMWPGKCoqyvn3wAMP6NChQzp79qx3i8cNI3v+j4zCW9ge2M+ePXvUvXt3lS5dWjExMSpVqpSkS+/Jli1bVLNmTeXLly/T53bt2lX79+/Xxo0bJUkffPCBatSoocqVK3ut/tyIHNoH+2/4K/YNOcNfMk5jy48EBgZq5cqV+vzzz1W5cmW9+uqrqlChgvbu3StJCg4Odpne4XAoLS1N0qVDKW+77TZFRUXp/fffV1JSkj755BNJlw7HvpbcdsjklS5ft+nrIrNh6es7LS1No0eP1pYtW5x/27dv1+7duxUWFubFypETyJ7/I6PwFrYH9tO+fXsdPXpUU6dO1aZNm7Rp0yZJl96T8PDwqz63cOHCat68uebMmSNJmjt3ru69916P15zbkUP7YP8Nf8W+IWf4S8a5K6KfcTgcaty4sRo3bqxnnnlG8fHxzp3x1fzyyy/6+++/NWHCBBUvXlySnOe0Xmnjxo0qUaKEJOn48eP69ddfVbFixZxbiFygVq1a2rVrl8qWLevrUpBDyJ69kFHcCLYH9nH06FHt3LlTb7/9tpo0aSJJ+uabb5zjq1WrpmnTpunYsWNZ/s98jx49NHz4cHXr1k179uxR165dvVJ7bkcOcyf23/AG9g2+46mM09jyI5s2bdKqVat02223qWDBgtq0aZP++usvVapUSdu2bbvqc0uUKKGQkBC9+uqr6t+/v3766SeNHTs202nHjBmjuLg43XTTTXrqqaeUP39+derUyQNLZF/PPPOM2rVrp+LFi6tLly4KCAjQtm3btH37dj377LO+Lg9uInv2Q0Zxvdge2EvevHkVFxend955R4ULF9aBAwf05JNPOsd369ZN48aNU6dOnTR+/HgVLlxYP/74o4oUKeI8Te3OO+/UgAEDNGDAADVv3lxFixb11eLkGuQw92L/DW9g3+A7nso4pyL6kZiYGH311Vdq06aNypcvr6efflovvfSS7rjjjms+t0CBApo5c6bmz5+vypUra8KECZo4cWKm006YMEGPPPKIateurUOHDmnx4sUKCQnJ6cWxtdatW2vJkiVauXKl6tatqwYNGmjSpEmKj4/3dWm4DmTPfsgorhfbA3sJCAjQvHnz9MMPP6hKlSoaOnSoXnzxRef4kJAQrVixQgULFlSbNm1UtWpVTZgwweX6TTExMWrfvr22bt2qHj16+GIxch1ymHux/4Y3sG/wHU9l3PH/r2aPXGDt2rVq3ry5jh8/rtjYWF+XA+QaZA9AOrYHgO+RQwCwF47YAgAAAAAAgCXR2AIAAAAAAIAlcSoiAAAAAAAALIkjtgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLZsLjExUTVq1HA+7tOnjzp16uSVeQHIWeQZsA/yDNgDWQbsgzxbF42tHHb48GH9+9//VunSpRUaGqrixYurffv2WrVqVY7No1mzZhoyZEi2pn3sscdydN7pHA6HFi1a5JV5Ab5Cnskz7IM8k2fYA1kmy7AP8kyec0qQrwuwk3379qlx48aKjY3VCy+8oGrVqunixYv64osvNHDgQP3yyy9eq8UYo9TUVEVFRSkqKsor8/TmvABPI8/kGfZBnskz7IEsk2XYB3kmzznKIMfccccdpmjRoub06dMZxh0/ftwYY8z+/ftNhw4dTGRkpImOjjZdunQxhw8fdk43atQoU716dTNr1iwTHx9vYmJizD333GOSk5ONMcb07t3bSHL527t3r1mzZo2RZJYvX25q165tgoODzerVq52vl653796mY8eOJjEx0RQoUMBER0ebBx980Fy4cME5TXx8vHn55Zdd6q9evboZNWqUc/zl84+Pj3epPV1qaqoZPXq0KVq0qAkJCTHVq1c3n3/+uXP83r17jSSzcOFC06xZMxMeHm6qVatm1q9f75xm3759pl27diY2NtZERESYypUrm6VLl7rztgDXhTyTZ9gHeSbPsAeyTJZhH+SZPOckTkXMIceOHdPy5cs1cOBARUZGZhgfGxsrY4w6deqkY8eOad26dVq5cqX27Nmje+65x2XaPXv2aNGiRVqyZImWLFmidevWacKECZKkKVOmqGHDhnrggQd06NAhHTp0SMWLF3c+94knntD48eO1c+dOVatWLdNaV61apZ07d2rNmjWaO3euPvnkE40ePTrby5qUlCRJmjFjhg4dOuR8fKUpU6bopZde0sSJE7Vt2za1bt1aHTp00O7du12me+qpp/TYY49py5YtKl++vLp166aUlBRJ0sCBA3XhwgV99dVX2r59u55//nk62/A48pwReYZVkeeMyDOsiCxnRJZhVeQ5I/J8g3zaVrORTZs2GUnm448/znKaFStWmMDAQHPgwAHnsJ9//tlIMt99950x5lLnNiIiwtllNsaYxx9/3NSvX9/5OCEhwTzyyCMur53edV60aJHL8My6zvny5TNnzpxxDnvzzTdNVFSUSU1NNcZcu+tsjDGSzCeffHLVeRUpUsQ899xzLtPUrVvXPPzww8aY/3Wdp02blmF97Ny50xhjTNWqVU1iYqIBvIk8k2fYB3kmz7AHskyWYR/kmTznNI7YyiHGGEmXLgyXlZ07d6p48eIuXeLKlSsrNjZWO3fudA4rWbKkoqOjnY8LFy6sI0eOZKuOOnXqXHOa6tWrKyIiwvm4YcOGOn36tP74449szSM7kpOTdfDgQTVu3NhleOPGjV2WVZJLd7xw4cKS5FzewYMH69lnn1Xjxo01atQobdu2LcdqBLJCnl2RZ1gZeXZFnmFVZNkVWYaVkWdX5PnG0djKIeXKlZPD4cjwwbucMSbT8F45PDg42GW8w+FQWlpaturI7FDO7EqvISAgwLmxSXfx4sUbes10ma2Dy5c3fVz68t5///36/fff1bNnT23fvl116tTRq6++el21ANlFnq/+munIM6yAPF/9NdORZ/g7snz110xHlmEF5Pnqr5mOPGcfja0cki9fPrVu3Vqvv/66zpw5k2H8iRMnVLlyZR04cMClu7tjxw6dPHlSlSpVyva8QkJClJqaet21bt26VefOnXM+3rhxo6KiolSsWDFJUoECBXTo0CHn+OTkZO3du9flNYKDg69aQ0xMjIoUKaJvvvnGZfj69evdWlZJKl68uPr376+PP/5Yw4YN09SpU916PuAu8uyKPMPKyLMr8gyrIsuuyDKsjDy7Is83jsZWDnrjjTeUmpqqevXqaeHChdq9e7d27typV155RQ0bNlTLli1VrVo19ejRQ5s3b9Z3332nXr16KSEhIVuHQaYrWbKkNm3apH379unvv//Odkc63T///KP77rtPO3bs0Oeff65Ro0Zp0KBBCgi49HG49dZbNXv2bH399df66aef1Lt3bwUGBmaoYdWqVTp8+LCOHz+e6Xwef/xxPf/88/rwww+1a9cuPfnkk9qyZYseeeSRbNc6ZMgQffHFF9q7d682b96s1atXux1u4HqQZ1fkGVZGnl2RZ1gVWXZFlmFl5NkVeb4xQb4uwE5KlSqlzZs367nnntOwYcN06NAhFShQQLVr19abb74ph8OhRYsW6d///reaNm2qgIAA3X777W4fHvjYY4+pd+/eqly5ss6dO5ehI3wtLVq0ULly5dS0aVNduHBBXbt2VWJionP8iBEj9Pvvv6tdu3bKkyePxo4dm2EeL730kh599FFNnTpVRYsW1b59+zLMZ/DgwUpOTtawYcN05MgRVa5cWYsXL1a5cuWyXWtqaqoGDhyoP//8UzExMbr99tv18ssvu7W8wPUgz67IM6yMPLsiz7AqsuyKLMPKyLMr8nxjHObKE0IBAAAAAAAAC+BURAAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWNL/A0vgUgLFo9T1AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1500x400 with 5 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cns.consistency_plot(max_features=21)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmoAAAJfCAYAAADPZfphAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8o6BhiAAAACXBIWXMAAA9hAAAPYQGoP6dpAACuAklEQVR4nOzddVwU+f8H8NfSgiwgooKEirCLp6KLIgp2i93dfWK3noodZ5x1tmd3d4uCgN2BQSOllMRSn98f/Ha+u+6SArvg+/l43ONkZnbmPbMzs+/51PAYYwyEEEIIIUTlqCk7AEIIIYQQohglaoQQQgghKooSNUIIIYQQFUWJGiGEEEKIiqJEjRBCCCFERVGiRgghhBCioihRI4QQQghRUZSoEUIIIYSoKErUCMlBenq6skMghBQCupZJSaWh7ACIvDdv3uDWrVt4+fIlAgMDkZCQAHV1dRgYGMDW1haOjo5o3749jIyMlB2qUjg4OAAATE1NcfHixSLZRnx8PDZv3ozatWujY8eORbINUnhCQ0Px33//wdfXF9HR0QAAQ0NDDB06FL1791ZydMrz+PFjjBkzBgDQsWNHuLu7Kzmi4pfbtTx69Gg8efIEAHDhwgWYmZkVd4iE5IgSNRXy4sULbNiwAS9fvpSbl5aWhpSUFEREROD+/fvYvHkzhg0bhmHDhkFDg77GwvTo0SPMnTsX379/R82aNZUdDslFcHAwBg8ejPj4eJnpERER0NHRUVJURBXQtUxKA/qFVxHbtm3Drl27IHn1qrq6OurWrQuBQABDQ0Okp6cjMDAQPj4+iI2NhVgsxrZt2/DixQusWbMGZcqUUfIelB5Pnz7F9+/flR0GyaOdO3dySZqhoSHatm2L8uXLIyEhASKRSMnREWWia5mUBpSoqYANGzbgwIED3N9du3bFuHHjUL58ebll09LScODAAWzbtg0ZGRnw9vbGggULsGbNmuIMWakk1RSEAICfnx/377///ht169ZVYjSkpNmxY4eyQyAkR9SZQMlu3rzJJWk8Hg8LFy7EX3/9pTBJAwBNTU0MHz4cixcv5qbdvn0bV69eLZZ4CVE1SUlJ3L//+OMPJUZCCCGFjxI1JRKLxfj777+5v4cOHYrOnTvn6bPt2rVDhw4duL+3bdvGVZsS8jvJzMzk/q2lpaXESAghpPDxGP26K83p06exbNkyAFltay5dupSvxs+BgYHo3r07AMDKygqbNm1C5cqVFS775csXnDp1Ck+ePMHXr1+RmpoKQ0NDCAQCNGvWDK6urtDU1FT42bCwMHTq1AkAMGHCBAwbNgzBwcE4ceIEHjx4gIiICPB4PJiamqJx48bo27dvtiWCEg8ePMDVq1fx4sULREVFAQCMjIwgEAjg4uICV1dXaGtrK/xsXnp9FmT9CxcuzLEX6cKFCxUm0uHh4Th9+jS8vb0RGhqKpKQk7ti2aNECrq6u2Xb4KIpjC2Q1sD99+jR8fX0RHByM1NRUGBgYwM7ODm3btkXbtm2hrq7OLb9x40bs27cPQN56ByYnJ6NNmzbcvl69ejXb8ycnGRkZuH37Nm7cuIE3b94gJiYGGhoaMDExgYODAzp16oRatWrJfW779u25Vlll933lxatXr3DhwgU8fvwY0dHRSE9PR/ny5VGnTh106NABTk5OCj+3evVqHDt2DACgq6uLEydOoFKlSgqXld4HY2NjHDt2jOvJLemJKDnHf/z4gcOHD+PmzZsICwsDYwyWlpZwcXFB3759YWxsrHAbee31yRiDh4cH7t+/j1evXiE6Oho/fvyArq4ujIyMUKtWLbRu3RqNGzdW+PmiOo8fPnyIu3fv4vnz54iKikJ8fDy0tbVhaGgIOzs7NG/eHK1bt5Y5l4H8Xct57fWZmJiIc+fOwdPTE58+fUJcXBz09PRQuXJlODk5oUePHtl+19LbsbKywunTp5GWloYzZ87gxo0bCAgIwI8fP2BkZIS6deuia9euqF+/fo7HJiwsDGfPnoWPjw8CAwORkpICPp8PMzMzODo6okuXLjA3N8/28x07dsTXr1+52CTnCVE91EZNiaSrK9u2bZvvHmpWVlbYunUrbGxsUK5cOYXLpKSkYP369Th16pRciVtkZCQiIyNx//597NmzBytXrkSNGjVy3e7FixexYsUKpKSkyEz/9OkTPn36hOPHj2P16tUKf8ySk5Mxd+5c3Lt3T25eeHg4wsPD4eHhgZ07d2LdunWws7PLNZ7iXP/PDhw4gH///RdisVhmelRUFKKiouDp6Yl9+/ZhzZo1sLa2znV9v3JsgazSpS1btuDAgQPIyMiQmfft2zd4enrC09MTx44dw7p167gfeFdXVy5Ru3PnDubOnZttogwA9+7d46oc27ZtW6Ak7dOnT5g/fz4+fvwoM10sFiMxMREBAQE4deoU2rZti7/++qtYOsyIxWIsW7YMly5dkpsXGhqK0NBQXLp0Cc7Ozli2bBn09fVllnFzc4O3tzeCgoKQlJSE1atXY926dXLrevfuHXbv3s39vWDBgmyH2wkODoabmxuCg4Nlpvv5+cHPzw/Hjh3DmjVr0KBBg4LsMvz9/TFr1ix8/vxZbl5CQgISEhIQFBSES5cuoVGjRli1ahV0dXVzXOevnsdRUVGYPXs2nj9/LjcvPT0diYmJCA0Nxc2bN3Hw4EH8888/2SarheH27dtYunQp4uLiZKbHxcUhLi4Ob9++xcGDBzF69GgMGzYs1/WFhoZi6tSp+PTpk8z0iIgIXL16FVevXkWPHj0wZ84c8Hg8uc+fPXsWK1euRFpamsz079+/4/v373j9+jX27duHUaNGYdSoUQXYY6JKKFFTkpSUFJmbUG5PT9nJ6eacnp6OGTNm4MGDB9y0P/74A/Xq1YOuri6CgoLg4eGBHz9+IDQ0FCNHjsTmzZtz7Cn34MEDPH/+HJmZmbC2tkbDhg3B5/MRGBiIW7duISUlBYmJiZg5cybOnTsn9+OzZs0aLonS09ND48aNYWVlBR6Ph9DQUNy+fRuJiYmIjIzEn3/+ibNnz4LP5+f5ePzK+tu2bQtra2v4+PjA19cXANCmTRsumfu5/ZN0KRQA2Nvbo27dutDT08PXr19x7949REdHIzAwEMOGDcPu3bthY2NTZMcWAJYsWYLz589zf1evXh1OTk7Q09NDQEAAbt++jbS0NLx+/Rrjx4/H/v37oa2tDWtrawiFQrx//x6JiYnw8vJCixYtso31ypUr3L+lq+Dz6tOnTxg5ciQSEhIAADo6OmjcuDGsra2RlpaGFy9e4PHjxwCAa9euISQkBDt27OAeZpycnLjEbe/evVyvz0mTJnHbyG97tbS0NIwfP567LjU0NODs7AyBQAAejwd/f3/cv38fycnJ8PLywsiRI7F3716ZpKVMmTJYtGgRRo4ciczMTHh4eOD27dsyx1IsFmPBggVcIt27d2+4uLgojEksFmPKlCkIDg6GlpYWmjdvjmrVquH79++4ffs2oqKikJiYiEmTJmH9+vVo2LBhvvY5MjISI0aM4BKQ8uXLw8XFBaamplBTU0N4eDgePHjAlbw8ePAAmzZtwqxZs7Jd56+ex8nJyRg5ciRCQkIAAHw+Hy4uLrCwsICmpiaio6Ph6+sLf39/AFlJ7+LFi/HPP/9w68jvtZyTy5cvY8GCBdyDrrGxMZo2bQpTU1PExsbC29sbX758QWpqKjZv3ozIyMgcj09ycjLc3NwQGBgIfX19NGvWDBYWFoiPj4eHhweXkJ86dQoCgQA9evSQ+fzTp0+xdOlSLh6RSITatWujbNmyiI6OxqNHj/D582dkZGRg27ZtqFSpElfaSUooRpTi7du3TCQScf99//690LexdetWbv0uLi7s9u3bcst8//6dubm5ccu1bt2axcTEyCwTGhoqE2v9+vXZmTNn5NYVFBTE2rdvzy23e/dumflfv35l9erV47YTEhKiMJ5evXpluw7GGDfP1dW1SNa/bds2bv65c+fk5jPG2N27d7llmjdvznx8fOSWSUlJYatWreKW69atG0tNTZVZprCOLWOM3bhxQ2Y9p06dklsmICCAtW3blltu165d3LxDhw5x02fMmKFwvxljLCYmhjk6OnL7lF+pqamsU6dO3LaGDh3KwsPD5ZZ7/Pgxa9GiBbfc4sWLFa7P1dWVW+ZXrF27lltPv379WHBwsNwykZGRbMSIEdxyCxcuVLiuDRs2cMu0bduWJSQkKNxO9+7dWXJystznR40aJXNedOrUiX358kVmmaSkJDZjxgyZZcRiscwyjx494uYvWLBAbjt//fUXN3/SpEksJSVFbpm0tDS2evVqmXvJz8sV5nn877//cvMHDRrE4uLi5JZhjLF9+/bJbFPROZSXa1n6WIeGhsrM+/LlC3eui0QitnTpUpaUlCSzTGZmJjty5AirX78+t9ylS5dy3I5IJGJTpkxh8fHxMsukpaXJfCddu3aVW8+4ceO4+SdOnJCbn5mZyTZu3JjjOkjJQp0JlCQiIoL7t4aGRqG/ZSAmJgaHDx/m/l66dCmaN28ut5yRkRHWrl0LoVAIIKt6TPpzigwdOhRdu3aVm25hYYGxY8dyfz98+FBm/tu3b7mG323atFHYns7IyAjTp0/n/n737l2OsRTn+iUYY9iyZQuArJ66a9euVViyqa2tjZkzZ3KlHIGBgTIlUYoU9NgCkCndc3Nz49ovSrOyssKSJUu4v0+dOsX9u3379lxbH09PTyQmJiqM8caNG9zreApSmnb+/HmEhoYCAMzMzLBp0yZUrFhRbjkHBwds2LCBi+n8+fMIDAzM9/byIjIykmtbZmxsjK1btyps32NiYoL169dzTQ0uXbokVyUJAOPGjUO1atUAZFXjbd26FQDw7NkzHDlyBEDWdb9s2bJcmzzo6Ohgy5YtqFq1qsz0MmXKYPny5RAIBACyqtPOnj2b531OTk7GzZs3AWSdqwsWLFBY3a2hoYHJkydz1bxJSUm5fg+/ch5Lty3766+/si1RHzx4MHeMgYJdy7nZuXMnd663aNEC8+bNk6uC5/F46Nu3L9zc3Lhp//77b46vrLKwsMCKFSvkqs41NDQwe/ZsrpQ2KCgI4eHhMsu8fv0aAKCvr4+ePXvKrZvH42HChAlce7moqCjubR2kZKJETUmkhxQwNDQs9PXfv3+f24aDgwOaNm2a7bKampoyVUbnzp3Lcd29evXKdp50Fe63b99k5kk3+H379m22NzIHBwccPXoUnp6e+RofrqjXL/Hy5UuuPY+Dg0Ou43aNHDmS+7eitk/SCnpsIyIi8PbtWwBZ51Pfvn1zXE/9+vXRoEEDNGnSBMnJyQCykthGjRoByKpyu3PnjsLPS5JNHo+H9u3b57g/iki3zRw1ahTKli2b7bK1atVC27ZtAWS1v7tw4UK+t5cXFy9e5M6Xnj175nhN6uvrc8c3MzNTYfKtpaUFd3d37pw8ceIEnj9/Dnd3d+5hYty4cdwDUk569+4NCwsLhfM0NDRk2iDdvn071/VJpKenY/r06Rg6dChGjx6dbTtXIOseUaVKFe7vHz9+5Ljugp7HaWlpGD16NEaOHIkhQ4bk2FQAgMz83GLKr5SUFO4a4PF4MvdIRQYMGABTU1MAWQ39Hz16lO2ynTt3zrYNqK6urkzb2ezuo0lJSXJt3CR4PB62bduGa9euwdPTM08dN4jqokRNSaSTip8bhBYG6ZtETm2NJBwdHWFgYAAAiI6ORlBQkMLlKlasCBMTk2zXI/0D93MD+1q1anGNzl+8eIHhw4fjwoULCm9ENjY2+W48XtTrl5AecDcvnRFq1KjBxfXq1atsE8hfObaSdjhAVrvF3Br3b9u2DVu3bsXs2bNljoP0uxCvXbsm97mwsDDuFWd16tTJtpdxdlJSUvDq1SsAWT8mikp5f9a6dWvu30+fPs3X9vIqv9+pvb09929FDd6BrO996NChALISuvHjx3Olbw4ODhg8eHCeYmvTpk2O852dnblexU+fPpVrwJ8dfX19dO/eHW5ublyc2QkLC5N5uMyptOhXzmNNTU107twZ48aNw8SJE3OM6du3b4iNjc1TTAXx8uVLpKamAgAEAkGOPSgBQE1NTeZem9O5mtvrrKRrWCQxSEjaEGdkZGDUqFHYsWMH3r9/L9dZzMLCghK0UoI6EyiJdJF3fHw8MjIy5LqY/wpJ1RIArmokN7a2tlyCFxISAktLS7llcrvwpX/0f75xlCtXDkOGDMGuXbsAZL18/s2bN+DxeLC1tYWTkxOcnZ1hb29foPeXFvX6JSSNmIGsXp/Sb5XIjVgsRkxMjMIfsl85ttJV6XnpXZqdJk2agM/nIz4+Hr6+voiJiZH50bh69Sq37YJUe0ZFRXEPJmZmZnJVP4rY2tpy/5Y0MC9s0t/p5MmT8/XZn6umpI0aNQr379+Hn58fl5SULVsW7u7uUFPL/TlZQ0Mj11IlLS0tmJubIyAgABkZGYiKisq2BC43kZGRCAoKQkhICIKDg+Hv74/379/LnF+A/Pkn7VfOY0W+f/+OwMBAhISEICQkBP7+/vjw4YPcuZCXdeVHQe6h0stJf/5nuR0j6epw6XECAWDs2LHw9fVFcnIy4uPjsX37dmzfvh3lypWDk5MTGjZsCGdnZ+7Bm5R8lKgpifSNlDGG79+/5/gUml/S3cjz2mtS+sL++QXXEvkZQkTRjXPs2LEoU6YMduzYwf1wMcbw4cMHfPjwAfv27YOhoSHatGmDIUOG5DgukSJFvX4Acl308yshIUHhd/0rx1b6fYZ5SX6yo6WlhdatW+PUqVPIyMjAzZs3ZaqxJNV8kuXyS7oEJK8/JHk5L3/Vr3ynOcWkqamJGTNmyFRPduvWjasiyw2fz8/TQ4X0Nf79+/d8JWrfv3/Hvn37cPXq1RzbMqmrq8sN+aLIr94jgKwxyw4fPowLFy7kmPDkNaaC+NV7aE7n1K8cIxsbG/z7779wd3eXecD4/v07Ll++jMuXL0NdXR2Ojo7o168fnJ2d87wtopooUVOSypUrcyUXQFb1SUF++F69eoW0tDSZaj9A9uJWNA6PItJPbnl52i8IHo+HoUOHolu3brh58yY8PDzw+PFjmSqQ2NhYHD9+HOfPn8eaNWu4dlOqsH4AMj8MnTp1kmnQnBeF3XEEQKH+WLm6unKdDK5evcolah8+fMCXL18AAI0bN/6lhBBQrfNS+viNGzcuX284yGm8OUC2wwaQNdB1nz598pSs5bXkVzr+/Ixp9/z5c0ydOlUuqdDS0oKFhQVsbGxQq1YtODk5Yfny5cXynl1/f3+4ublxQ4JIqKurw9zcHNWrV0fNmjXh6OiII0eO5Diw7a9Q1XsokNXM4/jx4/D19cXt27fh5eUlU+opeQ+0t7c3unbtivnz5+d5H4jqoURNSdTU1FC/fn3cunULAODj41OgRG379u3w9vaGjo4ORo4cyQ22KP1kJ12KkRPp5XJq4F0YDAwM0KNHD/To0QOpqal4+fIlHj58CE9PT3z48AFAVnumuXPn4uLFi/mOpyjXL/10Xbt2bYW9K4ubdPy/2qja3t4eFhYWCA4OxosXLxAZGYkKFSrItFlzdXUt0Lqlj50qnZd8Pp9ry9i6dWtYWVkVynql38PL4/HAGENiYiIWL16MrVu35vrjmdfvUrpUL6/tkmJjYzFjxgwuSRMIBOjbty9q164NCwsLuaYYeW379ivS0tIwY8YMLkkzNzfHgAEDULduXVSpUkUuCS3KmH71HvqrDzK5UVNTQ8OGDble5f7+/nj06BF8fHzg4+PDPZyePXsWIpGowNcsUT7qTKBE7dq14/59584drvddXn39+pXr3p6SkiLz4yJd9eHn55fruhhjMiPE59ZwtjBpaWmhXr16GD9+PA4fPoydO3dCT08PQFY14f3791Vq/dIN6CVd5XOT1xt9QUl/XwEBAbkuf+HCBSxduhR79+5VONSCpP0ZY4w7PpKBhA0MDPJdCilRqVIl7sc2LCyMG/A2J5LEGii681L6O33z5k2uy6elpWU7fIlETEwMVqxYwf29ePFibjsPHz7EiRMnct1OUlKSXPuwnyUnJ3PVg7q6ujn23pR29uxZrspcKBTiv//+Q+fOnVGlShWF7WVjYmK4fxd2ezCJO3fucNV5FStWxIEDB9C7d2/Y2NgoLCksypikz7W83EMB2XM1vx1tflXVqlXRu3dvrFu3DleuXJHpXZtbb3Oi2ihRU6ImTZpwN4O4uDiZV8rkxb///stVeUjeoSdRp04d7t+SUruc+Pr6cj+aRkZGBW6MnJO9e/di5MiRaNmyJV68eJHtciKRiBuSAchq4Fyc68+tlEP6zQ13797NNcH+8OEDWrZsCRcXFwwaNKjQe6cBsr0QfX19c60KvXz5Ms6cOYPNmzfLtG+T6NixI3ccPDw8EBoayv2AFvSVUUBWNaHkNWWMsWyHAJEmff5K72dhkh5iRXr4kOycOHECTZo0QYsWLbB8+XKFy6xcuZI7ti1btkSHDh0wZ84cbv7GjRvz1DnCy8srx/n379/nqtyke4DmRtL7Fsj6vnOq7g0LC0NYWBj3988N3AuLdEytWrXKsW1YSkqKzIOSokTtV6r7atWqxR3LDx8+KBwvT1pmZqbM+VwU5+qLFy8wZcoUdOnSJdvzDsh6mBo/fjz3d17voUQ1UaKmRBoaGjJd0Pft24fLly/n6bPHjx+XeUoaO3aszI9nq1atuN5VT58+hYeHR7brSktLw+bNm7m/27ZtWyTtGb59+4Znz54hNjY214FfpZOHvHayKKz1S7ctUfSDVL9+fW6A1ri4OOzcuTPHbUmObXJyMszMzH6px2l2rK2tuR5n0dHROY6F5+/vz7U1MjY2VjhUgJmZGZe8PH78GNevX+fmFaS3pzTpIUB27tyZY/XemzdvcOPGDe5v6QS7MEknpl5eXjkmR/Hx8fjvv/8AZH3/1atXl1vm+vXr3GCyZcuWxYwZMwAADRs25ErSk5OT4e7unmtJ0IEDB7Kt4ktLS+N6OQO5D+Xx82clcivx/fl9pUXxsAHIDkWRW0xbt26VaXuqKKbcruWclClTBi1btgSQlQRu2rQpx+WPHDnClX4aGRnB0dExX9vLCx0dHdy7dw8hISG4e/dujqW60ve4ChUqFHospPhQoqZkLVu25EbwzszMxF9//YXly5cjKipK4fKxsbFYuXIlVq1axU1r06aNzI8fkNXmpn///tzf8+fPx927d+XWFxcXhxkzZnCjehsbG2PEiBG/uFeKdenShfv3yZMnce7cOYU/Urdu3eKq2cqUKZPnarbCWr+kWhSATCmChKampswgtvv27cOOHTvkfijEYjHWrFnDvWtVXV1d5nOFTXrdf//9t8LBT79+/YpZs2ZxJW4DBw7MtnRM0qZFLBZj7969ALLebFCrVq1fitPV1ZUrSQ4LC4Obm5vC6r1nz55h8uTJXKydO3fO0wCxBVGtWjWZJGfOnDkKH26io6Mxbdo0rj1bpUqVZM47IOuBYeXKldzfkyZNknkYmD59Otf+6enTp9ybCrITFBSEmTNnylUTJyQkYMaMGTKDL+dlXDoJ6WE/Tp48qbDEKDY2FrNnz5Yr+SyqtmHSQ7HcvHlTpoRNIjk5GatXr8ahQ4dyjSm3azk3w4cP50oab926hWXLlsmVoDPGcPLkSZl3jU6ePDlfHVLySiAQcA9k3759w/z58xU2H/j27ZtMPHkZS5OoLupMoALmzp2LlJQUrsrl1KlTXAPQGjVqQF9fH0lJSfDz88OjR49kniKbNWsGd3d3hesdPXo093LrpKQkTJs2DTVr1pR7KbvkQtfS0sKSJUvy3MYlv2xsbNCjRw+cOnUKjDEsXrwYR48ehb29PSpUqIDk5GS8fPmSexk3kFVSmNc3NxTW+qXblhw8eBBpaWkoW7YsRCIRV8rUvXt3PHv2jCsB3b59Oy5evIjGjRujXLlyiIiIwL1792QSbjc3t1zHxPoVLVq0QM+ePXHy5EmIxWLMmDED9vb2cHBwQJkyZeDv74/bt29zP2gikUgmmf9Zq1atsHr1aojFYu7J/VdL04Cs6s/Vq1dj1KhRSExMxMuXL9G9e3c0adIE1apVQ3p6Ol6+fIlHjx5xibaNjQ1mzpz5y9vOydy5c/Hx40d8+fIFiYmJmDp1Kne9aGtrIzAwEHfu3OGuP21tbSxbtkyu1+eyZcu4Bvp169ZFt27dZOYbGRlh8uTJ3HW7efNmODs7Z9uBQUNDA15eXujatStatmyJSpUqITw8HLdu3eJKncqVK4d58+blqyS8e/fuOHLkCMRiMWJjY9G7d2+0aNECVlZWSE1NRUBAALy8vLhSLg0NDe5h5FeHqMlOmzZtsG3bNnz//h1isRgjRozgzgsej4fg4GCZ15vlFlNeruWcVK9eHTNnzsSyZcvAGMPp06fh4eGBZs2aoVKlSoiPj8eDBw+4ZBnIemD8+cG5MM2YMQNjxoxBRkYG7t27h06dOqFJkyZcaX1QUJBMaVuNGjXQuXNnufV07NiR67QxevRojBkzpshiJr+GEjUVoK6ujmXLlsHBwQHbtm3Dt2/fkJGRgUePHmX7GhI9PT2MHTsWffv2zbYbuIaGBjZt2oSVK1fi/PnzYIzh9evXChvAW1paYuXKlXke2LGgZsyYAbFYzHWp9/PzU9hQV0tLC6NGjcLAgQOLff2Ojo4wNzdHSEgIxGIx9u/fDwDo27evzM3d3d0dlSpVwv79+5Geno7Q0FAcPXpUbn3a2tqYOHFijq91KiyzZ8+GgYEB/vvvP2RkZODFixcK2+s1bdoUixcvzrEatmzZsmjWrBnX27Ogr4xSRCAQYM+ePZg9ezb8/f2RkpIiU70qrWPHjnJvUCgKZcuWxZ49e7BgwQKuxDW766VixYpYsmSJTFtQIKvRtqQkTktLK9vkqXPnzrh06RI3dMyiRYuwe/duhdfyokWLsGbNGsTGxsoN9QFkVXtv2LABZmZm+drfypUrY+nSpZg/fz7EYjFSU1MVts/j8Xjo1q0b7OzssGzZMgBF815NIKun5N9//40pU6YgLi4OGRkZuHPnjsK2jM2bN4erqyv37l5FMeX1Ws5Jt27dULZsWaxYsQJxcXH49u2bwu9BU1MTbm5uGDBgQH52Od/q1q2LFStWwN3dHYmJiUhISMi2s4CjoyOWL19eJKV7pPhQoqZCunfvjvbt28PDwwNeXl7w8/NDZGQkEhMToampCSMjIwgEAjg5OaF9+/Z5GqpAS0sLCxYsQJ8+fXDu3Dk8fvwYERERSE5OhqGhIYRCIVq1aoX27dsXuIF4fmhqasLd3R1du3bFxYsX8erVK4SHhyMlJQV8Ph+mpqZo1KgROnXqVKAefoWxfh0dHezcuRObN2+Gr68v4uLiwOfz5V71paamhj///BNdunTBmTNn8PDhQ4SGhuLHjx/Q1dWFpaUlnJyc8jXA6a/i8XgYP348OnTogNOnT8PX15fb/3LlyqFWrVro0qVLngfB7NChA5eoFeSVUTmpXr06jh07hmvXruHOnTt48+YNYmNjwRiDqakpHBwc0Llz51+uas0PfX19rF+/nistffr0KaKioiAWi8Hn82FjY4OmTZuiU6dO3IuzJaKiomTeHTt8+HC5F6lLmzdvHvr27QuxWIyXL1/i4MGDCl8rZW9vjxMnTuDAgQO4e/cuIiIioK2tDYFAgPbt28PV1bXA126LFi1w7NgxHD58GA8fPsTXr1+RkZEBPT09mJubo2bNmujSpQsEAgGioqKgpqaGzMxM3L17FzNmzCiS5Nne3h7Hjh3DkSNH8ODBA4SGhkIsFkNPTw+mpqaws7ODq6srRCIRUlNToa+vj4SEBDx58gQRERFc+1Eg79dyblq3bg0nJyecOXMGXl5e8Pf3R1xcHLS1tWFpaYmGDRuie/fuxXadt2zZEvb29jh37hx8fHzg7++PhIQEaGlpoXz58qhduzZat24NFxeXYomHFC0eK6p+1oSQEu/8+fNcFd38+fPlqvFI0Rg9ejTX4ePChQv5Li0jhJQe1JmAEJItSRs8HR2dAg3ITAgh5NdQokYIUcjf35/reNGqVasif1sFIYQQeZSoEUIAZI2CL2kJ4e/vj1mzZnF/F0dHCEIIIfKoMwEhBEBWe7TNmzdDS0tLZqiD1q1bw87OTomREULI74sSNUIIAHBjzUkP6GlpaYlZs2YpMSpCCPm9UdUnIQRA1nhc1atXh5aWFkxMTNC9e3fs3r0bRkZGyg6NEEJ+WzQ8ByGEEEKIiqISNUIIIYQQFUWJGiGEEEKIiqJEjRBCCCFERVGiRgghhBCioihRI4QQQghRUZSoEUIIIYSoKErUCCGEEEJUFCVqhBBCCCEqihI1QgghhBAVRYkaIYQQQoiKynei5uDgAAcHB5w/fz7XZc+fP88tX5pJ9tHX17dIt7N9+3Y4ODhg+PDhMtM7duwIBwcHnDlzpki3T4rXwoUL4eDggPnz5ys7lAJLTk5GWFiYzDTJfaF9+/ZKiqpopKWlYevWrejUqROcnJzQqlUrbN++XdlhFZuwsDDuXhgcHMxNz+n7jo6Oxvz589G6dWs4OTmhXbt2ePDgAQDg4sWL6NevHxo1aoSmTZtiwoQJxbYvxSU9PR2BgYHKDuOXxMXFITo6WmZadr9VylLY95ykpCTs2bMHAwYMQOPGjdGwYUN07twZixcvxufPnwtlG9KoRI0QUiSuXLmC7t27F/kDjKpYv349du/ejbCwMJiZmaFChQowNTVVdlgqKzMzE25ubrhy5Qri4uJQrVo16Ovrw9TUFLdu3cLChQvh5+cHfX19WFpaonLlysoOuVB5e3ujd+/euHTpkrJDKbDDhw+ja9euRZKcqKrIyEgMHDgQW7Zswfv376Gvrw8LCwuEh4fj3LlzGDBgQKF/pxqFurbf1MmTJwEAlSpVKtLt9O7dG23atIGOjk6RboeQwrBlyxZERkbKTW/evDlq1aoFDY3Sdfu5ceMGAGDo0KFwc3NTcjSqI7vvOzAwEH5+fgCADRs2oFGjRtw8SUlknTp1sH379lJ3rgDA3r17S3xp2tq1a5UdQrGbM2cOAgMDYWJiguXLl0MkEgEAYmJisGTJEnh4eMDd3R3VqlWDnZ1doWyTStQKQdWqVVG1alWUKVOmSLdjZGSEqlWr0lM6KdH09fVRtWpVWFhYKDuUQhUbGwsApb6pR35l931LjhcA1KtXT+G8OnXqlMokjZRMT58+xfPnzwFkNU2RJGlA1u/zypUrYW1tjYyMDBw4cKDQtkuJGiGEFILMzEwAgJaWlpIjKRkyMjK4f/98zOhYElXk5eUFAKhcuTIaNmwoN19LSwtt2rQBALx//77QtqvUR5XIyEgcPnwYnp6eCAsLg5qaGiwsLNC8eXP069cP+vr6AADGGDp06IDIyEgsXbpUrkHg5cuX8ddffwEAjh07hurVq8vMX7duHQ4dOoQ+ffpg5syZucbl7++P/fv34/Xr1wgLC4O6ujrMzc3h7OyMfv36oVy5cjLLS56gt27digYNGgDIarzo7u6O9u3bY/bs2dizZw9u3ryJqKgoGBkZoWnTpvjzzz9RtmxZ+Pn5YdeuXXjy5AkSExNRuXJldO/eHf379wePx+O2s337duzYsQP29vbYs2dPno7xhw8fcOLECTx79gxRUVEQi8Xg8/mws7ND586d0apVK5nlJXG3adMGffr0wapVq+Dv7w8DAwMMHjwYAwYMyHWbUVFROH78OHx9fREcHIzExETo6emhSpUqaNGiBXr16iVTfRsWFoZOnTrB2NgYhw4dwpIlS/D48WNoa2ujYcOGWL58Obfs06dPcfToUTx//hxxcXHg8/moVasW+vbtC0dHxzwdk5/dvXsXp0+fxtu3b5GQkAAjIyOIRCIMGjRIpuiaMYZx48bh0aNHMDY2xokTJ2BgYCCzroULF+LixYswMTHBkSNHYGRkxH1v/fr1w5AhQ7Bp0yZ4e3sjMTERZmZmaNOmjcz5nhe/coyvXbuGc+fO4fTp0/D39wcAWFtbo3v37ujUqZPMOSeRn/NIsr8SS5cuxdKlSzF69GiMGTOGO8cqVKiAK1euyG3r4cOHOHHiBF68eIG4uDiULVsWNWrUQLdu3dCiRQu55Tt27IivX7/i5MmT+P79O/bt24fXr18jOTkZZmZmaN26NQYPHgxdXV2Zz2VkZOD06dO4ceMGAgMDERcXBwMDA9SsWRNdunRBkyZN8vRdSLYvMWbMGABZ94UdO3Zwx2PIkCGoVasWNm3ahLCwMJQvXx5ubm5o27YtACAlJQWnTp3C9evX4e/vj7S0NJiYmMDJyQkDBw6EpaWlzHYfP36MMWPGwN7eHtu3b8eBAwdw6dIlhIWFQV9fH05OTnBzc4OJiQnCwsKwfft2eHt7Iz4+HhUqVEC7du0wcuTIfCdD79+/x/79+/H8+XPExsbC3NwcPXv2lKm6lPbz9y05F6VJ7qEdO3bExYsXuek7duzgzqUnT55w03/8+IEjR47gzp07CA4ORmZmJipXrowWLVpgwIABctdSXu9rGRkZuHz5Mi5evAg/Pz8kJyfDxMQEDRo0wODBg+W+g4JcV5JYJHbv3o3du3ejY8eOMtMVKcrv/Nu3bzh48CDu37/P/e5VqVIFbdq0Qe/evaGtrc0tK7nPSYwfP56b3rlzZ5n1xsTEYO/evfDw8EBERAT4fD7q1KmDoUOHokaNGgr3MzAwEIcOHYKvry8iIiKgpaWFqlWrok2bNujRo0e2zX9u376N48ePw8/PD2lpabCzs8OwYcNyPKavXr3C4cOH8eHDB4SHh0NLSwtWVlZo1qwZevfuDT09PW7Zbt26oVatWjk2P5LM09TUzHG7+aG0RO3hw4eYMWMGfvz4AQ0NDVhbWyM9PR2fPn2Cn58fzp49i3/++Qc2Njbg8Xho3LgxTp06BW9vb7lETbqx8qNHj+QStfv37wMAmjZtmmtcL1++xPjx45GcnAx9fX1YWVkhNTUVnz59wocPH3Dx4kXs3bs3z+3RYmJiMGjQIAQFBaFKlSqoVKkSgoKCcPz4cbx//x5Dhw7FrFmzoKamBisrK0RHRyMgIADr1q3D9+/ff6mty4kTJ7B69WpkZmaCz+fD3NwcYrEYYWFh8PLygpeXF4YPH44///xT7rMBAQFwc3ODmpoaqlWrhoCAAFSrVi3Xbb569Qpubm5ISEiAtrY2zM3NYWpqitDQULx8+RIvX76Eh4cHtm/fDnV1dZnPpqam4s8//0RgYCCsra0RHh4OMzMzbv7GjRuxb98+AACfz4eNjQ0iIyPh4eEBDw8PDBkyBBMnTszz8UlPT8eiRYu4ZKFcuXKwtbVFaGgorl27hps3b2LatGno06cPAIDH48Hd3R19+/bFt2/fsGbNGixdupRb3/Xr13Hx4kWoqalh8eLFMDIyktleZGQkBg0ahKioKFhaWsLY2BifP3/G9u3bcf36dWzZsgUVK1Ys0mPMGMPChQtx6dIlrpF2aGgoXr16hVevXiEgIEDuGOb3PKpUqRLs7e3x7t07pKamwsLCAuXKlcvTNbN69WocO3YMAGBgYACBQIDIyEg8ePAADx48QOvWrbFkyRKFN8EzZ87g8OHD0NLSgqWlJeLj4xEQEICdO3fi4cOH2LlzJ3c8GGOYM2cObt26BQCwsLBAhQoV8PXrV9y9exd3797FyJEjMW7cuFxjrlGjBipUqIAXL14AyPpxLlu2rNx96OnTpzh48CD4fD6qVq2KL1++QCAQAAAiIiIwfvx4BAQEAACsrKygq6uLL1++4NSpU7h48SIWLVrEPa1LE4vFGDNmDF68eIHKlSvD3NwcgYGBuHTpEp4/f45FixZh8uTJEIvFsLKygoaGBkJDQ7F7926EhITIPAjl5vLly3B3d0d6ejr4fD6sra0RFhaGVatW5bnKV0tLC/b29vjx4wfXCN3e3p7bb3t7e3z69AmJiYmoWLGi3Hnj7++PiRMncslE5cqVoaOjg8+fP2Pnzp24ePEiNm3ahKpVq8ptO6f7WlJSEqZPn879nlSoUAGVK1dGUFAQzpw5g8uXL2Pp0qUKHxbyc10ZGxsr3EcrK6s8fguF/50/f/4cU6dORVxcHDQ0NGBlZQXGGN69e4e3b9/i8uXL2LRpE8qXLy/zPf18zhsbG8usNzo6GgMGDEBERATMzc1haWmJwMBA3Lp1Cx4eHti0aZPcA/bly5exZMkSpKamQltbG9WrV0dSUhJev36N169f4/z589i4caPcvXLlypU4ceIEAKBixYowMzPD69evMWHChGzPzdu3b2P27NnIyMiAoaEhqlWrhsTERLx58wavX7/GlStXsHfvXi5ZMzc3h7m5ebbfS2pqKi5cuACgkJtAsHwSiURMJBKxc+fO5brsuXPnuOWlhYWFMRcXFyYSidiUKVNYdHQ0Ny84OJgNHTqUiUQi1qFDBxYfH88YY8zT05OJRCLWpk0bue20bduW286UKVNk5gUGBjKRSMSaNm3KUlNTc4158ODBTCQSsdWrVzOxWCwTV9euXZlIJGLLli1TeEx8fHwU7nubNm3Y69evFc6rV68emzt3LktISGCMMZaWlsbc3d2ZSCRiDRs2ZMnJydzntm3bxkQiERs2bJjM9l1dXZlIJGKnT5+W2W9HR0cmEonYrl27ZPY9NjaWzZo1i4lEIubo6Mji4uIUxjZkyBDu+MfExLDMzMwcj116ejrr3LkzE4lEbOrUqTLrTU1NZXv37uXWfe/ePW5eaGgoN7158+bs8+fP3Gckx+XkyZPc93jp0iXus5mZmezatWvM2dmZiUQidubMmRxjlLZx40YmEolY+/btmZeXl8x+HDlyhNWvX585ODgwb29vmc9du3ZNbj++fv3KmjZtykQiEduyZYvM8pLvTSQSsWbNmjFfX19u3pcvX1i3bt2YSCRif/75p8znFixYwEQiEZs3b16hHuP69euzw4cPs/T0dMYYYykpKWz+/PncvO/fv3OfK+h5xJji85Kx/51j7dq1k5m+f/9+LoZjx46xjIwMbt7169e5e8bq1asVbkckErFFixZx52xmZiY7duwYN+/27dvcZ7y8vJhIJGItW7Zkfn5+Msd39+7dXBzh4eEsryTbefTokcx06e9/2rRp3H1FcpzT09NZv379mEgkYt26dWMfPnzgPpuQkMAWL17MHeOXL19y8x49esStt3HjxszT05Ob5+vryxwcHLh7zLhx41hkZCR3XKRjCg0NzdP+BQcHs4YNGzKRSMTWrl3LnQvp6elsz5493PpEIhELCgriPpfd9y0d/89GjRrFRCIR27Ztm8z0pKQk1qVLF+5eL9knxhiLiopiEydOZCKRiHXt2lXm3pmX+9qcOXOYSCRivXr1Yq9eveI+m5KSwjZv3szdkz9+/MjNK+h1Jb2PP98vclIU33lERARr3rw5E4lEbMmSJdyxYYyxoKAg7jdxxIgRcvEo+u1jTPac79ixo8zxDAkJ4e55gwYNkvncy5cvWf369blYJPd/xhh7//4997n+/fuztLQ0bt6lS5eYSCRiDRo0YJcvX+amx8fHs5kzZ3KxSJ+DGRkZrE2bNkwkErF9+/Zx3xtjjL19+5a1bNmSiUQitmfPnhy+kf9JTU1l06ZNYyKRiDVp0oSFhYXl6XN5UeA2au7u7tyYOdn9l10x7t69e5GUlARra2usWrVKJgs3NzfHP//8A2NjY4SHh3NP1/Xr14euri6io6Px8eNHbvnPnz8jKioKderUgZqaGp4+fcq1bwD+V5rm4uKSp6JIybo7d+4sUzxsbm6OKVOmoHHjxvnu3Tlt2jT88ccf3N+dOnWCiYkJAMDU1BSLFy9G2bJlAQAaGhoYNWoUgKynJskTdn75+PhAXV0ddnZ2GDFihMy+GxgYYPLkyQByHsdn/PjxXBWCoaGhwioxaX5+foiLi4OWlhb++usv8Pl8bp6mpiaGDh3KdbH/9OmTwnX06tWLe8LV1NRE2bJlkZaWxvUCW7BgATp06MAtz+Px0KZNG0yaNAlAVrVbenp6jnECwPfv33H48GEAWT2XpKtt1NXV0bdvXwwcOBCMMWzdulXms23atOFiWLFiBRISErBgwQIkJCTA3t4eo0ePzna77u7uMk+QVatWxdq1a6GmpgZvb2+8evUqx7gL4xj37NkT/fr140qXtLW1MW3aNPB4PGRkZOD169fcsoVxHuWFWCzG7t27AQBjx45F7969oab2v9tT69atufHkTpw4ITc2GwDY2tpiwYIF3DnL4/HQu3dv2NjYAAD39A+A621Yu3Ztbj6Q9d0PHz4crVq1Qrt27RAfH1/gfVJk8uTJ3H1FUuJ68+ZNfPjwAdra2ti4cSNsbW255cuWLYu//voLjRo1Qnp6uty5KDF8+HA4Oztzfzs6OqJWrVoAgDJlymDVqlXcPYfH42H48OHcd5nXtjT79++HWCyGg4MDpk6dyn1eXV0dw4YNk6vyKgpnzpxBcHAwhEIh1qxZw+0TAJQvXx6rVq2CqakpgoKCuJKNnym6r/n5+eHatWvQ0dHB5s2bUbNmTW55bW1t/Pnnn2jdujXEYjF27dqlcL35ua4KQ2F95wcOHEBcXByaNm2K+fPny1QbW1hYYN26ddDT08OzZ8+4Nlr5sXTpUpnjWblyZe437u3btxCLxdy87du3IyMjA05OTpg/fz73uwgAAoEAmzZtgra2Nt6/f4/r169z8yT3juHDh8vUuOnr62Pp0qUKSytjYmK48d+6desmU/tgZ2eH8ePHo1mzZnLNWxRJSUnBtGnTcOfOHWhra2PNmjWF2umvwImapaUl7O3tc/zv5/p8CUny1KtXL4XJE5/PR5cuXQBktR8CsorLnZycAGSNPyMhKaZu3rw5rK2tkZCQgA8fPnDzPT09AeSt2hMA1zNp+fLlePjwIdLS0rh5TZo0wYYNG/I1iB+Px5Nru8Hj8bgv0cnJSa56SlK8DACJiYl53pa03r1748GDB9neVKTr2JOTk+Xmq6mpoXbt2vnapp2dHe7evYs7d+7A0NBQbn5qaip30qekpChcR506deSmvXjxAt++fYOenh6aNWum8HPt27eHmpoaIiMj8/TD4+npidTU1By7UEuSsTdv3uD79+8y82bNmgVTU1NERERg6NChePLkCfT19bFs2bJse6lZWFgobPdUtWpVrveQ5HzPTmEcY0UxGBoacolDQkICN/1Xz6O8evbsGRISEqCuro7evXsrXKZNmzaoUKECMjIyuHuINBcXF4UPE1WqVAEgu1+Se5Onpyf27NmD8PBwmc+sWrUKixcvlknifpWxsbHCapN79+4ByPpesqtWkbShevLkicx+SLi4uMhNk9xj7O3t5dpsaWpqcudPXu8xknvpz+3LJHr27Jmn9fwKyfXRtm1bufsmkHU+tmzZEgAUniPZ3dfu3LkDIKu6qkKFCgq3LbkfPHjwQKYjhER+rqvCUFjfuWTfsxsM1tjYmPvtlZyreSWp5v2Z5LpijCEuLg5A1v3j8ePHAID+/fsrXF/lypXRvHlzAP87F0JCQrgCDUXnpqamJrp27So33dDQkHvQnTdvHl6+fClTyNO9e3esXbsW3bt3z3EfGWOYNWsWvLy8oKuri3/++afA7aWzU+A2anl5gvq50SSQdYJIxlbKaYwRyTzpp/QmTZrg9u3b8PHxweDBgwFkPfEDWU8ToaGh+PjxIx49egQ7OzskJibi2bNn0NLSknnyyMmkSZMwefJkvH79GuPGjYOuri7q1q0LJycnuLi4ZJt8Zqds2bIyTwUSkgT153ZM0vOArJPgV2hra+P169f4/PkzQkJCEBISgk+fPsmU1Cnahr6+foHHa9PR0UFQUBDevn2LkJAQhIaG4vPnz/j06RP39JTdfkknqRKSdixpaWkYOXJktttVU1NDZmYmAgICZJ7gFJGsMyIiItvEWzrGgIAAmU4kZcuWxZIlSzB69GjuWM6bNy/HpyjpUtWf2djY4PHjxwgKCsoxbolfOcbZ/RBJGgsr+hEq6HmUV5L1WFpaKrxegKwHHKFQiMjISIWld9KlKz/HDsjuV5MmTeDg4IAnT55gy5Yt2LJlC6pUqYIGDRqgYcOGcHR0lGk8XRiyi0+y73m5H2ZkZCAkJERuWUVtG3O6xwDgHijy8r2lpKQgIiICAOTa3knY2tqCx+P98j0rJ5JS4jNnzmT7UPPt2zcAUFgbkd19TXI/ePfuXbb3A8l1JfkN+/laL8h19SsK4ztPSkriOsLs3LkTR44cUfg5yTL5reHJ7phId+yRHNeQkBCuYCS3a+Hq1atcLJJ7gZ6eXrb3X+lSagl1dXW4ublh2bJlXFtbPp+PevXqcb/3eWkzfObMGXh6ekJHRwdbt27lSjULU7F3JpDO5LO7IQPgGu8lJSWBMcZ1KFBXV8fz58+RkpICdXV1PH36FIaGhrCxsUH9+vVx/PhxPHr0CIMHD4a3tzfS0tLg7Ows1+MrO40aNcKBAwewb98+eHp6IjExkfsS165dizp16mDevHl5algPINex1aSrdwrb5cuXsXPnTrkf/8qVK6NLly45vnKqoD9Sr169wqZNm2R6aAFZTy/Ozs748OEDQkNDs/28opvojx8/AGSVFklXX2UnL0+uknUmJiYWeJ12dnYwMTFBREQENDQ0cj0ncipCl5yfeYn9V49xbk0Afv6h/ZXzKK8k94Wc7gnA/+4LikqB8rNfGhoa2LJlC44dO4YLFy5wSWdAQACOHTsGPT09DBkyBMOHD8+1yj+vsrum8rLv0j3PFO17TveZwohf+rzMbluamprQ0dH5pZLV3Eiu26CgoFwfahRdS9l9B5L1fv/+Xa70PKflpeX3uvpVhfGdS+9HXt4ukN9Swfz0KC5IbgCAa56QU8GCdBMRad27d4elpSXXwzQ+Ph63b9/G7du3wePx4OLigjlz5uSYsElepzlgwIAiSdIAJSRq0gmTopNdQnLwdXV1uZPO0NAQtWvXxrNnz/D06VNoaWkhOTmZq/KoX78+l8ilp6dzRfXZVZdlRyAQYPny5UhLS8Pr16/x+PFj+Pr64sWLF3j+/DnGjRuHs2fPFvkAt7/iwoULWLRoEYCs5FNSNVy1alXw+XykpaUV+rtB/f39MWbMGIjFYlSrVg2dO3eGra0tqlatyj1ZDR8+PMckQhHJcbazs8PBgwcLJVbJOlu2bInVq1cXaB0bNmxAREQE1NTUkJ6ejr/++gv79u3L9oad0w+Y5Fr4eeiXnxXVMc5OcZ1HkvtCTvcE4H/3BenEpaA0NTUxcOBADBw4EBEREXj8+DEeP34MLy8vfPv2DVu3boW2tjYGDhz4y9vKSV72XfoHsjD2Pb+kHzKyqypljCE1NbVI4yhTpgx+/PiB9evX53n4lLyQ/MgPHDgQU6ZMKbT1qjrp3zBFQ1sVJ+nz+sePH9neCyXXguS6kZybksRNEel2cD+rV68e6tWrh5SUFC638Pb2xrt373D//n1ERETg8OHD2Sa/X758AZD/PCM/in3A27Jly3JVAO/evct2Ocm8n0ezllycPj4+XH22pD5YX18fQqEQSUlJePXqFby8vMDj8fJ8QWdkZCA4OBhPnz4FkHUjr1u3LkaNGoVdu3Zh165d4PF4iI6OVvn3F+7duxcA4Orqik2bNqF79+6wt7fnniwUvdrnVx05cgRisRhVqlTB/v37MWjQIDRo0ECm+FtSfZIfkoagQUFB2XYUYIzh0aNHCAoKkmlXmNs6c3qKTE5OxpMnTxASEiJXbfHgwQOcOHECampq2LBhA8qXL48PHz7g33//zXZ9OW1L0q4yt1K5ojrG2Smu80jSjiwoKCjbhCUzM5M7Tr/6VoP4+Hi8evWKa5tWsWJFuLq6ckMsSO4Zly9f/qXt5IVk33O6H759+xZAVklJTsMDFBUtLS2uWkm6DbC0gICAQq/e+5nkupX8OCoiaRIQExOT5/VKvoOc1hsbG4vnz5/j69evRVq9W5z09fW5znw57fvHjx/x4cOHQu9cI83c3Jyrms3LtSBphiT57pKTk7Pt0KTo3puWlgZ/f3+uA5eOjg4aNmyIP//8EwcPHuSGMPHz85PpwPgzHR0dGBsbK2wzXFiU8maCxo0bA8jqvaXoRzU+Pp4bTO/ntmWSrNXHx4er+pFuuCcZcPa///7D9+/fUatWLYXtnhT5/PkzunbtirFjx3K9QaTVrl2by+KlGx2qIkmvuOzq+s+ePcv9u7BurpJSnOxep+Xj48P9MOalZ6aESCRC2bJlkZiYyBUz/+zKlSsYO3YsevToIdcwXBEXFxeoq6sjICCAa+f4s8OHD2P06NHo37+/TGlYTEwMV8o0YMAAODs7Y/bs2QCyelBJEv2fvX37VuEF//HjR676VdIQOjtFdYyz8yvnkaRaPy8/anXq1AGfz0dGRgaOHz+ucJlr164hOjpaYQed/HJ3d8fQoUO5cfmkaWpqcp07ijrxAP738Hnv3r1sS0IlPZRr166dr4GRC5Nk/LDTp08rPC6FXUKviORYnT17VmFnmfT0dEydOhWDBg3C+vXr87xeyW+Sr68vN1jtzzZt2oQRI0ZgzJgxhXL/l5TQKDvpk3RKOHbsmML9SkhIwNixY9G/f3/uPJQozH0oU6YM9yqxn7cjERISwnVokNwDzMzMIBQKAfzvvdvSMjMzFf5ueHl5oWfPnpg0aZLCkmBJLgHkfB+4fv06rl+/LjPmZ2FTSqI2ZMgQ6Onp4fPnz5g1a5ZMm4DQ0FBMmjQJ3759Q4UKFeR6f1haWsLKygqfP3/Gy5cvYWZmJvOEWb9+fQD57+0JZDU4rF69OjIyMjB37lyZkom0tDRs2bIFiYmJKFOmDOrWrVugfS8ukqeM06dPy5R6/PjxA9u3b8d///3HTcuud2BBt+nj44Nnz55x09PT03H16lXMmTOnQNssU6YMN7r033//jfPnz8vcUO7evYsVK1YAyBrGIS+lLaamplxPoLlz58r0ZsrMzMSZM2e4IUF69eol02Zi2bJl+PbtG6ysrLgBUZs3b462bdsiMzMTCxYsUFgqxBjDjBkzZJ7uPn78iGnTpoExho4dOyocpFNaUR3j3LZXkPNIkkjmJXGW/o63bduG48ePy3zHt27d4p5wu3fvnq/BQRVxdXUFAJw6dQqXLl2S+aH5/Pkzjh49CkD+QbEotGrVCjY2NhCLxXBzc+OGDgGyqhmXLl3KDZOizJe9Dx48GAYGBnj37h3c3d25KlDGGE6cOMEds6LUu3dvlC9fHsHBwZg6darMGyFiYmIwe/Zs+Pv7Q1NTE4MGDcrzeuvWrYtGjRohIyMDEydOlGm3mpqail27dnEPJUOGDFHY4zS/JA/90vugDMOGDYOuri6eP3+O+fPny5REfv36FZMmTUJsbCzKli0r1yO7sPdhzJgxUFdXh4+PD5YuXSpTze7n54eJEydCLBbD1tYWHTt25OZNmDABAHD06FEcPnyYu3ckJydj6dKlePPmjdy2nJ2dYWhoiLi4OCxcuJDrfQpkVaNKEv2KFStmWyUsKZXz9/cv9F690pTyZgJzc3OsWrUKs2bNgoeHB7y8vLg3E/j7+yMzMxOVKlXC33//rbD3StOmTbF//36kp6dziZlEnTp1oK2tzdVJ57feeMWKFRg2bBiePHmCzp07c6Neh4WFccMHzJs3L9teNapi/PjxmDZtGr58+YLOnTtzP2zBwcEQi8WoXLkyeDweQkJCCq2qbODAgbh69SpiY2MxcuRIWFpaQk9PD6GhoYiPj4euri5q166Nly9f5rvKbMiQIQgJCcGZM2fg7u6Of/75B5UrV0ZkZCSioqIAZHVJl7xKLC+mTZuGyMhI3L9/H1OmTIGJiQkqVKiAsLAw7mbVsmVL7vUoQNaT/J07d6CmpoZFixbJNE6eMWMGHj16hK9fv2L16tVYvHixzPYqVqyI2NhY9OnTh6vi/PLlCxhjqF+/PqZPn55rzEV5jBX5lfNIIBDg06dP+O+//+Dp6YkWLVrk2Gt30KBBCA0NxcmTJ7Fq1Sps375d7jtu2bIlpk2b9sv71aJFC3Tr1g1nzpzBggULsH79elSqVAk/fvxASEgIGGP4448/MGLEiF/eVm40NDSwbt06uLm5ISAgAP369ZN5M4FYLIa2tjbmzp2r1AfE8uXLY+XKlZg+fTouXbqE27dvo1q1aoiIiEB0dDSaNm0KT0/PIi2F5PP5WL9+PSZPngxfX1907twZVatWhZqaGgIDA5Gamgp1dXUsX74830OrLFmyBJMmTcLr168xfPhwVK5cGXw+HyEhIdyPcP/+/dGjR49C2ReBQIB79+7hypUr+PjxI+rWrcuVzBcnCwsLrFy5EnPmzMG1a9dw69YtWFtbIy0tDYGBgcjIyECZMmWwceNGuXZjAoEAT58+xerVq3Hq1Cn06tWLG1qrIGrXro0FCxZg6dKl3NsgqlWrhqSkJK5as3r16vj7779lOio0bNgQEydOxKZNm7B27Vr8999/qFSpEgICApCYmIjmzZtzw5BIaGpqYtWqVZgwYQKuX78ODw8PmJubQ01NDSEhIUhOToaOjg7c3d2zbXccFRXFDUuj6PVZhUVpL2Vv2LAhTpw4gQEDBqBy5coICAhAREQEBAIBJkyYgKNHj2Zb3SJdSvbzeCVaWlrcWFxVqlThSgTyqlq1ajh06BB69uyJypUrIzw8HP7+/tzYbkeOHMl2vBlV0qRJE+zfvx/NmjWDsbEx/P39ER4ejurVq3PHV7IfisYbKghTU1McPXoUPXv2hJWVFSIiIhAQEABjY2P06dMHR48e5ZKex48f56t3GI/Hw/z587F582Y0b94c6urqeP/+PZKSklCrVi3MmDED27dvz1cHD21tbaxfvx4rVqxAo0aNkJaWhvfv3yMjIwP16tWDu7s7Vq5cyT09h4SEYO3atQCAfv36yY3HZGRkxL1L9tKlSzIDMgJZr1bav38/WrVqhaioKISHh6NGjRqYO3cuNm/enKcqraI8xor8ynk0ZcoUtGzZEmXKlEFAQEC2VUoSPB4Pc+bMwebNm9GsWTOoq6tz7aGaNGmCtWvXYvXq1YU2bMbcuXOxcOFC1KtXD5mZmdxgwnXq1MGsWbOwe/fuYmu4b2ZmhoMHD2LSpEn4448/EB0djS9fvqBSpUro168fjh49KlOCoCyOjo44dOgQunfvDkNDQ3z8+BE6OjoYM2YMVq1aVSwx1KhRA8ePH8eoUaNgY2ODr1+/wt/fH+XKlYOrqysOHTqk8DVPuTE0NMSuXbswb948ODg4ICEhAX5+ftDQ0ICzszPWrVtXKA8JEkOGDEHXrl1hYGCAoKCgHNtBFTVnZ2ccP34cAwYMgIWFBQICAhAcHAwzMzP06tULx44dUzge2oIFC9CgQQOuGcmvDHot0bFjRxw5cgTdunVD+fLl8fnzZ8TGxsLe3h6zZs3C/v37uUG9pQ0ZMgTbt2/nqsc/ffoEKysrLF++PNt3VNerVw/79u2Dq6srypcvj6CgIAQHB6NChQro06cPTp48KVcYpAw8puwKckJKOclLue3t7bFnzx5lh0MIIaQEUVqJGiGEEEIIyRklaoQQQgghKooSNUIIIYQQFUWJGiGEEEKIiqLOBIQQQgghKopK1AghhBBCVBQlaoQQQgghKooSNUIIIYQQFUWJGiGEEEKIiqJEjRBCCCFERVGiRgghhBCioihRI4QQQghRUZSoEUIIIYSoKErUCCGEEEJUFCVqhBBCCCEqihI1QgghhBAVRYkaIYQQQoiKokSNEEIIIURFUaJGCCGEEKKiKFEjhBBCCFFRlKgRQgghhKgoStQIIYQQQlQUJWqEEEIIISqKEjVCCCGEEBVFiRohhBBCiIqiRI0QQgghREVRokYIIYQQoqIoUSOEEEIIUVGUqBFCCCGEqChK1AghhBBCVBQlaoQQQgghKooSNUIIIYQQFUWJGiGEEEKIiqJEjRBCCCFERVGiRgghhBCioihRI4QQQghRUZSoEUIIIYSoKErUCCGEEEJUFCVqhBBCCCEqihI1QgghhBAVRYkaIQB4PB6aNWsmM23o0KHg8XgICAhQSkyl1X///Qcej4f//vtP2aH81hYtWgQej4e7d+8qOxSlKg3Hga6p0o0SNRU3ePBg8Hg8VKpUCenp6coOh+RRQEAAeDwehg4dquxQfkuKEu/fDZ2DpQd9l783StRUWHx8PE6dOgUej4eIiAhcunRJ2SH9VlasWIF3796hcuXKyg6FEEKy1a1bN7x79w7dunVTdiikCFCipsKOHDmCpKQkTJs2DTweD7t371Z2SL8VU1NTCIVCaGpqKjsUQgjJloGBAYRCIQwMDJQdCikClKipsN27d0NLSwtz5syBs7MzLl++jK9fv3LzAwMDoaamhpYtWyr8fEpKCgwMDFC9enWZ6ampqVi3bh1EIhH09PSgr6+Pxo0b4/z583LrkLTT+vLlC9avX48//vgD2traXBF8WFgYFi5cCCcnJ1SoUAHa2tqoUqUKxo8fj8jISIVxBQQEoE+fPihXrhzKli2Lpk2b4t69ezm2Fbl37x46deqE8uXLQ1tbGzY2Npg/fz6SkpLyeDSz7Nq1CzVr1oSOjg4sLCwwc+ZMpKSkKFw2uzZqp06dQtOmTVGhQgVuPe3atcPZs2cBZLUXqVq1KgBg37594PF43H+SfcvvcZOOZevWrbCzs4OOjg6srKzg7u6OzMxMhftw/vx5tG3bFsbGxtDR0UGVKlUwaNAgvH79Wma5/JwTcXFxWLBgAWrUqIGyZctyPxLDhg1DcHBwTodfzpkzZ1C/fn3o6uqiUqVKGDduHGJiYhQu6+/vj5EjR8LS0hLa2towNTXF0KFDERgYyC1z9+5d8Hg8AICHh4fMsf/vv//w/Plz8Hg8TJ48WWbdJ06cAI/Hg56eHlJTU2XmVapUCXZ2djLTGGPYs2cPnJ2dwefzoauri3r16mHPnj0KY8/P8tLXwfHjxyESiVCmTBmYmppi4sSJSE5OzvW45uUclJaf7RTWtfjy5Uv07dsXpqam0NLSgpWVFdzc3PDt2zdumaioKJiamsLAwABfvnyR+XxkZCQqVqwIQ0NDmXNAUu0dHByMPn36wNjYGHp6emjWrBkePHiQ5/j27NmDLl26oEqVKtDR0UG5cuXQtm1b3LlzR25ZyXm3aNEiPH36FG3btoW+vj4MDAzQrVs3he1cz5w5g379+qF69erQ1dWFgYEBGjdujFOnTsksl5fvMqc2ag8ePICrqyvKlSsHHR0dCIVCLFq0SOH3JTl2UVFRGD58OCpUqIAyZcrAyclJ4Xnz9etXTJo0CTY2NihTpgzKlSuHWrVqYfz48YiPj8/9IJO8YUQlvXz5kgFg3bp1Y4wxtmPHDgaArVixQma5Jk2aMDU1NRYSEiK3jqNHjzIAbOHChdy0lJQU1qxZMwaA1a1bl7m5ubGxY8cyCwsLBoBt2rRJZh1DhgxhAFiHDh1YuXLl2KBBg9jMmTPZ2rVrGWOMHTlyhOnp6bHOnTuziRMnsmnTprEWLVowAKxatWosNjZWZn0hISHM1NSUW+ecOXNY9+7dmba2NmvXrh0DwO7cuSPzmX///ZfxeDxWrlw5NmTIEDZ9+nTWtGlTBoA1atSIicXiPB3TxYsXMwCsYsWKbMKECWzKlCnM0tKSdezYkQFgTZs2Vbjv/v7+3LStW7cyAMzU1JSNHj2azZkzhw0dOpTVqFGDDRkyhDHG2LNnz9ikSZMYAGZvb88WLlzI/SdZV36PmySWnj17svLly7OhQ4eyiRMnMktLSwaAzZ07V25/Z8yYwQCwcuXKseHDh7PZs2ezAQMGsEqVKrH169dzy+XnnMjMzGQNGjRgAJizszObMmUKmzZtGuvRowczMDCQ++4U2bt3LwPAXF1dmZaWFhswYACbPXs2a9iwIXfMkpKSZD7j4+PDDAwMmIaGBuvWrRubMWMG69WrF9PQ0GAVKlRgnz9/Zowx5u/vzxYuXMgAMCsrK5lj/+zZM5aZmcnKlSvHateuLbP+8ePHMwAMALt37x43/e3btwwAGzdunMwx6N+/PwPAbG1t2ZgxY5ibmxsTCoUMAJs2bZrMuvO7vCT+nj17Mj09Pda/f382ZcoUZmdnxwCw/v3753qM83IOFmQ7hXUtnjt3jmlrazNdXV3Wt29fNmPGDObq6soAMBsbG/b9+3du2evXrzMej8caNGjA0tLSuGPavn17BoAdOXJEZt0AWO3atZmFhQVzdHRks2fPZoMGDWJaWlpMS0tL7hyVHIefp+vo6LAGDRqwESNGcOvQ19dnampq7OzZszLL3rlzhzundXV1WYcOHWSuaWtra5acnCzzGYFAwGrVqsWGDBnCZs+ezUaMGMFMTEwYALZx48Z8fZeSa2rv3r0y2zh58iTT0NBgurq6bNiwYWzWrFnMwcGBAWANGzZkKSkpcsfO3t6e2djYMAcHBzZ58mTWv39/pq6uzrS0tNirV6+4ZRMTE1nVqlUZj8djbdu2ZTNmzGCTJk1inTp1YmXKlJG5b5JfQ4maipJcmKdPn2aMMRYbG8t0dHSYjY2NzHI7d+5kANjq1avl1iFJQD5+/MhNmzt3LgPAFi1axDIzM7np8fHxrF69ekxLS4uFhoZy0yUJgrm5OQsMDJTbRkREBEtISJCbvm/fPgaALV26VGb6wIEDGQC2Zs0amemSG83PN8w3b94wDQ0NVrduXfbt2zeZz6xYsYIBYH///bfc9n/28eNHpqGhwSpXrswiIiK46XFxcUwgEOQ5UROJRExLS4tFRkbKbSM6Opr7t7+/PwPAJW8/y+9xk8RStWpVFhYWxk2PiopihoaGTF9fX+ZH8tKlSwwAq1WrlkxcjDGWlpbGwsPDub/zc078/AAhLSUlReE+/Uz6u75586bMvGHDhjEAbPHixdy01NRUVqVKFaavr8+eP38us/z9+/eZuro669ixo8x0Rd+nRLdu3RiPx2NRUVHcNDs7O9asWTOmrq7O3N3duelbtmxhANjx48e5aZKHphEjRnCJA2OMicVi1qlTJwaAPX78uMDLSxIHAwMD9v79e256UlISs7W1ZTweT+YazU5u52B+t1NY12J0dDTj8/kK7ymHDx9mANiECRNkpk+fPl3mgWTDhg3Z7pvk3Bo0aJDM+Xz37l3G4/FY9erVWUZGhtxx+DlR+/Lli9y6w8LCmJmZmdx9WJKoAWBHjx6VmTdo0CCFCaXk4UJaQkICq1WrFjMwMGCJiYnc9Ny+S0WJWnx8PDM0NGTa2trsxYsX3HTpB4clS5bIrEeyD+PHj5c5Rrt27WIA2JgxY7hp58+fZwDYlClT5OKJj4/Pc9JOckeJmgoSi8XM2NiYGRkZyZzsffr0YQCYh4cHNy02NpZpa2vLlRBERUUxTU1N5uTkxE3LyMhgRkZGrHr16jI3MAnJhSddgiJJEP7555987UNmZibj8/msWbNm3LSUlBSmra3NKlasKHcRZ2ZmciUM0jfMiRMnMgDs/v37ctvIyMhgJiYmzMHBIdd43N3dGQCuJFDagQMH8pWo6enpsZiYmBy3l9uNNTuKjpt0LHv27JH7jGTey5cvuWkdOnRgANjt27dz3F5+zwlJopaXUp3sSH5UWrduLTcvNDSUaWpqMmtra27a6dOnFf6oSHTv3p2pqamxuLg4blpOido///zDALATJ04wxhgLDw9nANj69euZo6OjzOd69uzJAMgk97Vr12Z6enpyJSSM/e/4SJeS5Xd5SeKwYMECueUl886fP69w36TlNVHL63YK61pct24dA8AOHDigcL5IJGLly5eXmSYWi5lIJGJqamps48aNTFtbm1lbW7P4+Hi5zwNg6urqLCgoSG6epNROeh+yS9Sy4+bmxgCwgIAAbpokUWvSpInc8pJ5U6dOzdP6165dywCwu3fvctMKkqjt379frjRYIigoiGloaMhcZ4xlHTs9PT25B660tDSmoaHBRCIRN01yb1BUmk8KlwaIyjl79iy+ffuGsWPHQktLi5s+ePBgHDt2DHv27EGTJk0AZDUi7dSpE06ePIlXr16hVq1aAICjR48iLS0NgwYN4j7/4cMHxMTEwMzMDO7u7nLbjYqKAgC8f/9ebp6jo2O28Z4+fRrbt2/H06dPERMTg4yMDG5eWFiYzPbFYjHq1asns19AVtuIhg0bym3bx8cHAHD16lXcvHlTbtuampoK4/3ZixcvAACNGzeWm6doWnZ69+6N2bNno2bNmujbty+aNWsGFxcXGBoa5nkdEnk9btJEIpHcNHNzcwBAbGwsN+3hw4fQ1tZG06ZNc4whv+eEnZ0datWqhcOHDyM4OBhdu3ZF48aNIRKJoK6unvMO/0TRcTczM4O1tTXev3+PhIQE6Ovrc+fA+/fvsWjRIrnPhIeHIzMzE35+fqhXr16u223evDkA4M6dO+jZsyfX5qh58+YIDw/Hhg0bkJKSAm1tbXh4eOCPP/5AhQoVAABJSUl49eoVzMzMsHLlSrl1p6WlcbEWZHlpef2uf1Vet1NY16JkPT4+Pvj06ZPc/JSUFERHRyM6Ohrly5cHAGhpaeHIkSMQiUSYOHEiNDQ0cPjwYejr6yvchpWVFSwsLOSmN27cGJcuXcLz58/h4uKSY5xfvnzBihUrcPv2bYSGhkIsFsvMDwsLg5WVlcy0/HxnkZGRWLlyJa5cuYLAwEC5NoHZ3QPy6tmzZwCgcJgaCwsLWFtb48OHD9x1JmFjY4OyZcvKLK+hoYGKFSvK7EOTJk1QqVIlrFixAs+fP4erqytcXFxQq1Ytrp0oKRyUqKkgSQNj6SQLANq2bYtKlSrhxIkT2LhxI/h8PrfcyZMncejQIe7H4ODBg9DU1ESfPn24z3///h0A8ObNG7x58ybb7ScmJspNq1ixosJl165di+nTp8PExARt2rSBubk5ypQpAwDYsGGDzM1N0rjUxMRE4boUbUMS87Jly7KNNy/i4uIAgPvBzW272Zk5cyaMjY2xbds2rFu3DmvXroWGhgY6dOiADRs2cI1+c5Of4yZNUa8uDY2sy1g60YuNjUXlypWhppZzf6H8nhMaGhq4ffs2Fi1ahNOnT2PatGkAgPLly8PNzQ3z5s3Lc8Km6LsAsr6P9+/fIz4+Hvr6+lyMhw4dynF9is5bRWrWrAkTExMuQbtz5w6MjY1Ru3ZthIeHY9WqVXjw4AFMTEwQFRUlcw3FxMSAMYbQ0FCFie3PseR3eWl5/a5/VV63U1jXomQ9W7ZsyXG5xMRELlEDshKIWrVqwcfHB46Ojjk+POZ0bgH/ux9k59OnT3B0dER8fDyaN2+OTp06gc/nQ01NDXfv3oWHh4fCazQ/x7J+/foICgqCs7MzWrVqBUNDQ6irq+P58+c4d+5ctveAvJLcb7O7v1WqVAkfPnzgrrOc9kGyH9L7YGBgAG9vbyxcuBAXLlzA5cuXAWQlpnPmzMH48eN/KX7yP5SoqZjg4GDcuHEDAODs7JztckePHsXo0aMBAO3bt0f58uVx+PBhrFixAp8/f4avry+6dOkCY2Nj7jOSxK5Hjx44efJkvuJS9ISUnp6OJUuWwMzMDM+fP5dJwBhjWL16tczyku1LSml+FhERITdN8pmfbyb5Jbn5REZGyj0FK9pudng8HkaOHImRI0fi27dvuH//Po4cOYLjx4/j48ePePXqVa6JSn6PW0EYGhpyJU05JWsFOSfKly+PzZs3Y9OmTXj//j1u376NTZs2YeHChdDU1MScOXPytJ7segVLvg9JbJL/X7hwAR07dszTunPC4/HQtGlTnDx5EuHh4bh79y6aNm0KHo8HFxcXaGpq4s6dO9yPvaQETjoWBwcHPH78ONdt5Xd5VVZY16JkPa9evULNmjXz/Lk1a9bAx8cHxsbGePDgAXbu3IlRo0YpXDa3cyu3YSzWr1+PmJgYHDx4EAMGDJCZN3bsWHh4eOQ5bkV2796NoKAgLF26FPPmzZOZt3LlSpw7d+6X1g/87zhnd3/7+ToriCpVqmDfvn3IyMjAq1evcP36dWzcuBF//vknjIyM0K9fvwKvm/wPDc+hYvbu3YvMzEy4uLhgxIgRcv9JStmkx1TT1NRE7969ERwcDA8PDxw8eBAAMHDgQJl129nZgc/n4/Hjx1yVy6+Ijo5GXFwcnJyc5ErJHj9+LFeULxAIoK2tjSdPnsgNgcAY46pEpDVo0AAAFM7LD3t7ewDA/fv35eYpmpYXxsbG6Nq1K44dO4YWLVrg3bt3XFWOJFlTVPKR3+NWEI6OjhCLxbn+oPzKOcHj8WBnZ4c///yTe7hQNJxHdhQd97CwMHz+/BnW1tZcMiA5B7y9vfO8bjU1tRxLnSTVQYcOHYKfnx9atGgBANDT04OjoyNu376NO3fucEmdhL6+Puzs7PDu3bs8VT/md/nClNM5WBCFdS0W5Pt88uQJ5s+fDzs7O7x69QpWVlaYPHkyPnz4oHD5wMBAhUPFSM65OnXq5Li9z58/AwA6d+4sMz0zMxNeXl55jju/65eOUVpBvsu6desCgMJhNUJDQ/H582dUq1btl5Ju6fjq1KmDmTNn4siRIwDydy8gOaNETYUwxrB3717weDzs378fu3btkvtv//79qFu3Lh4+fCgzFpYkgTt48CAOHToEQ0NDdOrUSWb9GhoaGDduHAIDAzF9+nSFP8yvX7/O9mn0Z5Ixdp4+fSozJk9MTAzc3NzkltfW1kbPnj0RHh6OjRs3yszbv38/3r17J/eZ8ePHQ0NDA25ubgpvvLGxsVxbjJz0798f6urqWLduncz+xcfHY+nSpbl+XuLatWtyr/JKS0vjqnMk1ZdGRkbg8XgICQmRW0d+j1tB/PnnnwCASZMmcbFJpKenc0/T+T0n/P398fbtW7llJOuT7H9e3LhxA7du3ZKZNn/+fKSlpWHIkCHctC5dusDS0hLr1q3DvXv35NaTlpYGT09PmWnlypVTeOwlJKVkq1atkvlb8u9Hjx7hzp07qFWrlkypNABMnDgRSUlJGDVqlMIqS39/f5lxs/K7fGHJ6RwsiMK6FocNGwZ9fX3MmzdPYXV7UlKSTDKYmJiI/v37g8fj4fDhwzA1NcXBgwchFovRv39/uYc+ICuhmTdvHhhj3DQPDw9cvnwZ1atXR6NGjXKMUVLq/vN5tWrVKrkxCAsiu/UfPnyYq0KUVpDvskuXLjAwMMDevXtljjNjDHPmzEFaWtovvZLq9evXMuPXSRTkXkByRlWfKuTWrVsICAhA8+bNc2zrNGzYMDx79gy7d+/G+vXrAQBOTk6wsbHB/v37kZaWhlGjRkFbW1vus+7u7nj69Ck2btyIS5cuoWnTpjAxMUFoaChevXqFFy9ewNvbO9s2HtLU1NQwfvx4rF27Fvb29ujUqRPi4+Nx5coVWFlZwczMTO4zK1aswM2bNzFjxgzcuXMHderUwYcPH3Dx4kW0a9cOV69elamqq1mzJrZu3Ypx48ZBIBCgQ4cOsLa2Rnx8PL58+QIPDw8MHToU27ZtyzHW6tWrY8GCBVi4cCFq166N3r17Q0NDA6dOnUKtWrWyfTL/WZ8+faCrqwsXFxdYWVkhLS0NN27cwNu3b9GnTx9YWloCAMqWLYv69evj3r17GDZsGGxsbKCmpob+/fvD0tIy38ctvzp06IDp06fj77//ho2NDbp164YKFSogNDQUt27dwvTp07lBX/NzTrx48QLdunVD/fr1UbNmTVSqVAmhoaE4e/Ys1NXVuTZreeHq6ooOHTqgV69esLCwgIeHB7y9vWFvb4/p06dzy2lra+PkyZNo3749mjZtipYtW3JVZkFBQbh//z6MjY1lGrK3aNECx48fR8+ePVG3bl2oq6vD1dWV62xTo0YNVKxYEREREahYsSJq1KjBfbZ58+ZYunQpYmNjZRJGiTFjxsDHxwf79u2Dl5cXWrVqBTMzM0REROD9+/fw9fXF4cOHUaVKlQItX1hyOwfzq7CuRRMTExw5cgS9evWCvb092rVrB6FQiJSUFAQGBsLDwwONGjXC1atXAWQlun5+fli3bh1XEubi4oK5c+diyZIlmDt3Lv7++2+ZbdSuXRt3796Fk5MTWrRogbCwMBw9ehSamprYuXNnrm03x44di71796J79+7coLk+Pj54+vQpXF1df/l1foMGDcKqVavg5uaGO3fuwMrKCi9fvsTNmzfRvXt3nD59Wmb5gnyXfD4fO3fuRL9+/dCgQQP06dMHJiYmuHXrFh4/fgxHR0fMmDGjwPtw8+ZNTJs2Dc7OzhAKhTA2NsaXL19w/vx5lClTBhMmTCjwuslPlNfhlPysb9++OXZbl4iOjmZaWlqsfPnyMsNcSIagwE9DePwsPT2dbd++nTk7OzM+n8+0tbWZpaUla9euHfv333/Zjx8/uGUVDVEhLTU1lS1btozZ2Nhw65k6dSpLSEhgVlZWzMrKSu4zX758Yb169WIGBgZMV1eXNW7cmHl4eLAJEyYwAOzZs2dyn3n48CHr27cvMzMzY5qamqx8+fJMJBKx2bNns3fv3uV4vKTt3LmT1ahRg2lpaTFzc3M2ffp0lpSUlOfhObZu3co6d+7MrKysmI6ODjM2NmYNGjRg27dvlxkjizHGPnz4wDp06MAMDQ0Zj8eTGQIgv8ctp+8hp+EFTp06xZo3b84MDAyYtrY2q1KlChs0aBB7/fq1zHJ5PSeCg4PZ7NmzmZOTE6tQoQLT0tJilpaWrGfPnszX1zdP34H0UAKnT59mDg4OTEdHh1WoUIGNGTNGbowuiZCQEDZp0iTumPH5fGZnZ8dGjhzJbt26JbPs169fWe/evVn58uWZmpqawsFAJcPd9OnTR2Z6cnIy09bWZgDYmTNnst2PY8eOsVatWjEjIyOmqanJKleuzJo1a8bWrl0rM0ZbfpfP6fvMbmDT7OR0DhZ0O4V1Lb5//56NGDGCWVlZMS0tLWZkZMRq1arFJk6cyB4+fMgYY+zEiRPcUC4/Dx+TlpbGnJycGI/HY9evX+emS67lwMBA1qtXL2ZkZMTKlCnDmjRpwjw9PeXiyO443Llzhzk7OzN9fX1maGjIOnTowJ48eaJweckQHNKDi0tkN7TG8+fPWZs2bZiRkRHT19dnTZs2ZTdv3sz22Of0Xeb0fd27d4+1b9+eGRoaMi0tLWZra8v++usvmfv8z8dOkZ/vS2/fvmWTJk1idevWZcbGxkxbW5tVq1aNDR06lL19+1bhOkjB8BiTKhsmRIlcXFzg7e2NuLg4ue7hhBCSF5J2hYraZhFSElEbNVLspN9XKnHo0CGuWoiSNEIIISQLtVEjxa5mzZqoW7cuatSowY0bdPfuXejr68u1NSGEEEJ+Z8WWqGVmZiIsLAz6+vo0avFvbtiwYbh69SoeP37MDWrZq1cvzJw5E1ZWVtxAjYQQUhAZGRl0HyEqjzGGhIQEmJmZ5djBpdjaqIWEhCh8pQchhBBCyO8qODiYe9WYIsVWoiYZVM/P712hDLD3u9PV1UdSUoKywygV6FgWLjqehYeOZeGhY1l46FgWjoSEBNja2uWaExVboiap7tTX1/+lV1aQLLq6+tDQoCrkwkDHsnDR8Sw8dCwLDx3LwkPHsnDl1hyMen0SQgghhKgoStQIIYQQQlQUJWqEEEIIISqKEjVCCCGEEBVFiRohhBBCiIqiRI0QQgghREVRokYIIYQQoqIoUSOEEEIIUVGUqBFCCCGEqChK1AghhBBCVBQlaoQQQgghKooSNUIIIYQQFUWJGiGEEEKIiqJEjRBCCCFERVGiRgghhBCioihRI6QUa9euA2bMmAUAsLOric2btyg5IkIIIfmhoewACCHF4969u9DT01V2GIQQQvKBEjVCfhMmJuWVHQIhhJB8oqpPQn4TP1d96unxsXv3HvTo0Qvly1eESFQPvr6++Pz5M9q16wATk0po3rwlvnz5IrOey5evwNm5CcqVM8Eff9TG8uUrkJ6eXty7QwghvwVK1Aj5ja1cuRr9+/eDt7cnbG1tMWzYSLi5Tca0aVNx/74HAGDq1Onc8jdu3MSIEaMwbtwYPHnyEBs3bsDBg4exevUaZe0CIYSUapSoEfIbGzRoAHr06A4bGxtMnToZgYGB6NOnN1q3bgWhUIDx48fh/n1Pbvk1a/7G1KlTMHDgAFStWhUtW7bAX3/Nw+7de5W4F4QQUnpRGzVCfmM1a9bk/l2hQoX/n1ZDZlpKSgri4+PB5/Px7NlzPHnyFGvW/M0tk5GRgZSUFCQlJUFXlzorEEJIYaJEjZDfmKamJvdvHo8HANDQkJ+WmZnJ/X/evLno0qWT3Lp0dHSKMlRCCPktUaJGCMmzOnXs8fHjR1hbWys7FEII+S1QokYIybPZs2ehZ8/eMDevjG7dukFNTQ2vX7/GmzdvsHDhAmWHRwghpQ51JiCE5Fnr1q1w8uRx3L59B02aNEPz5i2xadNmWFpaKjs0QggplXiMMVYcG4qPj4eBgQG+fg0Bn88vjk2Warq6+khKSlB2GKUCHcvCRcez8NCxLDx0LAsPHcvCER8fD1NTc8TFxeWYF1GJGiGEEEKIiqJEjRBCCCFERVGiRgghhBCioihRI4QQQghRUTQ8ByGkyGVkMjwJikPUj1SYlNWCg6UB1NV4yg6LEEJUHiVqhJAideNdNJZf+4SI+FRuWkW+Fua2rY7WduWVGBkhhKg+qvokhBSZG++iMfnEW5kkDQAi41Mx+cRb3HgXraTICCGkZCiyEjWxWAyxWMz9HR8fX1SbIoSooIxMhn/u+ENPW/FthgfgnzsBaCEwpmpQQgjJRpENeLto0SK4u7vLTc9tYDdCCCGEkNJO8iKA3PKiIkvUFJWoWVhY0JsJCgmNDF146FgWLsnxvPY2Cn9d+Jjr8ks62aBtDZNiiKzkoXOz8NCxLDx0LAtHXt9MUGRVn9ra2tDW1i6q1RNCVJyRriZ+iNPztBwhhBDFqDMBIaRIOFgaoCJfC9m1PuMBqMTXhoOlQXGGRQghJQolaoSQIqGuxsPcttUBQC5Zk/w9p601dSQghJAcUKJGCCkyre3KY0OvGqjA15KZXpGvjQ29atA4aoQQkgsa8JYQUqRa25VHC4ExvZmAEEIKgBI1QkiRU1fjwbGKobLDIISQEocSNUKIymGMoXJlS6ipqaFePQdUr14d1apVRbVq1WBtXQ3Vq1cHj0clcoSQ0o8SNUKIyuHxeKhc2Qxv377Dgwfe8PP7iK9fvyI1NetVVNu3/4uBAwcoOUpCCCl61JmAEKKSDhzYD3V1dejr6yMsLAyzZ8/E69cvcf36VXTr1lXZ4RFCSLGgRI0QopKEQgGGDh2ClJQUjB49CkuXLsfw4SNQsWIF6OnpKTs8QggpFpSoEUJU1ty5c5Ceng41NTXcuHEN0dHRcHJyxvbtO5CZmans8AghpMhRokYIUVmVKlXE1KmTsW3bdlSqVBE+Pg8waNAATJ06HV26dENoaKiyQySEkCJFiRohRKW5uU1AixbNkZDwA3p6eli/fh3Onj2Nd+/eo359Jxw9egyMMWWHSQghRYISNUKIStPV1cXp0ydRq1ZNblrr1q3w6JEP2rZtgxEjRmHgwMGIjv6mxCgJIaRoUKJGCCmRjIyMsHfvbhw4sA/37t1D/foNcPnyFWWHRQghhYoSNUJIida9ezc8fOgLkaguevXqg/HjJyA+Pl7ZYRFCSKGgRI0QUuKZmlbCyZPHsWXLJpw6dRpOTs64f99T2WERQsgvo0SNEFIq8Hg8DB06BL6+D2BuXhnt27ti9uy5SElJUXZohBBSYJSoEUJKlSpVquDKlUtYtmwptm/fAReXJnj27JmywyKEkAKhRI0QUuqoq6tj0iQ3eHreg5aWNpo1a4kVK1YiLS1N2aERQki+UKJGCCm1/vijBu7evYVp06ZgxYpVaNmyNT588FN2WIQQkmeUqBFClGLatBl48+ZtkW9HS0sLCxb8hVu3riM+Ph6NGrlg69Z/6RVUhJASgRI1Qkix+/z5M7Zt247u3XsWW3Vk/fr18eCBJ4YNG4IZM2ahY8cuCA4OLpZtE0JIQVGiRggpdhcvXgaPx0NoaCiWL19RbNvV1dXF33+vwYUL5/Dp0yc4OjbEwYOH6BVUhBCVRYkaIaTYXbx4EWZmZjAzM8OaNWtx7979Yt1+ixbN8fChN1xdO2DMmHHo128AIiOjijUGQgjJC0rUCCHFKjIyCt7ePqhfvx7i4+Ph4uKCESNG4fv378Uah6GhIXbt2oHDhw/C29sb9es3wIULF4s1BkIIyQ0laoSQYnXlyhXweDx07OiKhIQELFu2BCkpyZg4cbJS4unSpTMePvRFgwaO6Nu3P0aPHou4uDilxEIIIT+jRI0QUqwuXryEhg2d4OhYHwAQFxeHnTt3QCwWKy2mihUr4NixI9i27V+cP38Bjo4Ncfeuh9LiIYQQCUrUCCHFqn79epg2bSqqVKkCbW1tvH//Hu3atcWJE8eUGhePx8OgQQPw8KE3qlWrClfXTpgxYxaSk5OVGhch5PdGiRohpFjNnDkDbdu2gbq6OmxsbPD+/QdlhyTD0tISly5dwKpVK7B79x44OzfGkydPlB0WIeQ3RYkaIURphEJbfPigWokaAKipqWHChD/h5XUfurp6aN68FZYuXUavoCKEFDtK1AghSiMUCvH+/Xtlh5EtOzsh7ty5idmzZ2L16r/RrFlLvHunuvESQkofStQIIUojFAoRHf0NUVHRyg4lW5qampg7dw7u3r2F5OQkODs3xsaNm+kVVISQYkGJGiFEaQQCAQCoZPXnz0QiEby87mPUqJGYM2cuOnToiMDAQGWHRQgp5ShRI4QoTfXq1lBXVy8RiRoAlClTBqtWrcDlyxcREBCIBg0aYd++A/QKKkJIkaFEjRCiNFpaWrC2rlbi2n01bdoEvr4P0LVrF4wf/yd69+6L8PAIZYdFCCmFKFEjhChVVoeCklGiJs3AwADbtm3FsWNH8OjRYzg6NsDZs+eUHRYhpJShRI0QolRCoaDEVH0q0rGjKx498oWzszMGDBiEESNGITY2VtlhEUJKCUrUCCFKJRAIEBYWVqLfr2liUh6HDx/Ezp3bcfnyFdSv74Rbt24rOyxCSClAiRohRKmEQiEAwM/PT8mR/Boej4f+/fvh0SMf2NraonPnrpg6dRoSExOVHRohpASjRI0QolS2tjbg8Xh4967kVn9KMzc3x4ULZ7F27Rrs338QjRq54OHDh8oOixBSQlGiRghRKl1dXVhZWan0GwryS01NDWPHjsGDB54wNDREy5Zt4O6+GKmpqcoOjRBSwlCiRghRupLeoSA7trY2uHXrBubPn4t16zagadMWeP36jbLDIoSUIJSoEUKUTiAQlMghOvJCQ0MDs2bNxN27t5GWlobGjZti/fp/kJGRoezQCCElACVqhBClEwqFCAwMRFJSkrJDKTJ169aBp6cHxo0bi7/+WoB27TrA399f2WERQlQcJWqEEKUTCm3BGIOf30dlh1KkdHR0sHz5Uly9ehlhYV/RoEEj7NmzF9u370CNGrVQrpwJnJ2bwMvrQZ7W5+3tAz7fCE5OzjLT27XrAD09vtx/3bv3LIrdIoQUIUrUCCFKJ3k5e2nqUJATFxdn+Ph4oXfvXnBzm4Rp02Zg9OhRePDAE40aNUS3bj0QHByc4zri4uIwatRoNGvWVG7e4cMH8fnzR+6/R498oa6ujm7duhXVLhFCigglaoQQpTMwMICZmVmp7FCQHX19fWzevBE2NtWho6ODtWvX4s2bN1izZhXMzStj587dOX5+4sRJ6N27Fxo0cJSbV65cOVSqVJH77/bt29DV1UX37l2LaG8IIUWFEjVCiEoozR0KspOamoovX/yxYcN6NG3aFIMHD8WQIcPg7NwIvr6+2X5u//6D+PLFH3PnzsnTdvbtO4CePXtAT0+vsEInhBQTDWUHQAghQNYQHbdv/16vXfr27RsyMjJQvbo1DhzYh+PHT2Dq1OlIT08Hn89X+JlPnz5hwYKFuHHjKjQ0cr+FP378GG/fvsW//24u7PAJIcWAStQIISpBKBTg06fPv+WgsDxe1iuo+vTpjUePfFChQgWEhYVh3Lhx+PHjB7dcRkYGhg0bgfnz58LGxiZP69637wBq1KiBevXqFVX4hJAiRIkaIUQlCIVCZGRk4NOnz8oOpdgYGxtDXV0dERGR3DQzMzO0bdsG1tbVsH//fjRs6Axvbx8AQEJCAp4+fYapU6eDzzcCn2+EFStW4dWrV+DzjXD3rofM+pOSknDy5CkMHTq4WPeLEFJ4KFEjhKgESc/P36lDgZaWFurWrSNX5Xvnzh107doVz58/h4mJCdq0aYe//loIbW1tPHzoA29vL+6/kSOHw9bWBt7eXqhfX7bU7NSpMxCLxejbt09x7hYhpBBRGzVCiEowMSmP8uWNf5shOiTc3CZg5MjRqFtXhAYNHLFnz14EB4dg5MjhsLGxgbNzI6SkpGDTps24du06du3agdq1a3GfNzExgba2Dv74o4bcuvfv349OnVxhbGxcnLtECClEVKJGCFEZQqHwt+v52bNnD6xevRIrV65Cw4bO8PJ6gNOnT8LS0hIAEBERCT6fj3v37gIAmjRphjVr1iI9PT3H9X78+BEPHnhj8GCq9iSkJOMxxlhxbCg+Ph4GBgb4+jUk295MJO90dfWRlJSg7DBKBTqWhetXjufEiZPh6/sQvr55G5m/tPv5WIrFYixduhwbNvyD+vXrYefO7bC2tlZihCUHXeeFh45l4YiPj4epqTni4uJyzIuoRI0QojKEQgE+fvxILyzPhra2NpYsccf161cRFRUFJydn7Ny5C8X0vE0IUQJK1AghKkMgEEAsFiMgIEDZoai0hg2d4O3thf79+2Hy5Kno2rU7wsLClB0WIaQIUKJGCFEZdnZCAPjt2qkVRNmyZfHPP+tx+vRJvH79BvXrO+HYseNUukZIKUOJGiFEZZiamoLP51Oilg9t27bBo0c+aN26FYYPH4nBg4ciOvqbssMihBQSStQIISqDx+NBILD97Ybo+FXlypXDf//twb59e3H37l04Ojrh6tWryg6LEFIIKFEjhKgUoVD4Ww16W5h69uyBhw99YG9fGz169MaECRORkEC98wgpyShRI4SoFIFAgPfvP1BbqwIyNTXF6dMnsXnzRhw/fgJOTs7w9PRSdliEkAKiRI0QolLs7ARITExESEiIskMpsXg8HoYNGwofHy+YmZmiXbsOmDt3PlJSUpQdGiEknyhRI4SoFKGQen4WlmrVquHq1ctYsmQx/v13G1xcmuLZs+fKDosQkg+UqBFCVIqlpSXKlClDHQoKibq6OqZMmYT79z2gqamJZs1aYNWq1bm+gooQohooUSOEqBQ1NTXY2triwwc/ZYdSqtSs+Qc8PG5j6tTJWLp0OVq1agM/v4/KDosQkgtK1AghKoeG6CgaWlpaWLhwAW7duo6YmBg0auSCbdu2IzMzU9mhEUKyQYkaIUTl2NkJ8f79e+r5WUQcHR3x4IEnBg8eiGnTZqBTp67UeYMQFUWJGiFE5QiFQsTExCIyMkrZoZRaenp6WLduLc6fPws/Pz84OjbE4cNHKDkmRMVQokYIUTkCgQAAqPqzGLRs2QIPH3qjfft2GDVqDAYMGISoqGhlh0UI+X+UqBFCVE61alWhqalJbygoJkZGRti9eycOHToAT09P1K/fAJcuXVZ2WIQQUKJGCFFBmpqaqF7dmkrUilnXrl3w8KEv6tevh969+2Ls2PGIj49XdliE/NYoUSOEqCShUIh376hErbhVqlQRx48fxdatW3DmzFk0aNAI9+7dV3ZYhPy2KFEjhKgkgcCWqj6VhMfjYciQQfD1fQBLSwu0b++KmTNnIzk5WdmhEfLboUSNEKKShEIhIiIiEBMTo+xQfltVqlTBlSuXsGLFcuzatRvOzo3x9OlTZYdFyG+FEjVCiEqSvPOT3lCgXGpqapg4cQK8vO6jTBldNGvWEsuXr0BaWpqyQyPkt0CJGiFEJdnYVIeamhp1KFARdnZC3L17CzNnTsfKlavRokUrvH9PVdOEFDVK1AghKklHRwdVq1bBu3eUqKkKTU1NzJ8/D3fu3MSPHz/g7NwYmzdvoVdQEVKEKFEjhKgsgUBAHQpUkIODAx488MTw4cMwa9YcuLp2QlBQkLLDIqRUokSNEKKyhEIhVa+pqDJlymDNmlW4dOkCvnzxh6NjQxw4cIheQUVIISuyRE0sFiM+Pl7mP0IIyQ+hUIDg4GD8+PFD2aGQbDRr1hQPH3qjc+dOGDt2HPr27U/vaCWkEPFYET3+LFq0CO7u7nLT4+LiwOfzi2KThJBS5tGjR3B0dMSjR49Qr149ZYdDcnH27FmMHj0ajDHs2LED3bp1U3ZIhKis+Ph4GBgY5JoXFVmiJhaLIRaLZQKysLDA168hlKgVAl1dfSQlJSg7jFKBjmXhKszjmZCQgEqVKmPnzu3o379foayzJCmJ52ZkZBQmTpyECxcuon//flizZhUMDQ2VHVaJPJaqio5l4YiPj4epqXmuiVqRVX1qa2uDz+fL/EcIIfmhr68Pc3NzaqdWglSoYIIjRw5h+/Z/cfHiJTg6NsTt23eUHRYhJRZ1JiCEqDShUEBjqZUwPB4PAwcOwMOH3qhevTo6deqC6dNnICkpSdmhEVLiUKJGCFFpQqGQhugooSwsLHDx4jmsWbMKe/fuQ6NGLnj8+LGywyKkRKFEjRCi0oRCAb588UdKSoqyQyEFoKamhvHjx+HBA0/w+Xy0aNEaS5YsRWpqqrJDI6REoESNEKLShEIhMjMz8enTZ2WHQn6BQGCL27dvYu7c2fj773Vo1qwl3r59p+ywCFF5lKgRQlSaQGALANROrRTQ0NDA7NmzcPfuLaSmiuHi0gT//LMJGRkZyg6NEJVFiRohRKWVK1cOFSpUoEStFKlbty48Pe9h9OhRmDdvPjp06IiAgABlh0WISqJEjRCi8rI6FPgpOwxSiHR0dPD9+3c4OTVAUFAwGjRohH379tMrqAj5CSVqhBCVJxTa4t07KlErjYyNjeHr+wA9enTH+PET0LNnb4SHRyg7LEJUBiVqhBCVJxQK8enTJ6Snpys7FFIE+Hw+tm7djBMnjuHp02dwdGyAM2fOKjssQlQCJWqEEJUnEAiQlpaGL1/8lR0KKYAzZ86ifn0nGBtXgIWFFVxdOyMxMZGbv2HDRlSrZoMxY8aiXbs2cHZ2xsCBgzFs2Ajs2rUbLi5NUbGiGapWrY6hQ4fLvPT93r370NPj4+rVq2jQoBHKlTNB06bN8fr1G2XsKiGFjhI1QojKEwqFAKjnZ0n09Ws4hg4djsGDB+Lp00e4cuUyunTpxLVFu3fvPvz9/XHlyiXs2LENJ0+eRuvWrbB7905cu3YdCxe6o1MnV/j4eOHYscMIDAzEmDFj5bYzb95fWL58Ke7duwsTExP07t0XaWlpxb27hBQ6DWUHQAghualYsQIMDQ3//w0FnZQdDsmH8PBwpKeno0uXzrC0tAQA1Kz5Bzff0NAQ69b9DXV1dQgEtmjXri08PDywb99/cHFxxtixf2Lx4qUIDw/H0qVL8Pffq9GkSXP8+PEDZcuW5dYzZ85stGzZAgCwY8c22Nra4fz5C+jRo3vx7jAhhYxK1AghKo/H40EoFFCHghKodu1aaNasGRwdG2LgwMHYu/c/xMTEcPPt7IRQV1fn/q5YsSIiI6MBAObm5li8eBH++KMGdu7cjYoVzdC6dTsAQHBwCADA09MLANCggSO3jnLlysHGxoZePUZKBUrUCCElAg3RUTKpq6vj4sVzOHPmFIRCAf79dzvq1HHgxk3T1NSUWZ7H44GxTABAYmIiunXrjj/++AO7d+9EzZo1uepMSRu3Y8eOZbttHo9XBHtESPGiRI0QUiIIBAJ8+PABmZmZyg6F5BOPx0PDhk6YP38evL09oaWlhfPnL+b6OT8/P0RHf8OSJe7o06c3PD090KVLZwDAyJGj8OrVa/Tp0wcAsGfPXu5zMTEx+PTpE2xtbYtmhwgpRpSoEUJKBKFQgOTkZAQFBSk7FJIPjx49wpo1f+Pp06cIDg7GuXPnER0dzb0aLCfm5hbQ0tLCv/9uh7+/P65du47Xr18DADIyMtGkSTOEhYUBAP75ZxNu3ryFN2/eYsyYcTA2NkanTh2LdN8IKQ6UqBFCSgShUAAAeP+e2h2VJPr6fHh6eqFbt56wtxdh8eIlWLFiGdq2bZPrZ01MymP79n9x5sxZODg4Yu3adVi+fBkAYM+eXfjzz/H47799AACxWIyxY8fDxaUJwsPDcfz4UWhpaRXpvhFSHHismN7XER8fDwMDA3z9GgI+n18cmyzVdHX1kZSUoOwwSgU6loWrqI5nZmYmKlWqjLlz52Dy5ImFvn5VROemvIyMDDg5OQMArK2rIS4uDvfu3QePxwOfz8fHj++hp6cn9zk6loWHjmXhiI+Ph6mpOeLi4nLMi6hEjRBSIqipqUEgsKWefL85NTU1TJkyCS4ujZCUlISPHz8BABhjiIuLw+rVa5QcISGFi8ZRI4SUGAKBgAa9/c3xeDz0798P/fv3A5A1YG779q7w8rqHt2/foWNHVyVHSEjhokSNEFJiCIVCXL58BYwxGnqBAACaNGmMxMR4AECdOnWUGwwhRYCqPgkhJYZQKEBcXBzCw8OVHQohhBQLStQIISWGpOcnvaGA/KqMTIaHAbG49DoSDwNikZFZLP3qCMk3qvokhJQYVapUgba2Nj58+IAWLZorOxxSQt14F43l1z4hIj6Vm1aRr4W5baujtV15JUZGiDwqUSOElBgaGhqoXr06jaVGCuzGu2hMPvFWJkkDgMj4VEw+8RY33kUrKTJCFKNEjRBSotjZCWiIDlIgGZkMy699gqJKTsm0Fdc+UzUoUSmUqBFCShSBQEBt1EiBPA+JlytJk8YAhMeL8SQorviCIiQXlKgRQkoUoVCI6OhoREd/U3YopISJ/pF9kiYtKo/LEVIcKFEjhJQoQqEQAKj6k+Rb+bJ5e/enSR6XI6Q4UKJGCClRqle3hrq6Or2hgORbHXM+KvK1kN1QyTwAlfjacLA0KM6wCMkRJWqEkBJFS0sL1tbVqOcnyTd1NR7mtq0OAHLJmuTvOW2toa5Gb70gqoMSNUJIiUPv/CQF1dquPDb0qoEKfNnqzYp8bWzoVYPGUSMqhwa8JYSUOEKhEIcOHVZ2GKSEam1XHi0ExngSFIeoH6kwKasFB0sDKkkjKokSNUJIiSMUChAWFob4+Hjw+Xxlh0NKIHU1HhyrGCo7DEJyRVWfhJASRyDIeucn9fwkhJR2lKgRQkocgcAWPB4P79/7KTsUQggpUpSoEUJKHF1dXVhaWlKHAkJIqUeJGiGkRBIKqecnIaT0o0SNEFIiCQT0cnZCSOlHiRohpEQSCoUICAhEcnKyskMhhJAiQ4kaIaREsrMTgDEGP7+Pyg6FEEKKDCVqhJASSTJEB7VTI4SUZpSoEUJKJAMDA5iamlKiRggp1ShRI4SUWFkdCmgsNZI9Hx9fqh4nJRolaoSQEsvOjoboINm7cuUqWrVqg8GDhyo7FEIKjBI1QkiJJRQK8fnzF6Smpio7FKJijh8/gT59+oExBjU1+qkjJRedvYSQEksgECA9PR2fP39RdihEhezYsRPDh4+ElZUV+Hx9JCUlKjskQgqMEjVCSIklFAoB0MvZSRbGGFatWo0pU6Zh1KiRCA8Ph6OjI8LCvoIxpuzwCCkQStQIISWWiUl5GBuXo3ZqBADw8uUrLF68FAsWzEfdunWRnJyMdu3aIjExEQkJCcoOj5AC0VB2AIQQ8iuEQiHevaNEjQC1a9fCs2dPYGtrg3btOqBp06aoXbs2ACA0NBRWVuZKjpCQ/KMSNUJIiSYUCmmIDgIA4PF4sLW1gb+/P+7f98TAgf1RtWoVqKurQywWKzs8QgqEEjVCSIkmENjCz88PGRkZyg6FqIjDh49AX18fnTt3gpmZGd69ew17e3tlh0VIgVCiRggp0YRCIcRiMQIDA5UdClEBmZmZOHToCLp37wY9PT0AQOXKlcHj8ZQcGSEFQ4kaIaREEwol7/yknp8E8PT0QmBgIAYOHKDsUAgpFJSoEUJKNDMzM+jr61OHAgIAOHjwEKytq6FhQydlh0JIoaBEjRBSovF4PAiFAhpLjSAhIQFnzpzFwIEDqKqTlBqUqBFCSjyBgN75SYAzZ84hOTkZ/fr1VXYohBQaStQIISWeZIgOGn3+93bo0CE0a9YMFhYWyg6FkEJDiRohpMQTCm3x48cPhIaGKjsUoiRfvnyBp6cXBg7sr+xQCClUlKgRQko8yTs/qUPB70t67DRCShNK1AghJZ6lpSV0dHSoQ8FvSjJ2Wo8e3aGrq6vscAgpVJSoEUJKPHV1ddja2tJYar+pe/fuIygoiMZOI6USJWqEkFKBhuj4fR08eAjVq1vDyamBskMhpNBRokYIKRWEQgHevXtHPT9/M/Hx8Th79hyNnUZKLUrUCCGlglAoRExMLCIjo5QdCilGZ86cQ0pKCo2dRkotStQIIaWCQJD1zk+q/vy9HDp0CM2bN4O5ubmyQyGkSFCiRggpFaytq0FDQ4PeUPAb+fz5M7y8HlAnAlKqUaJGCCkVNDU1YWNTnUrUfiOHDx8Bn89Hp04dlR0KIUWGEjVCSKkhEAjw7h0lar8DGjuN/C4oUSOElBo0RMfvw8PjHoKDgzFoEFV7ktKNEjVCSKkhEAgQHh6OmJgYZYdCitjBg4dgY1Mdjo6Oyg6FkCJFiRohpNSQvPPzwwc/JUdCilJ8fDzOnTuPAQNo7DRS+lGiRggpNWxsqkNNTY2qP0u5M2fOIiUlBf3709hppPSjRI0QUmqUKVMGVapY4d07GqKjNDt48BBatGiOypUrKzsUQoocJWqEkFJFKBRSiVop9vnzZzx44E1jp5HfBiVqhJBSRSAQ4P17StRKq4MHD8HAwIDGTiO/DUrUCCGlilAoQFBQEH78+KHsUEghy8jIwKFDR9CzZw+UKVNG2eEQUiwoUSOElCp2dlk9Pz9+/KjkSEhh8/C4h9DQUAwc2F/ZoRBSbChRI4SUKra2tgBAHQpKoYMHD8HW1gb169dXdiiEFBuNolqxWCyGWCzm/o6Pjy+qTRFCCEdfXx/m5uY0llopExcXh/PnL2D27Fk0dhr5rRRZorZixQq4u7vLTdfV1Yeurn5Rbfa3Qsex8NCxLFzKPp41atTAx4+flB5HYSgN+1AYDh8+BrFYjBEjRhb4mNCxLDx0LH9dejrL03I8xljelswnRSVqFhYW+Po1BHw+vyg2+VvR1dVHUlKCssMoFehYFi5VOJ4zZ87GtWvX8OLFM6XG8atU4Viqilat2kBPTw/nzp0p0OfpWBYeOpaFIz4+Hqam5oiLi8sxLyqyNmra2trg8/ky/xFCSHEQCgX48sVf5mGRlFwfP36Et7cPjZ1GfkvUmYAQUuoIhUJkZmbi48dPyg6FFIJDh47Q2Gnkt0WJGiGk1BEIsnp+0hsKSr6MjAwcPnwEvXr1hI6OjrLDIaTYUaJGCCl1jI2NYWJigvfvaYiOku7uXQ8aO4381ihRI4SUSnZ2QnqVVClw8OAhCAS2qFevnrJDIUQpKFEjhJRKAoEtJWolnGTstAEDBtDYaeS3RYkaIaRUEgqF+PjxI9LT05UdCimg06fPIDU1Ff3791V2KIQoDSVqhJBSSSgUIi0tDf7+/soOhRTQgQMH0apVS5iamio7FEKUhhI1QkipJBAIAICqP0soP7+P8PV9SGOnkd8eJWqEkFKpUqWKMDQ0pESthDp06DAMDQ3h6tpB2aEQolSUqBFCSiUej/f/HQpoiI6S5n9jp/WgsdPIb48SNUJIqSUU0hAdJdGdO3cRFhZG1Z6EgBI1QkgpJhQK4efnh8zMTGWHQvLh4MFDEAoFcHBwUHYohCgdJWqEkFJLILBFUlISgoODlR0KyaPY2FhcuHCRxk4j5P9RokYIKZF27NiJGjVqoVw5Ezg7N4GX1wO5ZezshACyen5u374DIlE9GBtXQJ06Ihw6dFhm2QMHDkFPjy/3X0pKSrHsD8ly6tRppKamol8/GjuNEADQUHYAhBCSXydPnsLMmbOxYcM6ODk5YffuPejWrQeePHkICwsLbjlzc3Po6uriv//2486dO9i8eSMcHER4/PgJJkyYCCMjI3To0J5bns/n49mzJzLbosbsxevgwUNo3boVTE0rKTsUQlQClagRQkqcTZs2Y8iQwRg6dAiEQgHWrFkFc/PK2Llzt8xyampqEAgE8Pb2xvDhw9CzZw9UrVoVvXr1xODBg7Bu3XqZ5Xk8HipVqijzHyk+Hz744eHDR9SJgBAplKgRQkqU1NRUPHv2HC3/r707j66qvvc+/jkZIZAECBkYEqaQvQOIxYFJoRTnelGZEUK1XbY+t6uuVmu13vZa7b1X7dXedqnPtWhVbjmHISCPKKAyieIEiiBeyUkICUOEBBIgAQIhw3n+CInMZNjn7HPOfr/W8o/ss8/e3/2TsD7svX/f3w3jz9o+fvx4bdy48bz9TdPQ8ePH1aFD7FnbO3bsqC++2Kza2trmbceOHZNpDtbAgaYmT56qrVu/8s9F4II8nvnq2rXLWXc5AacjqAEIKRUVFaqvr1dKSspZ21NTU1RWVnbe/oZhqL6+XnPn/kNbtmyRz+fTl19+qX/8Y55qa2tVXl5xer+BmjPnJeXmLtTcua+pQ4cOuvHGm1VYWBiQ63K673qnTeFxM3AG3lEDEJLOnRDo8/kuOEswO9tUTU2Nxoy5XuPG3SCfz6eUlBTl5MzSX/7yV0VGRkqShg8fruHDhzd/b9SokRo9eoz+9rc5eu65Z/16LZDWrXtf+/fv57EncA7uqAEIKUlJSYqMjFRZ2YGzth84cPC8u2xSY4sOSbr33ntUXl6mvLz/VX7+dvXpk6H4+Hh17550wfNERETo6quvUmHhTusvAudxu93KzjZ11VVX2V0KEFQIagBCSkxMjIYN+57WrVt31vb3339fI0aMOG//fv36KSYmRl6vV9HR0erVq5ciIyO1ZMkbuvXWWxQRceG/Bn0+n7Zt26a0NGYf+tvhw4f19tsrlJOTQ+804Bw8+gQQch544Be6776fadiwqzRixHC99trr2ru3RPfd9xNJ0uOPP6F9+/bp739/WVFRUcrIyNDy5St000036siRI3rhhRe1fft2vfzy35qP+dRTT+vaa69VZuYAVVUd1Usv/U3btn2tv/zlz3ZdpmO88cZS1dXVafr0aXaXAgQdghqAkDNlymQdOnRIzzzzJ5WWlmrQoEFaunSJMjIyJEmlpaUqKSlp3r9fv7765JNPNXLkdYqOjtbYsWO0du0a9enTp3mfI0cq9cADv1RZWZkSEhJ05ZVDtWrVO7rmmmsCfn1OQ+804OJcPp/PF4gTVVVVKTExUfv3lyghISEQpwxrcXHxqq4+ancZYYGxtFYwjudTTz2tOXNe0e7dRXaX0irBOJZW83rzdfXV18rt/ocmTrzLb+dxwlgGCmNpjaqqKvXo0VuVlZWXzEW8owYg7BmGofLy8uZWHAge9E4DLo2gBiDsmWbjmp/5+fk2V4Iz1dfXa8GChZo2bapiY2Mv/wXAgQhqAMJeZuYARUREENSCzJo1a+mdBlwGQQ1A2IuNjdWAAf2Vl+e1uxScweOZr0GDBmnYsGF2lwIELYIaAEcwTZM7akGksXfacuXkzKJ3GnAJBDUAjmAYhrxeglqwWLLkDdXX19M7DbgMghoARzBNQ99++62qqqrsLgVq7J128803KS0t1e5SgKBGUAPgCKZpSJIKCgpsrgR5eV598cVmJhEALUBQA+AIWVmNi7Pn5fH4024ez3x169ZVt912q92lAEGPoAbAETp16qQ+ffowocBmdXV1mj9/Ab3TgBYiqAFwDMPIktdLiw47rVmzVmVlZcrJybG7FCAkENQAOAYtOuzn8czX4MGD9b3vXWl3KUBIIKgBcAzTNFRcvEsnTpywuxRHOnTokJYvX0HvNKAVCGoAHMM0Dfl8PhUU7LC7FEeidxrQegQ1AI5hGI0tOnj8aQ+326NbbrlZqakpdpcChIwouwsAgEDp0qWL0tLSmFBgg+3b87R585eaP99tdylASOGOGgBHaZxQQNPbQHO7PUpK6kbvNKCVCGoAHMU0adERaHV1dVqwYKGmTZummJgYu8sBQgpBDYCjmKapwsKdqq2ttbsUx1izZo0OHDjAklFAGxDUADiKYRiqq6vTzp1FdpfiGG73fA0ZMkRXXjnU7lKAkENQA+AopmlKEo8/A6SiokIrVqxUTs5MeqcBbUBQA+AoycndlZTUjRYdAbJkyRtqaGjQ9OnT7S4FCEkENQCO4nK5ZBiG8vK4oxYITb3TUlKS7S4FCEkENQCOQ4uOwPjmm+368sstmj2bBdiBtiKoAXAcw8hSQUGB6uvr7S4lrLndHnXvnqRbbrnZ7lKAkEVQA+A4pmnq5MmT2r17t92lhK3a2lotXLiI3mlAOxHUADhOdnbjzE8mFPgPvdMAaxDUADhOz549FR8fr7w8gpq/uN3zdcUVV9A7DWgnghoAx2mc+ZnFHTU/ObN3GoD2IagBcCTDMGh66ye5uYvl8/nonQZYgKAGwJGaWnT4fD67Swk7bvd83XbbrUpO7m53KUDII6gBcCTTNHT06FHt27fP7lLCytdf/6+2bt3KJALAIgQ1AI5kmoYksUKBxTye+erevTu90wCLENQAOFKfPn3UoUMHJhRYqKl32vTp0xQdHW13OUBYIKgBcKTIyEgNHDhQXi9BzSqrV6/RwYMHeewJWIigBsCxTNPgjpqF3G6Phg4dqqFDr7C7FCBsENQAOJZpGsrLy2PmpwXKyyu0cuU79E4DLEZQA+BYpmnq0KHDOniw3O5SQl5ubq4k0TsNsBhBDYBjmSZrflqlqXda9+5JdpcChBWCGgDHGjCgv6KiolihoJ22bftaX331FZMIAD8gqAFwrOjoaGVmDuCOWjs19U67+eab7C4FCDsENQCOZhiG8vIIam3V1Dttxozp9E4D/ICgBsDRTJPF2dtj1arVKi8v57En4CcENQCOZhiGSktLdeTIEbtLCUnz5rl15ZVX6oorhthdChCWCGoAHI2Zn2138GC53nnnXc2ezd00wF8IagAcLStroFwul7zeArtLCTm5ublyuVyaOnWq3aUAYYugBsDROnbsqL59+zj2PbWXX35FgwZdoW7dknXddWP18cefXHL/mpoaPfHEH2Wag/Xoo48pOjpaK1asbP68trZWTz/9jIYMGapu3ZI1YsRorVq12t+XAYQtghoAxzNN05GPPpcseUOPPPJbPfLIw/rkk480evQoTZw4WXv37r3od2bPvkfr16/Xww8/JJ/Pp9///ncyjKzmz5988t/06quv67nnntXmzZt0330/0d13z9LWrV8F4pKAsENQA+B4hmHI63VeUHvhhRd1zz0/0r333iPTNPTss39S79699Morr15w/1WrVuujjz7W0qVLVFCwQ8nJyfr5z/+PRo4c0bzPggUL9Zvf/Fq33nqL+vXrp5/+9D7deOMNev75FwJ1WUBYIagBcDzTNLV7924dP37c7lIC5tSpU9qyZatuuGH8WdvHjx+vjRs3XvA7K1eu1LBhw/Tcc/+ll156SbW1p/T440/oxIkTZxy3Rh06dDjrex06dNCnn35m/UUADkBQA+B42dmGJKmgYIfNlQRORUWF6uvrlZKSctb21NQUlZWVXfA7xcW79Omnn+rDDzeoocGnxx9/XG++uUwPPvjr5n1uuOEGvfDCiyosLFRDQ4PWrl2nFStWqrS01K/XA4QrghoAx8vKanzHyokTClyus3/2+XxynbvxtIaGBrlcLqWkJGvYsGG6//6f6plnnpLb7Wm+q/bss/+pAQMGaNiwa9SlS5J+/euHNXv2LEVGRvr7UoCwRFAD4HgJCQnq1auX8vOd06IjKSlJkZGRKis7cNb2AwcOnneXrUlaWppSU1O0du065eTMlNT4fp/P59O3334rSUpO7q5Fixbo4MFSeb3faMuWzerUqbP69u3j3wsCwhRBDQAkGUaWo+6oxcTEaNiw72ndunVnbX///fc1YsSIC35n1KiR2rdvvyRp6tQpkqTCwkJFRESoV69eZ+3boUMH9ezZU3V1dVq2bJluv/12P1wFEP4IagCgxgkFTgpqkvTAA7/Q3Ln/0P/8zzx5vfl65JHfau/eEt13308kSY8//oTuu+9nzftPm9bY2DYlJUUHDhzURx99rN/97vf60Y9mq2PHjpKkzz//XMuWvaXi4mJ9/PEnuvPOSWpo8OnBB38Z+AsEwkCUvw5cU1Ojmpqa5p+rqqr8dSoAaDfTNDRnzsuqqalRbGys3eUExJQpk3Xo0CE988yfVFpaqkGDBmnp0iXKyMiQJJWWlqqkpKR5/507i1RbW6ukpCSNGfN9devWTZMmTdQf/vCvzfucPFmjP/7x31RcvEudO3fSzTffrFdffVldunQJ9OUBYcHl8/l8/jjwE088oSeffPK87ZWVlUpISPDHKQGgzTZs2KCxY8fq66+/1pAhLDB+Ib/61a+0cOFClZSUKCrKb//OBxyhqqpKiYmJl81FfvtNe+yxx/TQQw+dVVB6erqqq48qKurCM4rQcnFx8aquPmp3GWGBsbRWqI5n377pkqStW79U//7B8eJ7MI3lqVOn5PG4NWvWLJ06dUKnTtldUesE01iGOsbSGi0dQ78FtdjYWMc8PgAQ+pKSktS9e3fHvafWUu+++57Kyys0a9ZMu0sBHIXJBABwWna26cilpFrC7fboqquGafDgQXaXAjgKQQ0ATnPqmp+XU1Z2QO+++55ycmbZXQrgOAQ1ADjNNA3t2LFDdXV1dpcSVHJzcxUZGakpUybbXQrgOAQ1ADjNNE2dOnVKu3btsruUoOHz+TRvnke33/5DJSUl2V0O4DgENQA4zTQbF2fn8ed3tm79St98803zklEAAougBgCnpaWlKTExkaB2Bo/Ho9TUVN144412lwI4EkENAE5zuVyOW/PzUmpqarRoUa7uvnsGDW4BmxDUAOAMjWt+ckdNauyddujQYXqnATYiqAHAGUzTVEFBgRoaGuwuxXZut0dXX32VBg3KtrsUwLEIagBwBsPI0vHjx89ajNyJysoO6L33VtE7DbAZQQ0AzpCdbUpi5ueiRfROA4IBQQ0AzpCenq64uDhHB7XG3mluTZjwT+rWrZvd5QCORlADgDNEREQoK8vZMz+3bt2q7du3M4kACAIENQA4h2FkKT/fuXfU3G6P0tLSdMMN4+0uBXA8ghoAnCM7u7FFh8/ns7uUgKupqVFu7mJ6pwFBgqAGAOcwTVNHjhxRWdkBu0sJuHfeeZfeaUAQIagBwDkMo2nNT+e9p+Z2e3TNNVc3z34FYC+CGgCco3//foqOjnbce2qlpWVatWo1vdOAIEJQA4BzREVFKTMz03F31BYuXKSoqCh6pwFBhKAGABfQNKHAKXw+n9xujyZMuF1du3a1uxwApxHUAOACTNNwVFDbsmWL8vLyNGsWjz2BYEJQA4ALMAxDBw4c0KFDh+wuJSDcbo969OhB7zQgyBDUAOACTLNx1mN+foHNlfjfmb3TIiMj7S4HwBkIagBwAQMHZioiIsIREwpWrnxHhw8foXcaEIQIagBwAbGxserfv5/y8sI/qM2b59a1114j0zTsLgXAOQhqAHARhmGEfS+1/ftLtXr1Gs2enWN3KQAugKAGABdhmuHfomPhwkWKjo7W5MmT7C4FwAUQ1ADgIkzTUElJiY4ePWp3KX7h8/nk8Xg0YcI/qUuXLnaXA+ACCGoAcBFN72wVFITnzM8vv/xSeXlelowCghhBDQAuIisrS5LC9vFnU++08eN/YHcpAC6CoAYAF9G5c2elp6eHZVA7efKkcnOXaObMu+mdBgQxghoAXELjUlLh16JjxYqVOnLkCI89gSBHUAOASzBNMyxbdLjdHo0YMVxZWQPtLgXAJRDUAOASTNNQcfEunTx50u5SLLN//36tWbOWu2lACCCoAcAlmKaphoYG7dhRaHcpllmwYJFiYmI0adJEu0sBcBkENQC4BMNomvkZHu+p0TsNCC0ENQC4hK5duyo1NTVsgtrmzZvl9ebz2BMIEQQ1ALiMxjU/w6Pp7bx5HvXq1Us/+ME4mysB0BIENQC4jOzs8GjRcfLkSS1eTO80IJQQ1ADgMkzTVGHhTtXW1tpdSrssX75ClZWVmjXrbrtLAdBCBDUAuAzDMFRbW6uiomK7S2kXt9ujkSNHaOBAeqcBoYKgBgCXYZqmpNCe+blv3z6tXbuOSQRAiCGoAcBlpKQkq2vXLiG9QgG904DQRFADgMtwuVwyTVN5eaF5R62pd9odd0xQYmKi3eUAaAWCGgC0QOOan6HZouPzzz9Xfn6BZs/OsbsUAK1EUAOAFjCMLBUUFKihocHuUlrN7Z6v3r176/vfH2t3KQBaiaAGAC1gmqZOnDihPXv22F1Kq5w4cUJLlryhmTNn0DsNCEEENQBoAdM0JIXezM/veqfNtLsUAG1AUAOAFujdu7c6d+6svLzQmvnpdns0atRIZWZm2l0KgDYgqAFAC7hcLhlGVki16Ni3b5/WrXuf3mlACCOoAUALGUZorfnp8SxQbGwsvdOAEEZQA4AWamrR4fP57C7lspp6p9155x1KSEiwuxwAbURQA4AWMk1DVVVV2r9/v92lXNamTZu0Y0chjz2BEEdQA4AWapr5GQorFNA7DQgPBDUAaKG+ffsqNjY26CcUNPVOmzXrbkVE8Nc8EMr4DQaAFoqMjNTAgQPl9QZ3UHv77eWqqqqidxoQBghqANAKpmkE/R01t9uj0aNHacCAAXaXAqCdCGoA0AqmGdwtOkpKSk73TmMBdiAcENQAoBVM01R5eYUOHiy3u5QLWrBgoTp27KhJk+6yuxQAFiCoAUArGEbjzM9gfPzp8/nkdjf2TouPj7e7HAAWIKgBQCtkZg5QZGRkUD7+3LhxkwoLd9I7DQgjBDUAaIWYmBhlZg4IypmfbrdH6enpGjt2jN2lALAIQQ0AWqlxzc/gCmrV1dV6442l9E4Dwgy/zQDQSsHYouOtt96mdxoQhghqANBKhmFo3759qqystLuUZm73fF1//XXq37+/3aUAsBBBDQBayTRNScEz83Pv3r1av369Zs1iEgEQbghqANBKWVkD5XK55PUW2F2KpO96p02ceKfdpQCwGEENAFopLi5Offr0CYoWHU290+666056pwFhiKAGAG0QLBMKPvtso3buLKJ3GhCmCGoA0AbB0qLD7fYoIyNDY8Zcb3cpAPyAoAYAbWCapnbv3q3q6mrbajh+/Di904Awx282ALSBaWbJ5/OpoGCHbTW89dbbOnr0KL3TgDBGUAOANmhanN3OCQVu93yNGXO9+vXrZ1sNAPyLoAYAbZCYmKiePXvaNqFgz549+uCDD+idBoQ5ghoAtJGdEwoWLFiouLg4eqcBYY6gBgBtZFeLjjN7p3Xu3Dng5wcQOAQ1AGgj0zRUWLhTp06dCuh5P/nkUxUVFdM7DXAAghoAtJFpmqqvr1dh4c6Antft9qhv3766/vrrAnpeAIFHUAOANrJjcfbjx49r6dL/R+80wCGi/HXgmpoa1dTUNP9cVVXlr1MBgC26d09S9+5JAW3RsWzZWzp27Jhmzrw7YOcEYB+/BbWnn35aTz755Hnb4+LiFRfHwsFWYBytw1hay0njOWjQYBUWFvntms897oIFizRu3DgNGnSFX84Xzpz059LfGMv2q6vztWg/vwW1xx57TA899FDzz1VVVUpPT1d19VFFRbn8dVrHiIuLV3X1UbvLCAuMpbWcNp4DB2Zq48ZNfrnmc8dyz549WrdunebMeclRY2wFp/259CfG0hotHUO/veAQGxurhISEs/4DgHBjmoZ27Nih+vp6v59r/vwF6tSpk+66i95pgFPwJioAtINhGKqpqdGuXbv8ep6Ghga53R5NnHgXvdMAByGoAUA7ZGc3zvz09woFn3zyqYqLd2n27By/ngdAcCGoAUA79OjRQwkJCX4Pam63R/369dXo0aP8eh4AwYWgBgDt4HK5ZBhZfm3RcezYsdO902bSOw1wGH7jAaCdTNP0a9PbZcve0vHjx+mdBjgQQQ0A2skwDHm9+fL5WtYXqbXc7vkaO3as+vTp45fjAwheBDUAaKfsbEPHjx9XSUmJ5cfevXu3PvzwQ+XkzLT82ACCH0ENANqpac1Pf0wo8Hjmq3PnzvROAxyKoAYA7ZSRkaGOHTtaPqGgoaFBHs8CTZo0UZ06dbL02ABCA0ENANopIiJCWVlZys8vsPS4GzZs0K5du5STM8vS4wIIHQQ1ALCAP1p0zJ07l95pgMMR1ADAAtnZprxer2UzP48dO6bFixcrJ2eWXC6XJccEEHoIagBgAcMwdPjwER04cNCS47355jJ6pwEgqAGAFb6b+WnN40+326Px48crIyPDkuMBCE0ENQCwQP/+/RQdHW3JCgXFxcXasOEj/fjHP7agMgChjKAGABaIjo5WZuYAS+6ozZ+/QPHx8Zo4caIFlQEIZQQ1ALCIaZryetvXooPeaQDORFADAItY0aLjo48+1u7du+mdBkASQQ0ALGOapsrKynT48OE2H8Pt9qh//34aNWqkhZUBCFUENQCwSNPMz/z8AtXU1Mjt9rSqr9qxY8f05pvL6J0GoFmU3QUAQKh79933FBkZqTFjrldERIS8Xq927CjUP//zz3XnnXcoPj6+RcdZuvRNVVdX0zsNQDPuqAFAO23atEkzZsxUUVGx+vXrK683X8uXL9fIkSNaHNIkyePxaNy4cUpPT/djtQBCCUENANrpN795WP369dW99/5EmZmZ+uabb7R27TrdfvvtLT5GUVGRPvroY+XkzPRjpQBCDY8+AaCdOnbsqLlzX9fYseMUHR2tvXv36sSJE5owoeVBral32h13TPBjpQBCDXfUAMACQ4YM1lNP/bu2bt2qiooKGUaWMjMzW/Tdpt5pkydPUlxcnJ8rBRBKCGoAYJH77/+ZRo8eJUkaPnz4JffdvXu3fvjDCaqurtaGDR9pz5499E4DcB6CGgBYxOVy6fXXX1Xv3r10zz0/uuS+paWl+uCDD1RUVKx589zKzBygkSNHBKhSAKGCoAYAFurdu7fy8/Mu27C2Z8+ekqTCwsLm3mlffPGFRo8eo+Li4kCUCiAEENQAwAapqamSpJUr39XJkyfVp0+Gbr/9DsXFdVRaWprN1QEIFgQ1ALBBTEyMkpOTtWHDhxo8eJDuv//nuu660XrrrTfVsWNHu8sDECRozwEANklKSpLX65XL5dLkyZP0yitzFBMTY3dZAIIId9QAwCb19XWSpHvv/ZFee+3vhDQA5yGoAXCUVatW68Ybb1bPnulKT++jyZOnqqioqPnzb7/9Vvfcc696985QcnKarr/++/r8889VULBDnTolKD+/4KzjPf/8i8rOHtKqxdeb5OTkaObMu/XCC88rMjKy3dcGIPwQ1AA4SnV1tR544Bf68MP3tXz524qIiNCMGbPU0NCgY8eO6ZZbbtP+/aXKzV2kzz77WA8++Es1NDQoK2ughg0bpkWLFp11vNzcxZo2bapcLlera3n44Yf0yitz2vRdAM7AO2oAHOWuu+486+f//u//q759+ysvz6uNGzeqvLxCH364Xt26dZMkDRgwoHnf6dOnas6cl/X44/8qSdqxY4e2bNmiV16ZE7gLAOAo3FED4ChFRUW6996faPDgoUpL66XBg6+QJO3du1fbtm3TlVcObQ5p55oyZYr27NmrTZs2SZIWLcrV0KFDlZ1tBqx+AM5CUAPgKFOnTtehQ4f04ovPa/36dVq/fp0kqba2Vh06XLotRo8eaRo7dqxycxdLkhYvXqIZM6b7vWYAzkVQA+AYFRUV8nrz9eijj+gHPxgn0zR05MiR5s+HDBmsbdu+1qFDhy56jOnTp2nJkqXauHGjioqKNXXqZL/XDcC5CGoAHKNr165KSuqm1157XTt37tT69R/ot799rPnzadOmKjU1RTNmzNSnn36m4uJivfnmMm3cuLF5nzvvnKCjR4/ql798SGPHjm1eCgoA/IGgBsAxIiIiNHfu69q6dauuvXakHn30Mf3Hf/x78+cxMTF66603lZycrEmTpmj48FH685//66zWGQkJCfrhD2/T119/renTp9lxGQAcxOVrS/OfNqiqqlJiYqL27y9RQkJCIE4Z1uLi4lVdfdTuMsICY2ktxtM6jKV1GEvrMJbWqKqqUo8evVVZWXnJXMQdNQAAgCBFUAMAAAhSBDUAAIAgRVADAAAIUiwhBQB+Ut/g0+Y9lTp47JSSO8fo6oxERUawrieAliOoAYAfrM4r11PvFaqs6lTzttSEGP3LLZm6Kbu7jZUBCCU8+gQAi63OK9evFm8/K6RJ0oGqU/rV4u1anVduU2UAQg1BDQAsVN/g01PvFepCDSqbtj393k7VNwSkhSWAEEdQAwALbd5Ted6dtDP5JJVW1WjznsrAFQUgZBHUAMBCB49dPKS1ZT8AzkZQAwALJXeOsXQ/AM5GUAMAC12dkajUhBhdrAmHS1JaQqyuzkgMZFkAQhRBDQAsFBnh0r/ckilJ54W1pp8fu2UA/dQAtAhBDQAsdlN2d/116iClJJz9eDM1IVZ/nTqIPmoAWoyGtwDgBzdld9d4I4mVCQC0C0ENAPwkMsKl4X272F0GgBDGo08AAIAgRVADAAAIUgQ1AACAIEVQAwAACFIENQAAgCBFUAMAAAhSBDUAAIAgRVADAAAIUgQ1AACAIEVQAwAACFIENQAAgCBFUAMAAAhSBDUAAIAgRVADAAAIUgQ1AACAIEVQAwAACFIENQAAgCBFUAMAAAhSBDUAAIAgRVADAAAIUgQ1AACAIEVQAwAACFJR/jpwTU2Nampqmn+uqqry16kAAADCkt+C2tNPP60nn3zyvO1xcfGKi4v312kdhXG0DmNpLcbTOoyldRhL6zCW7VdX52vRfi6fz9eyPVvpQnfU0tPTtX9/iRISEvxxSkeJi4tXdfVRu8sIC4yltRhP6zCW1mEsrcNYWqOqqko9evRWZWXlJXOR3+6oxcbGKjY21l+HBwAACHtMJgAAAAhSBDUAAIAgRVADAAAIUgQ1AACAIOW3yQTnappcevQoM0WsUFfnY9aNRRhLazGe1mEsrcNYWoextEZTHrpc842ABbWKigpJUlZWdqBOCQAAENQqKiqUmJh40c8DFtS6desmSdqzZ88lC8LlNfWk27t3Lz3p2omxtBbjaR3G0jqMpXUYS+tUVlYqIyOjOR9dTMCCWkRE4+twiYmJ/M+1SEJCAmNpEcbSWoyndRhL6zCW1mEsrdOUjy76eYDqAAAAQCsR1AAAAIJUwIJabGys/vCHP7CslAUYS+swltZiPK3DWFqHsbQOY2mdlo6l3xZlBwAAQPvw6BMAACBIEdQAAACCFEENAAAgSBHUAAAAghRBDQAAIEgR1AAAAIIUQQ0AACBIEdQAAACC1P8HTcTKVXrYkt8AAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABLYAAAGbCAYAAADZbBnaAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8o6BhiAAAACXBIWXMAAA9hAAAPYQGoP6dpAABp+ElEQVR4nO3dd3gU5f738c+m94QSpIfepFcBJSAiSEflSJFmBeEoioIcC0EUUBHFrlRBKQqKCIIgTZFiFBERRKRzgB9IC12S3M8fPNnDkgSykC0zeb+uK9dFZu7d/c7sfnYyX6Y4jDFGAAAAAAAAgMUE+LoAAAAAAAAA4FrQ2AIAAAAAAIAl0dgCAAAAAACAJdHYAgAAAAAAgCXR2AIAAAAAAIAl0dgCAAAAAACAJdHYAgAAAAAAgCXR2AIAAAAAAIAl0dgCAAAAAACAJdHYAmAZU6ZMkcPhyPZnxYoVvi4xV5QqVUq9e/f2dRlZ+ueff9S3b18VKVJEgYGBqlmzpq9LymTXrl1yOByaMmWKr0uRJK1evVpJSUk6fvx4pnlNmzZV06ZNvV7T5Xr37u0XdfizpKQkORwOX5dxXWbNmqUbb7xR4eHhcjgc2rBhg69LyhUrVqyw5DbA4XAoKSnJ+XvGNm7Xrl1uPc/IkSM1d+7cXK3NCr7//nuFhoZq9+7dzmlNmzZV1apVr/i4zz//XF27dlW5cuUUHh6uUqVKqXv37tq2bZunS/a6P//8UyEhIVq/fr2vSwEAjwrydQEA4K7JkyerUqVKmaZXqVLFB9XkLe+9954++OADvfXWW6pTp46ioqJ8XZLfW716tYYPH67evXsrLi7OZd67777rm6LgtgceeECtWrXydRnX7PDhw+rRo4datWqld999V6GhoapQoYKvy8oVtWvX1po1ayy/DWjTpo3WrFmjIkWKuPW4kSNH6u6771bHjh09U5gfMsZo4MCBevDBB5WQkODWY19++WUVLlxYzzzzjMqUKaO9e/dq5MiRql27ttauXasbb7zRQ1V7X4UKFdS9e3c9/vjjWrlypa/LAQCPobEFwHKqVq2qunXr+rqMPGnTpk0KDw/XgAEDfF2KLVh9RzwvOHPmjCIiIlS8eHEVL17c1+Vcsz///FMXLlzQvffeq8TExFx5zox14ysXLlyQw+FQTEyMbrrpJp/VkVvi4+MVHx/v6zIsYdGiRVq/fr2mT5/u9mO/+uorFSpUyGXarbfeqlKlSun111/XhAkTcqvMa5aWlqbU1FSFhoZe93MNGDBAdevW1erVq9WoUaNcqA4A/A+nIgKwnZkzZ8rhcOjtt992mT5s2DAFBgZqyZIlzmnDhw9XgwYNlD9/fsXExKh27dqaOHGijDEujy1VqpTatm2r+fPnq1atWgoPD1flypU1f/58SRdPIalcubIiIyNVv359/fTTTy6P7927t6KiovT777+refPmioyMVHx8vAYMGKAzZ85cdZlSUlL05JNPqnTp0goJCVGxYsU0cOBAnT592mXcZ599pgYNGig2NlYREREqU6aM7rvvvqs+/7lz5zR06FCX5+/fv7/L6XMOh0MTJkzQ2bNnnad/Xu10v2+//VbNmzdXTEyMIiIi1LhxYy1dutQ5f9u2bYqJiVHnzp1dHrds2TIFBgbqueeec07LeA+++OILVa9eXWFhYSpTpozefPPNqy7fX3/9pT59+qh8+fKKiIhQsWLF1K5dO/32228u4zJOaZoxY4aeeeYZFS1aVDExMbrtttu0detWl7FLlixRhw4dVLx4cYWFhalcuXJ6+OGH9ffffzvHJCUl6amnnpIklS5dOtNps1mdinj06FE98sgjKlasmEJCQlSmTBk988wzOn/+vMs4h8OhAQMGaNq0aapcubIiIiJUo0YN52cyw+HDh/XQQw+pRIkSCg0NVXx8vBo3bqxvv/32qustK9OnT1fDhg0VFRWlqKgo1axZUxMnTnQZM2nSJNWoUUNhYWHKnz+/OnXqpC1btriMycjEH3/8oZYtWyoyMlJFihTR6NGjJUlr167VzTffrMjISFWoUEEfffSRy+MzTttasmSJ+vTpo/z58ysyMlLt2rXTjh07XMbm5L2S/ne64fr163X33XcrX758Klu2rMu8Sy1btkxNmzZVgQIFFB4erpIlS+quu+5yybQ/vJ+9e/fWzTffLEm655575HA4XD538+bNU8OGDRUREaHo6Gi1aNFCa9asyfG6udyvv/4qh8OR6XMhSQsXLpTD4dC8efMkuZ/NadOmadCgQSpWrJhCQ0P1119/ZXsqYk6Wq3fv3ipVqlSmOrN6v6/1+zUlJUUPPvigChQooKioKLVq1Up//vlnpnFZnYr4yy+/qG3btipUqJBCQ0NVtGhRtWnTRvv27ZN08XNz+vRpffTRR87vl4z39vDhw3rkkUdUpUoVRUVFqVChQrr11lv1/fffu7xuxunbY8aM0dixY1W6dGlFRUWpYcOGWrt2baY6161bp3bt2qlAgQIKCwtT2bJlNXDgQJcx27ZtU7du3Zx1V65cWe+8847LmPT0dL344ouqWLGiwsPDFRcXp+rVq2vcuHFXXafvvfee6tWrp4oVK1517OUub2pJUtGiRVW8eHHt3bv3qo/PON0xOTlZt9xyi/OzMHr0aKWnp7uM3bNnj+69916X9fDaa6+5jMtY/6+88opefPFFlS5dWqGhoVq+fLnzc7hx40Z17txZsbGxyp8/v5544gmlpqZq69atatWqlaKjo1WqVCm98sormeqtU6eOKleurPfff9/tdQUAlmEAwCImT55sJJm1a9eaCxcuuPykpqa6jO3bt68JCQkxycnJxhhjli5dagICAsyzzz7rMq53795m4sSJZsmSJWbJkiVmxIgRJjw83AwfPtxlXEJCgilevLipWrWqmTFjhvn6669NgwYNTHBwsHn++edN48aNzeeff26++OILU6FCBXPDDTeYM2fOOB/fq1cvExISYkqWLGleeukls3jxYpOUlGSCgoJM27ZtM71Wr169nL+fPn3a1KxZ0xQsWNCMHTvWfPvtt2bcuHEmNjbW3HrrrSY9Pd0YY8zq1auNw+EwXbp0MV9//bVZtmyZmTx5sunRo8cV12t6erpp2bKlCQoKMs8995xZvHixGTNmjImMjDS1atUy586dM8YYs2bNGtO6dWsTHh5u1qxZY9asWWMOHTqU7fNOmzbNOBwO07FjR/P555+br776yrRt29YEBgaab7/91jlu5syZRpIZN26cMcaYAwcOmBtuuMEkJia6vK8JCQmmWLFipmTJkmbSpEnm66+/Nt27dzeSzKuvvuoct3PnTiPJTJ482Tlt5cqVZtCgQWb27Nlm5cqV5osvvjAdO3Y04eHh5o8//nCOW758uZFkSpUqZbp3724WLFhgZsyYYUqWLGnKly/vUs97771nRo0aZebNm2dWrlxpPvroI1OjRg1TsWJF888//xhjjNm7d6/597//bSSZzz//3LneTpw4YYwxJjEx0SQmJjqf8+zZs6Z69eomMjLSjBkzxixevNg899xzJigoyLRu3dpl/WbUWb9+ffPpp5+ar7/+2jRt2tQEBQWZ7du3O8e1bNnSxMfHmw8//NCsWLHCzJ071zz//PNm5syZ2X8osvHcc88ZSebOO+80n332mVm8eLEZO3asee6555xjRo4caSSZrl27mgULFpipU6eaMmXKmNjYWPPnn386x2VkonLlymbcuHFmyZIlpk+fPkaSGTp0qKlQoYKZOHGi+eabb0zbtm2NJPPTTz85H5/xfVCiRAlz3333mYULF5oPP/zQFCpUyJQoUcIcO3bMrffKGGOGDRtmJJmEhAQzZMgQs2TJEjN37lyXeRl27txpwsLCTIsWLczcuXPNihUrzCeffGJ69OjhfG1/eT//+usv88477xhJZuTIkWbNmjXm999/N8YY88knnxhJ5vbbbzdz5841s2bNMnXq1DEhISHm+++/z9G6yUqtWrVM48aNM03/17/+ZQoVKmQuXLhgjHE/m8WKFTN33323mTdvnpk/f745cuSIc97y5cud43O6XL169TIJCQmZ6rz8/b6e79dmzZqZ0NBQ53f/sGHDTJkyZYwkM2zYMOfYjM/0zp07jTHGnDp1yhQoUMDUrVvXfPrpp2blypVm1qxZpm/fvmbz5s3GmIvfy+Hh4aZ169bO75eM9/aPP/4w/fr1MzNnzjQrVqww8+fPN/fff78JCAhwWVcZ35mlSpUyrVq1MnPnzjVz58411apVM/ny5TPHjx93jl20aJEJDg421atXN1OmTDHLli0zkyZNMl26dHGO+f33301sbKypVq2amTp1qlm8eLEZNGiQCQgIMElJSc5xo0aNMoGBgWbYsGFm6dKlZtGiReaNN95wGZOV8+fPm/DwcDN48OBM8xITE82NN954xcdnZfv27SYgIMA8/vjjVx2bmJhoChQoYMqXL2/ef/99s2TJEvPII48YSeajjz5yjjt06JApVqyYiY+PN++//75ZtGiRGTBggJFk+vXr5xyXsf6LFStmmjVrZmbPnm0WL15sdu7c6fwcVqxY0YwYMcIsWbLEDB482EgyAwYMMJUqVTJvvvmmy/fnnDlzMtXcr18/U7BgQeffCwBgNzS2AFhGxh/9Wf0EBga6jD137pypVauWKV26tNm8eXOWjZLLpaWlmQsXLpgXXnjBFChQwOUPwISEBBMeHm727dvnnLZhwwYjyRQpUsScPn3aOX3u3LlGkpk3b55zWq9evVyaNxleeuklI8msWrXK5bUubWyNGjXKBAQEOJt0GWbPnm0kma+//toYY8yYMWOMJJedkJxYtGiRkWReeeUVl+mzZs0yksyHH37oshyRkZFXfc7Tp0+b/Pnzm3bt2rlMT0tLMzVq1DD169d3md6vXz8TEhJi1qxZY2699VZTqFAhs3//fpcxCQkJxuFwmA0bNrhMb9GihYmJiXG+B1k1ti6Xmppq/vnnH1O+fHmXHZmMHeTLmw6ffvqpkWTWrFmT5fOlp6ebCxcumN27dxtJ5ssvv3TOe/XVV112Vi91eWPr/fffN5LMp59+6jLu5ZdfNpLM4sWLndMkmRtuuMGkpKQ4px08eNAEBASYUaNGOadFRUWZgQMHZrsucmrHjh0mMDDQdO/ePdsxx44dc+5kX2rPnj0mNDTUdOvWzTktIxOX7oRduHDBxMfHG0lm/fr1zulHjhwxgYGB5oknnnBOy/g+6NSpk8tr/fDDD0aSefHFF7Os8UrvVcZO5PPPP5/pcZc3OjLyd/nn8VL+9H5mfLY/++wz57S0tDRTtGhRU61aNZOWluacfvLkSVOoUCHTqFEj57QrrZusvPnmm0aS2bp1q3Pa0aNHTWhoqBk0aFC2j7taNps0aZLtsmU0a9xZrpw2tq71+3XhwoVX/O6/UmPrp59+MpKu2EA0xpjIyEiXbUZ2UlNTzYULF0zz5s1dcpPxnVmtWjWXbeSPP/5oJJkZM2Y4p5UtW9aULVvWnD17NtvXadmypSlevLizgZ9hwIABJiwszBw9etQYY0zbtm1NzZo1r1r35datW2ckZdnMvZbG1oULF0zTpk1NTEyM2bNnz1XHJyYmGklm3bp1LtOrVKliWrZs6fz96aefznJcv379jMPhcGYjY/2XLVvWpdFuzP8+h6+99prL9Jo1azr/w+TS5YiPjzd33nlnpprHjx9vJJktW7ZcdfkAwIo4FRGA5UydOlXJyckuP+vWrXMZExoaqk8//VRHjhxR7dq1ZYzRjBkzFBgY6DJu2bJluu222xQbG6vAwEAFBwfr+eef15EjR3To0CGXsTVr1lSxYsWcv1euXFnSxdMSLr3OTMb0S+/UlKF79+4uv3fr1k2StHz58myXd/78+apatapq1qyp1NRU50/Lli1dTr+pV6+eJOlf//qXPv30U/33v//N9jkvXweSMt2JsXPnzoqMjHQ5dTCnVq9eraNHj6pXr14uNaenp6tVq1ZKTk52OY3y9ddf14033qhmzZppxYoV+vjjj7O8gPKNN96oGjVquEzr1q2bUlJSrnjXp9TUVI0cOVJVqlRRSEiIgoKCFBISom3btmU6RU6S2rdv7/J79erVJbm+p4cOHVLfvn1VokQJBQUFKTg42HkR46yeMyeWLVumyMhI3X333S7TM96by9+LZs2aKTo62vn7DTfcoEKFCrnUWb9+fU2ZMkUvvvii1q5dqwsXLlxTbUuWLFFaWpr69++f7Zg1a9bo7NmzmT5LJUqU0K233pqpfofDodatWzt/DwoKUrly5VSkSBHVqlXLOT1//vyZlivD5Zlq1KiREhISXDLl7nt11113ZbuMGWrWrKmQkBA99NBD+uijjzKd/ij59/spSVu3btX+/fvVo0cPBQT870/CqKgo3XXXXVq7dm2mU6Vzsm6ki+9LaGioy+nKM2bM0Pnz59WnTx/nNHezmZPXv5bluppr/X7N+Bxm991/JeXKlVO+fPk0ZMgQvf/++9q8ebNbNUvS+++/r9q1ayssLMz52V+6dGmW67ZNmzYu28jLv/f+/PNPbd++Xffff7/CwsKyfL1z585p6dKl6tSpkyIiIly+/1u3bq1z5845T2+sX7++fv31Vz3yyCP65ptvlJKSkqNl2r9/v6SsTyl0lzFG999/v77//ntNnTpVJUqUyNHjChcurPr167tMq169uktWly1bpipVqmQa17t3bxljnNveDO3bt1dwcHCWr9e2bVuX3ytXriyHw6E77rjDOS3j+zOr78mMdZXTzy0AWA2NLQCWU7lyZdWtW9flp06dOpnGlStXTrfccovOnTun7t27Z2qU/Pjjj7r99tslSePHj9cPP/yg5ORkPfPMM5Kks2fPuozPnz+/y+8hISFXnH7u3DmX6UFBQSpQoIDLtMKFC0uSjhw5ku3y/t///Z82btyo4OBgl5/o6GgZY5zXCWrSpInmzp2r1NRU9ezZU8WLF1fVqlU1Y8aMbJ8747WDgoIyXbTY4XCocOHCV6ztSjVL0t13352p7pdfflnGGB09etQ5PjQ0VN26ddO5c+dUs2ZNtWjRIsvnzVhfWU27Up1PPPGEnnvuOXXs2FFfffWV1q1bp+TkZNWoUSPT+ywp0/uUcQHfjLHp6em6/fbb9fnnn2vw4MFaunSpfvzxR+cOW1bPmRNHjhxR4cKFM13bp1ChQgoKCsq0jJfXmVHrpa8/a9Ys9erVSxMmTFDDhg2VP39+9ezZUwcPHnSrtsOHD0vSFS+gnlFfVk3JokWLZqo/IiIi0w5ySEhIpkxlTL88U1L2n4mM17qW9yond6UrW7asvv32WxUqVEj9+/dX2bJlVbZsWZfrA/nz+5lRn5T9+5Wenq5jx465TM/pHfvy58+v9u3ba+rUqUpLS5N08RpS9evXd7nrnLvZzMnrX8tyXc31fr9m991/JbGxsVq5cqVq1qyp//znP7rxxhtVtGhRDRs2LEcNzbFjx6pfv35q0KCB5syZo7Vr1yo5OVmtWrW6pu+9nH4HpKam6q233sr03Z/RxM7YZg0dOlRjxozR2rVrdccdd6hAgQJq3rx5pmtUXi6jnuyaazlljNEDDzygjz/+WFOmTFGHDh1y/NicZPXIkSPZfgYz5l/qSp/trP7OyO77M6vvyYxx17ptAgB/x10RAdjWhAkTtGDBAtWvX19vv/227rnnHjVo0MA5f+bMmQoODtb8+fNd/jicO3euR+pJTU3VkSNHXP4gztgZzeqP5AwFCxZUeHi4Jk2alO38DB06dFCHDh10/vx5rV27VqNGjVK3bt1UqlQpNWzYMMvHFyhQQKmpqTp8+LBLc8sYo4MHDzqPVHBHRk1vvfVWtncru+GGG5z/3rRpk55//nnVq1dPycnJGjt2rJ544olMj8lq5z0n6/Djjz9Wz549NXLkSJfpf//9t+Li4q66PJfbtGmTfv31V02ZMkW9evVyTv/rr7/cfq5LFShQQOvWrZMxxqUZcujQIaWmprq81zlVsGBBvfHGG3rjjTe0Z88ezZs3T08//bQOHTqkRYsW5fh5Mj4b+/bty/aohoz34MCBA5nm7d+//5rqv5rsPhPlypWTdG3v1eWNqOzccsstuuWWW5SWlqaffvpJb731lgYOHKgbbrhBXbp08ev3U7r6+xUQEKB8+fK5TM/pupGkPn366LPPPtOSJUtUsmRJJScn67333nMZ4242c/L67ixXWFhYpgv5Z7z+5a7n+zW77/6rqVatmmbOnCljjDZu3KgpU6bohRdeUHh4uJ5++ukrPvbjjz9W06ZNM63zkydP5ui1L3fpd0B28uXLp8DAQPXo0SPboztLly4t6eJ/9jzxxBN64okndPz4cX377bf6z3/+o5YtW2rv3r3Z3nEzIzeX/ueIuzKaWpMnT9bEiRN17733XvNzZadAgQLZfgYlZcq/O9lyV8a68sR3MAD4A47YAmBLv/32mx599FH17NlT33//vapXr6577rnH5X/pHQ6HgoKCXE69OHv2rKZNm+axuj755BOX3zNuVX75nfEu1bZtW23fvl0FChTIdKRa3bp1s7yjV2hoqBITE/Xyyy9Lunhnrew0b95c0sWdoEvNmTNHp0+fds53R+PGjRUXF6fNmzdnWXPdunWdR7adPn1anTt3VqlSpbR8+XINGDBATz/9dKbTSyXp999/16+//uoybfr06YqOjlbt2rWzrcfhcGS6bfqCBQuu+bSMjB2Qy5/zgw8+yDT28qMerqR58+Y6depUpubq1KlTnfOvR8mSJTVgwAC1aNHiiqduZuX2229XYGBgpp3kSzVs2FDh4eGZPkv79u3TsmXLrrv+rFyeqdWrV2v37t3OTLnzXl2rwMBANWjQwHnXt4x168/vpyRVrFhRxYoV0/Tp013uBHv69GnNmTPHeUfBa3X77berWLFimjx5siZPnqywsDB17drVZUxuZ1Nyb7lKlSqlQ4cOOY8ylaR//vlH33zzTbbP7873a7NmzSRl/92fUw6HQzVq1NDrr7+uuLg4l/f78iOFLn3M5et248aNme4MmVMVKlRQ2bJlNWnSpCybgdLFozCbNWumX375RdWrV8/yuz+r/4SIi4vT3Xffrf79++vo0aMud4a8XMbp/tu3b7+m5TDG6MEHH9TkyZP1wQcfuJwam5uaN2+uzZs3Z8rm1KlT5XA4nJ8Nb9ixY4cCAgKu6S6SAGAFHLEFwHI2bdqk1NTUTNPLli2r+Ph4nT59Wv/6179UunRpvfvuuwoJCdGnn36q2rVrq0+fPs6dzDZt2mjs2LHq1q2bHnroIR05ckRjxozJtCOQW0JCQvTaa6/p1KlTqlevnlavXq0XX3xRd9xxh26++eZsHzdw4EDNmTNHTZo00eOPP67q1asrPT1de/bs0eLFizVo0CA1aNBAzz//vPbt26fmzZurePHiOn78uMaNG6fg4GAlJiZm+/wtWrRQy5YtNWTIEKWkpKhx48bauHGjhg0bplq1aqlHjx5uL2tUVJTeeust9erVS0ePHtXdd9+tQoUK6fDhw/r11191+PBhZ4Okb9++2rNnj3788UdFRkbqtdde05o1a9SlSxf98ssvLkdtFC1aVO3bt1dSUpKKFCmijz/+WEuWLNHLL798xR3wtm3basqUKapUqZKqV6+un3/+Wa+++uoVT6m5kkqVKqls2bJ6+umnZYxR/vz59dVXX2nJkiWZxlarVk2SNG7cOPXq1UvBwcGqWLGiy7WUMvTs2VPvvPOOevXqpV27dqlatWpatWqVRo4cqdatW+u2225zq84TJ06oWbNm6tatmypVqqTo6GglJydr0aJFuvPOO916rlKlSuk///mPRowYobNnz6pr166KjY3V5s2b9ffff2v48OGKi4vTc889p//85z/q2bOnunbtqiNHjmj48OEKCwvTsGHD3HrNnPjpp5/0wAMPqHPnztq7d6+eeeYZFStWTI888ogk994rd7z//vtatmyZ2rRpo5IlS+rcuXPOoyoz3id/fj8lKSAgQK+88oq6d++utm3b6uGHH9b58+f16quv6vjx4xo9erTbz3mpwMBA9ezZU2PHjlVMTIzuvPNOxcbGuozJ7Wy6u1z33HOPnn/+eXXp0kVPPfWUzp07pzfffNN5+mSGa/1+vf3229WkSRMNHjxYp0+fVt26dfXDDz/k6D9Q5s+fr3fffVcdO3ZUmTJlZIzR559/ruPHj7ucrl2tWjWtWLFCX331lYoUKaLo6GhVrFhRbdu21YgRIzRs2DAlJiZq69ateuGFF1S6dOkst6E58c4776hdu3a66aab9Pjjj6tkyZLas2ePvvnmG2fzbty4cbr55pt1yy23qF+/fipVqpROnjypv/76S1999ZXz2lLt2rVT1apVVbduXcXHx2v37t164403lJCQoPLly2dbQ/HixVWmTBmtXbtWjz76aKb5KSkpmj17dqbp8fHxSkxM1KOPPqqJEyfqvvvuU7Vq1ZynJUsXm4SXXt/vejz++OOaOnWq2rRpoxdeeEEJCQlasGCB3n33XfXr108VKlTIldfJibVr16pmzZqZjsAEANvw+uXqAeAaXemuiJLM+PHjjTHG3HvvvSYiIsJ5y/MMn332mZFkXn/9dee0SZMmmYoVK5rQ0FBTpkwZM2rUKDNx4sRMd7FLSEgwbdq0yVSTJNO/f3+XaRl3OHr11Ved0zLuJrhx40bTtGlTEx4ebvLnz2/69etnTp065fL4y++KaMzF274/++yzpmLFiiYkJMR5K/XHH3/cHDx40BhjzPz5880dd9xhihUrZkJCQkyhQoVM69atXW5tn52zZ8+aIUOGmISEBBMcHGyKFCli+vXrZ44dO+YyLqd3RcywcuVK06ZNG5M/f34THBxsihUrZtq0aeO8M1vGnZouv4PhX3/9ZWJiYkzHjh1d1kubNm3M7NmzzY033mhCQkJMqVKlzNixY10em9VdEY8dO2buv/9+U6hQIRMREWFuvvlm8/3332e6K2FWd47L7jk3b95sWrRoYaKjo02+fPlM586dzZ49ezLd6cwYY4YOHWqKFi1qAgICXO7edvnrG3PxDoB9+/Y1RYoUMUFBQSYhIcEMHTrUnDt3zmVcVp+9jPWU8fk5d+6c6du3r6levbqJiYkx4eHhpmLFimbYsGEud/J0x9SpU029evVMWFiYiYqKMrVq1cr0/k2YMMFUr17d+Vnt0KFDpjxm91nK7q5ml2cw4/tg8eLFpkePHiYuLs55R8Zt27a5PDan71XGHcgOHz6c6fUvv0vemjVrTKdOnUxCQoIJDQ01BQoUMImJiS53QzXGf97P7D7bxly8k2uDBg1MWFiYiYyMNM2bNzc//PBDlsuf1bq5kj///NP5Hb1kyZJM8683m5fOy8iVO8tljDFff/21qVmzpgkPDzdlypQxb7/9dqb3+3q+X48fP27uu+8+ExcXZyIiIkyLFi3MH3/8cdW7Iv7xxx+ma9eupmzZsiY8PNzExsaa+vXrmylTprg8/4YNG0zjxo1NRESEkeRcb+fPnzdPPvmkKVasmAkLCzO1a9c2c+fOzXQnyKy2WRmy+j5bs2aNueOOO0xsbKwJDQ01ZcuWdbmDZcZz3nfffaZYsWImODjYxMfHm0aNGrncrfS1114zjRo1MgULFjQhISGmZMmS5v777ze7du266jp97rnnTL58+TLlKOOOhVn9ZKyXhISEbMdkdYfMy2X3HZXVHTZ3795tunXrZgoUKGCCg4NNxYoVzauvvupyt84rrf/scufO9+fJkydNREREpjsrAoCdOIy55BhtAIBH9O7dW7Nnz9apU6d8XYpllSpVSlWrVtX8+fN9XQr8wJQpU9SnTx8lJyerbt26vi4HgBft379fpUuX1tSpU3XPPff4uhy/NnHiRD322GPau3cvR2wBsC2usQUAAADAMooWLaqBAwfqpZdeUnp6uq/L8Vupqal6+eWXNXToUJpaAGyNa2wBAAAAsJRnn31WERER+u9//5vtnVrzur179+ree+/VoEGDfF0KAHgUpyICAAAAAADAkjgVEQAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEY8vPTJkyRQ6HQz/99NNVx/bu3VulSpW65td64IEHVLVqVcXFxSk8PFwVKlTQU089pb///ttl3IYNG9SmTRuVLFlS4eHhyp8/vxo2bKiPP/4403OuWrVKDzzwgOrUqaPQ0FA5HA7t2rXrmmsE7MabGT958qQeffRRFStWTKGhoapQoYJeeeUVpaWluYxbsWKFHA5Hlj9r16695tcH7M5beb5SRh0Oh/r27esce/LkSQ0ePFi333674uPj5XA4lJSUdE2vC9iRt3J74MABPfvss2rYsKEKFiyomJgY1alTRx9++GGm7bA7f2v37t07y++BSpUqXVOdgJWx74wMQb4uAL5z+vRpPfTQQypXrpzCwsL0008/6aWXXtLXX3+tX375RSEhIZKk48ePq0SJEuratauKFSum06dP65NPPlGPHj20a9cuPfvss87nXLp0qb799lvVqlVLMTExWrFihY+WDsjbUlNT1aJFC/35558aMWKEKlSooEWLFunpp5/Wvn379Oabb2Z6zMiRI9WsWTOXaVWrVvVWyQCyUbt2ba1ZsybT9Pfee09Tp05Vp06dnNOOHDmiDz/8UDVq1FDHjh01YcIEb5YK4P/7+eefNXXqVPXs2VPPPfecgoODtXDhQvXr109r167VpEmTnGPd+VtbksLDw7Vs2bJM0wB4DvvO/o3GVh42Y8YMl99vvfVWRUdH65FHHtGqVat06623SpKaNm2qpk2buoxt27atdu7cqQ8//NAlnM8995yGDRsmSRozZgzhBHxk9uzZWrdunebMmaM777xTktSiRQudOnVK77zzjvr376+KFSu6PKZ8+fK66aabfFEugCuIiYnJlE1jjLp3766EhAS1aNHCOT0hIUHHjh2Tw+HQ33//TWML8JHGjRtr+/btCg4Odk5r0aKF/vnnH73zzjsaPny4SpQoIcm9v7UlKSAggO014GXsO/s3TkW0iClTpqhixYoKDQ1V5cqVNXXqVI+8Tnx8vCQpKOjqPc+CBQtmGhcQwEcKuBa5nfEffvhBDodDd9xxh8v0tm3bKj09XV988cV1PT+A7Hljm718+XLt2LFDffr0cdn2ZpyWBMA9uZ3bfPnyuTS1MtSvX1+StG/fvqs+R1Z/awO4Ovad8x7WpAVMmTJFffr0UeXKlTVnzhw9++yzGjFiRKZDkKX/nXfvzrm5qampOn36tH744Qc999xzuvnmm9W4ceNM49LT05WamqrDhw/r3Xff1TfffKMhQ4Zcz6IBkGcy/s8//yggICDTH9WhoaGSpI0bN2Z6TP/+/RUUFKSYmBi1bNlSq1atuvaFAvIoT2+zM0ycOFEBAQHq06dPLlQN5G3eyq0kLVu2TEFBQapQoUKmeTn9W/vs2bMqXLiwAgMDVbx4cQ0YMEBHjx69pnoAu2HfOW/ivwD8XHp6up555hnVrl1bX3zxhfN/YW+++WaVL19eRYsWdRkfGBiowMDAHP9v7dq1a9WwYUPn761bt9bMmTMVGBiYaewjjzyiDz74QJIUEhKiN998Uw8//PC1LhoAeS7jVapUUVpamtauXaubb77ZOT2jWXXkyBHntNjYWD322GNq2rSpChQooL/++kuvvvqqmjZtqgULFqhly5a5tbiArXl6m53h+PHj+vzzz9WiRQuVLFky1+oH8iJv5VaSFi9erGnTpumxxx5TgQIFMs3Pyd/aNWrUUI0aNZzXwFy5cqVef/11LV26VMnJyYqKinK7LsAu2HfOwwz8yuTJk40kk5ycbIwxZvPmzUaSGTNmTKaxiYmJJiEh4bpe79SpUyY5OdmsXLnSjBs3zhQpUsQ0aNDAnD59OtPY3bt3m+TkZLNgwQLTt29fExAQYF599dVsn/vVV181kszOnTuvq0bATryV8cOHD5v8+fObypUrm7Vr15pjx46Z6dOnm9jYWCPJtGrV6oqPP3bsmClevLipXr36Nb0+kBd4e5ud4e233zaSzGeffXbFcYcPHzaSzLBhw3LldQE78FVuf/75ZxMbG2saNWpkzp07l+UYd//WzjB79mwjyYwdOzZXagWsgn1nZOCILT+XcVRF4cKFM80rXLjwdd8ONDIyUnXr1pUkNWnSRA0aNNBNN92kDz74QI8//rjL2JIlSzr/Z7h169aSpKFDh6pXr17O84sBuMdTGS9YsKAWLVqkXr16OS8wW6BAAY0dO1b333+/ihUrdsXHx8XFqW3btnr//fd19uxZ7rYE5ICnt9kZJk6cqPj4eHXo0CFXng/Iy7yR219++UUtWrRQ+fLl9fXXXzsvC3C5a/1bu1OnToqMjNTatWuvu1bAyth3zru4xpafyzhM+eDBg5nmZTXtetWtW1cBAQH6888/rzq2fv36Sk1N1Y4dO3K9DiCv8GTG69Wrp82bN2vnzp3atGmT9u/fr8qVK0u6uDG+GmOMJHEhaiCHvLHN/uWXX/TLL7+oZ8+eWV6YGoB7PJ3bX375RbfddpsSEhK0ePFixcbG5vix7vytbYzhQtTI89h3zrv49vNzFStWVJEiRTRjxgznTqYk7d69W6tXr87111u5cqXS09NVrly5q45dvny5AgICVKZMmVyvA8grvJHxUqVK6cYbb1RwcLBee+01FS1aVJ07d77iY44dO6b58+erZs2aCgsLy5U6ALvzRp4nTpwoSbr//vtz5fmAvM6Tud2wYYNuu+02FS9eXEuWLFG+fPncenxO/9aePXu2zpw54zxCG8ir2HfOuzgV0c8FBARoxIgReuCBB9SpUyc9+OCDOn78uJKSkrI8xPL+++/XRx99pO3btyshISHb550/f77Gjx+v9u3bKyEhQRcuXNBPP/2kN954Q+XKldMDDzzgHPvQQw8pJiZG9evX1w033KC///5bn332mWbNmqWnnnrK5VDKw4cPa+XKlZKk3377TZK0cOFCxcfHKz4+XomJibm1agBb8FTGJemZZ55RtWrVVKRIEe3Zs0eTJk3SunXrtGDBApdTC7t166aSJUuqbt26KliwoLZt26bXXntN//d//6cpU6bk9iIDtuXJPEvSuXPnNH36dDVq1Mh59GVWFi5cqNOnT+vkyZOSpM2bN2v27NmSLp4OERERcY1LCNiPp3K7detW3XbbbZKkl156Sdu2bdO2bduc88uWLev8Gzqnf2vv3r1b3bp1U5cuXVSuXDk5HA6tXLlSb7zxhm688UaXv9+BvIh95zzMh9f3QhYuvwBehgkTJpjy5cubkJAQU6FCBTNp0iTTq1evTBfA69WrV44uOrdlyxZz9913m4SEBBMWFmbCwsJMpUqVzFNPPWWOHDniMnbSpEnmlltuMQULFjRBQUEmLi7OJCYmmmnTpmV63uXLlxtJWf4kJiZeyyoBbMVbGTfGmH79+pmSJUuakJAQU7BgQXPXXXeZjRs3Zho3atQoU7NmTRMbG2sCAwNNfHy86dSpk/nxxx+vZ1EB2/Nmno0x5pNPPjGSzKRJk644LiEhIdttMRelRV7nrdxmvE52P5MnT3aOzenf2kePHjWdOnUypUqVMuHh4SYkJMSUL1/eDB482Bw/fvx6VgtgSew7I4PDmEuO0QMAAAAAAAAsgmtsAQAAAAAAwJJobAEAAAAAAMCSaGwBAAAAAADAkmhsAQAAAAAAwJJobAEAAAAAAMCSaGwBAAAAAADAkmhs+UB6erqioqI0aNAgX5dyVadOndLAgQNVtGhRhYWFqWbNmpo5c+Y1PdeECRPkcDgUFRWV5fxffvlFHTt2VNGiRRUREaFKlSrphRde0JkzZ65nEQCPymt5XrVqlVq3bq18+fIpPDxc5cuX14gRI1zGrFixQg6HI8uftWvX5uYiAbmKPGfOs8T2GfaRVzJOZmEneSW3kvTjjz+qZcuWio6OVlRUlJo1a6YffvjhusfmBUG+LiAv+v3333X69GnVq1fP16Vc1Z133qnk5GSNHj1aFSpU0PTp09W1a1elp6erW7duOX6e//73v3ryySdVtGhRnThxItP8zZs3q1GjRqpYsaLeeOMNFSxYUN99951eeOEF/fzzz/ryyy9zc7GAXJOX8jx9+nT16NFD//rXvzR16lRFRUVp+/bt2r9/f5bjR44cqWbNmrlMq1q1aq4sC+AJ5Dlzntk+w07yQsbJLOwmL+RWkpKTk9WkSRPVr19f06ZNkzFGr7zyipo3b67ly5erYcOG1zQ2zzDwugkTJhhJ5q+//vJ1KVe0YMECI8lMnz7dZXqLFi1M0aJFTWpqao6fq23btqZdu3amV69eJjIyMtP8Z555Jst18tBDDxlJ5ujRo9e2EICH5ZU879u3z0RGRpp+/fpd9bWWL19uJJnPPvvsumoGvI08Z8b2GXaSFzJOZmE3eSG3xhjTsmVLc8MNN5jTp087p6WkpJiCBQuaRo0aXfPYvIJTET1s/PjxqlatmsLCwlS1alV98803+vHHH5UvXz6VLVvW1+Vd0RdffKGoqCh17tzZZXqfPn20f/9+rVu3LkfP8/HHH2vlypV69913sx0THBwsSYqNjXWZHhcXp4CAAIWEhLhZPZD78nKeJ0yYoNOnT2vIkCGeLBPwGvKcszyzfYZV5dWMk1lYWV7NrST98MMPatq0qSIiIpzToqOj1aRJE61evVoHDhy4prF5BY0tDxo4cKAeffRRdezYUQsXLlT//v3Vq1cvLVy4UHXr1vXIaxpjlJqamqOfq9m0aZMqV66soCDXM1arV6/unH81hw4d0sCBAzV69GgVL14823G9evVSXFyc+vXrpx07dujkyZOaP3++PvjgA/Xv31+RkZFXfS3Ak/J6nr/77jvlz59ff/zxh2rWrKmgoCAVKlRIffv2VUpKSpaP6d+/v4KCghQTE6OWLVtq1apVOVxywLPIc87zzPYZVpSXM05mYVV5ObeS9M8//yg0NDTT9Ixpv/322zWNzTN8eryYjc2ePdtIMjNnznSZPnLkSCPJ/Oc//zHGGLNt2zYTGBhozp496zLu3Llzpnfv3qZ48eImOjraNGjQwPzwww9Xfd2MU4By8rNz584rPlf58uVNy5YtM03fv3+/kWRGjhx51Xruuusu06hRI5Oenm6MMdmeimiMMVu2bDGVKlVyqfHRRx91PhbwFfJsTMWKFU1YWJiJjo42I0eONMuXLzevvPKKCQ8PN40bN3bJ6fr1681jjz1mvvjiC/Pdd9+ZSZMmmcqVK5vAwECzaNGiqy434Enk2b08G8P2GdZCxsksrIfcGlOzZk1ToUIFk5aW5px24cIFU6ZMmUynOLozNq/g4vEeMmLECNWrV0/33HOPy/QqVapIkrPrvHHjRlWsWFFhYWEu41JTU1W6dGn98MMPKl68uKZNm6b27dtrz549LoccXq5OnTpKTk7OUY1Fixa96hiHw3FN8yRpzpw5+uqrr/TLL79cdeyuXbvUrl073XDDDZo9e7bi4+O1bt06vfjiizp16pQmTpx41VoBTyHPF+9Ic+7cOQ0bNkxPP/20JKlp06YKCQnRwIEDtXTpUt12222SpFq1aqlWrVrOx95yyy3q1KmTqlWrpsGDB6tly5Y5WSTAI8ize3lm+wyryesZJ7OworyeW0n697//rfvvv18DBgzQM888o/T0dA0fPly7d++WJAUEBFzT2DzD1501Ozpw4ICRZF5//fVM895++20jyezdu9cYY8zzzz9vunbtmqPnzZcvn9mwYcMVx6Snp5sLFy7k6OdqbrrpJlOvXr1M0zdt2mQkmQ8++CDbx548edLccMMNZtCgQebYsWPOn65du5rIyEhz7Ngxc+rUKef4e+65xxQqVMhlmjHGTJo0yUgyK1asuGq9gCeQ5/89XpJZv369y/StW7caSebll1++ag19+/Y1ksyZM2euOhbwBPL8v8fnNM9sn2ElZJzMwnrI7f+MHj3aREVFOY8Sa9iwoRkyZIiRZL7//vtrHpsX5MFWnuft27dPklSkSJFM86ZPn67ChQs7rzf166+/Os+7vZI//vhDZ8+evepF81auXKng4OAc/ezateuKz1WtWjVt2bIl0znFGefsVq1aNdvH/v333/q///s/vfbaa8qXL5/zZ8aMGTp9+rTy5cun7t27O8dv2LBBVapUyXTef8ZtXXNyPS/AE8jzRdktlzFGUs7+Zyhj7NX+xwrwFPJ8kTt5ZvsMKyHjZBbWQ27/Z8iQIfr777/122+/adeuXVq9erWOHTumyMhI1alT55rH5gWciugB8fHxki5uOC49nHL27NlavXq12rZt65y2ceNGPfzww1d8vjNnzqhHjx569tlnFRUVdcWxuXk4ZadOnTR+/HjNmTPHZTk++ugjFS1aVA0aNMj2sYULF9by5cszTR89erRWrlyphQsXqmDBgi61bNq0SadOnXJZxjVr1kjSFS88D3gSeb7orrvu0ocffqiFCxe6nGb49ddfS5JuuummKz7+2LFjmj9/vmrWrJnp8HHAW8jzRe7kme0zrISMk1lYD7l1FRoa6myC7dmzR7NmzdKDDz6o8PDw6xprez4+YsyW0tPTTb169UxkZKQZN26cWb58uRk+fLjJnz+/kWSGDx9ujDHmxIkTxuFwmP/+97/ZPtc///xj2rRpY3r27OmTCz62aNHC5MuXz3z44Ydm2bJl5sEHHzSSzMcff+wybsWKFSYwMNC5bNnJ7uLxX375pXE4HOamm24ys2bNMkuXLjUvvfSSiYqKMlWqVDHnz5/P1eUCcoo8/0+7du1MaGioGTFihFmyZIkZNWqUCQsLM23btnUZ17VrVzNkyBDz2WefmeXLl5sPP/zQVKxY0QQFBZklS5Z4fDmB7JDn/8lpntk+w0rIOJmF9ZDbi3777TeTlJRk5s+fb5YsWWLGjBljChYsaOrWrWtOnjzp8nh3xuYVNLY8ZOfOnaZVq1YmKirKxMXFmXbt2pmJEycaSWbBggXGGGO+//57U6BAgWyfIy0tzXTp0sW0b98+R+f1esLJkyfNo48+agoXLmxCQkJM9erVzYwZMzKNy7ijxLBhw674fFe6K+KyZcvM7bffbgoXLmzCw8NNhQoVzKBBg8zff/+dG4sCXDPyfNGZM2fMkCFDTIkSJUxQUJApWbKkGTp0qDl37pzLuFGjRpmaNWua2NhYExgYaOLj402nTp3Mjz/+6MnFA3KEPF+U0zwbw/YZ1kLGySysh9xevM5lkyZNTP78+U1ISIgpV66cefbZZzNdL8/dsXmFw5j/f0EFeN27776rTz/9VIsWLXJOCwgIUEhIiCTpwQcf1LZt27Ro0SJO3QH8HHkG7IM8A/ZGxgHrIbe4Ei4e70O//vqrVq5cqfDwcOfPXXfdJUnavXu3JkyYoHXr1qlgwYKKiopSVFSUvv/+ex9XDSAr5BmwD/IM2BsZB6yH3OJKOGILAAAAAAAAlsQRWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALAkGlsAAAAAAACwpCBfFyBJ6enp2r9/v6Kjo+VwOHxdDuBRxhidPHlSRYsWVUCA/XrL5Bl5CXkG7MHuWZbIM/IOu+eZLCMvyWme/aKxtX//fpUoUcLXZQBetXfvXhUvXtzXZeQ68oy8iDwD9mDXLEvkGXmPXfNMlpEXXS3PftHYio6OliT9+ecW57+RtYiIaJ05c9LXZdiWN9bvyZMnVaFCZdt+1smzZ5B9/0SecSlyal12z7JEnj2BzPsnu+eZLHsOmXafp9dZTvPsF42tjEMoo6OjFRMT4+Nq/FtERLSCgjjk1FO8uX7teugwefYMsu/fyDMkcmoHds2yRJ49gcz7N7vmmSx7Dpl2n7fW2dXybL+TjgEAAAAAAJAn0NgCAAAAAACAJdHYAgAAAAAAgCXR2AIAAAAAAIAl0dgCAAAAAACAJdHYAgAAAAAAgCXR2AIAAAAAAIAl0dgCAAAAAACAJdHYAgAAAAAAgCUF+boAd0R8meDrEnwrKFrqvNtlUtK0ZB8VYz+hwYEacV+ir8vIM/J8nt2RRfYBf0Ke5dc55W+FHEg95+sK/AZ5ziE/zjwgkWW3WTjTvtrO+9P+M0dsAQAAAAAAwJJobAEAAAAAAMCSaGwBAAAAAADAkmhsAQAAAAAAwJJobAEAAAAAAMCSaGwBAAAAAADAkmhsAQAAAAAAwJJobAEAAAAAAMCSaGwBAAAAAADAkoJ8XYA7znTY7esSfC7ist+TetTzSR3A9SLP7rk8+4A/Ic8X+WtO+Vvh6lJSUvTqAF9X4R/Ic875a+YBiSxfC6tmmu08R2wBAAAAAADAoix1xJYkRXyZ4OsSfCcoWupsz8570rRkX5eg0OBAjbgv0ddl5Dl5OtM5lU32/SE3eV7qOV9X4HfybKZtvI0G3JUnvgd8mHm2/1fBtvm65In8ZsXPtuNWyLk/7T9zxBYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACwpyNcFuOtMh92+LsGnInxdgIck9ajn6xLgI3k90zmVVfbJje+lpKTo1QG+rsK/5OVM23UbDbgrr3wP+CrzbP+vjG3z9ckr+c2KP23Hybl7OGILAAAAAAAAlmS5I7auJOLLBF+X4FlB0VJna3TQk6Yl+7oEt4UGB2rEfYm+LgP/n+3z7A4PZd+KOfU7qed8XYEl2TLffrCNJtPXgSz7hKW/CzyYebJ8ncgzrsOomet1/kKar8uwBH/af+aILQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWBKNLQAAAAAAAFgSjS0AAAAAAABYEo0tAAAAAAAAWJLDGGN8XURKSopiY2N14MA+xcTE+LocvxYREa0zZ076ugzb8sb6TUlJUZEixXXixAlbft7Js2eQff9EnnEpcmpdds+yRJ49gcz7J7vnmSx7Dpl2n6fXWU7zzBFbAAAAAAAAsKQgXxcAVxFfJmQ/Myha6rzbe8XkUaNmrtf5C2lK6lHP16Ugj7hi7iWyD/gBcgrY21UzfjkyDwB+gyO2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSUG+LgCuznTYfcX5EV6qIy8b2qW2r0tAHnO13EtkH/A1cgrYW04yfjkyDwD+gSO2AAAAAAAAYEk0tgAAAAAAAGBJnIrohyK+TMh6RlC01Nn9w6TzoqRpyW4/JjQ4UCPuS/RANcDVZZt7iewDfoRtNGBvV9weX4rMA8jjRs1c7zf7zxyxBQAAAAAAAEuisQUAAAAAAABLorEFAAAAAAAAS6KxBQAAAAAAAEuisQUAAAAAAABLorEFAAAAAAAAS6KxBQAAAAAAAEuisQUAAAAAAABLCvJ1AcjsTIfd2c6L8GIdVpbUo56vSwDccqXcS2Qf8BdsowF7u9r2+FJkHkBeNrRLbV+X4MQRWwAAAAAAALAkGlsAAAAAAACwJE5F9EMRXyZkPSMoWuqc88OjAVgL2QesxSWz5BSwJbbNAJC1UTPXa8R9ib4uQxJHbAEAAAAAAMCiaGwBAAAAAADAkmhsAQAAAAAAwJJobAEAAAAAAMCSaGwBAAAAAADAkmhsAQAAAAAAwJJobAEAAAAAAMCSaGwBAAAAAADAkoJ8XQAyO9Nhd7bzIrxYBwDvIvuAtVyeWXIK2A/bZgDI2tAutX1dghNHbAEAAAAAAMCSaGwBAAAAAADAkjgV0c9FfJnwv1+CoqXO2R8ODcA+yD7g/8gpkLeQeQC4KGlaskKDAzXivkRflyLpGo7Y+uijj7RgwQLn74MHD1ZcXJwaNWqk3bv5cgeshDwD9kCWAfsgz4B9kGfAO9xubI0cOVLh4eGSpDVr1ujtt9/WK6+8ooIFC+rxxx/P9QIBeA55BuyBLAP2QZ4B+yDPgHe4fSri3r17Va5cOUnS3Llzdffdd+uhhx5S48aN1bRp09yuD4AHkWfAHsgyYB/kGbAP8gx4h9tHbEVFRenIkSOSpMWLF+u2226TJIWFhens2bO5Wx0AjyLPgD2QZcA+yDNgH+QZ8A63j9hq0aKFHnjgAdWqVUt//vmn2rRpI0n6/fffVapUqdyuD4AHkWfAHsgyYB/kGbAP8gx4h9tHbL3zzjtq2LChDh8+rDlz5qhAgQKSpJ9//lldu3bN9QIBeA55BuyBLAP2QZ4B+yDPgHe4fcRWXFyc3n777UzThw8fnisFAfAe8gzYA1kG7IM8A/ZBngHvcPuILUn6/vvvde+996pRo0b673//K0maNm2aVq1alavFAfA88gzYA1kG7IM8A/ZBngHPc7uxNWfOHLVs2VLh4eFav369zp8/L0k6efKkRo4cmesF5nVnOuz+30+bTb4uBzZDnv0X2Yc7yLJvkFN4Ann2X2Qe7iLPsKukHvU0tEttX5fh5HZj68UXX9T777+v8ePHKzg42Dm9UaNGWr9+fa4WB8CzyDNgD2QZsA/yDNgHeQa8w+3G1tatW9WkSZNM02NiYnT8+PHcqAmAl5BnwB7IMmAf5BmwD/IMeIfbF48vUqSI/vrrr0y3J121apXKlCmTW3XhMhFfJkhB0VLn3b4uxfZGzVyv8xfSspyX1KOel6vxLPLs/8g+coIs+07ElwkX/0FOkUvIs38j83AHeUZekLH/7Mt9ZbeP2Hr44Yf12GOPad26dXI4HNq/f78++eQTPfnkk3rkkUc8USMADyHPgD2QZcA+yDNgH+QZ8A63j9gaPHiwTpw4oWbNmuncuXNq0qSJQkND9eSTT2rAgAGeqBGAh5BnwB7IMmAf5BmwD/IMeIdbja20tDStWrVKgwYN0jPPPKPNmzcrPT1dVapUUVRUlKdqBOAB5BmwB7IM2Ad5BuyDPAPe41ZjKzAwUC1bttSWLVuUP39+1a1b11N1AfAw8gzYA1kG7IM8A/ZBngHvcfsaW9WqVdOOHTs8UQsALyPPgD2QZcA+yDNgH+QZ8A63G1svvfSSnnzySc2fP18HDhxQSkqKyw8A6yDPgD2QZcA+yDNgH+QZ8A63Lx7fqlUrSVL79u3lcDic040xcjgcSktLy73qAHgUeQbsgSwD9kGeAfsgz4B3uN3YWr58uSfqAOAD5BmwB7IM2Ad5BuyDPAPe4XZjKzEx0RN14CrOdNgtSYrwcR15wdAutX1dgteQZ/9H9pETZNl3MjIqkVPkDvLs38g83EGekRf4w/6z242t77777orzmzRpcs3FAPAu8gzYA1kG7IM8A/ZBngHvcLux1bRp00zTLj1fmPOEAesgz4A9kGXAPsgzYB/kGfAOt++KeOzYMZefQ4cOadGiRapXr54WL17siRohKeLLBEUsqOrrMmwraVqyRs1c7+syvI48+z+yj5wgy74T8WUCOUWuIs/+j8wjp8gz8oJRM9craVqyT2tw+4it2NjYTNNatGih0NBQPf744/r5559zpTAAnkeeAXsgy4B9kGfAPsgz4B1uH7GVnfj4eG3dujW3ng6AD5FnwB7IMmAf5BmwD/IM5C63j9jauHGjy+/GGB04cECjR49WjRo1cq0wAJ5HngF7IMuAfZBnwD7IM+Adbje2atasKYfDIWOMy/SbbrpJkyZNyrXCAHgeeQbsgSwD9kGeAfsgz4B3uN3Y2rlzp8vvAQEBio+PV1hYWK4VBcA7yDNgD2QZsA/yDNgHeQa8w+1rbK1cuVKFCxdWQkKCEhISVKJECYWFhemff/7R1KlTPVEjAA8hz4A9kGXAPsgzYB/kGfAOtxtbffr00YkTJzJNP3nypPr06ZMrRQHwDvIM2ANZBuyDPAP2QZ4B73C7sWWMkcPhyDR93759Wd7OFID/Is+APZBlwD7IM2Af5BnwjhxfY6tWrVpyOBxyOBxq3ry5goL+99C0tDTt3LlTrVq18kiRkM502C1JivBxHXaV1KOer0vwKvJsHWQfV0KWfS8joxI5xfUhz9bBthlXQ56RlwztUtvXJeS8sdWxY0dJ0oYNG9SyZUtFRUU554WEhKhUqVK66667cr1AALmPPAP2QJYB+yDPgH2QZ8C7ctzYGjZsmCSpVKlSuueee7iTA2Bh5BmwB7IM2Ad5BuyDPAPelePGVoZevXp5og5cRcSXCVJQtNR599UH47qMmrle5y+kXfPjrXRaI3n2f2QfOUGWfYucIjeRZ/9H5pFT5Bl5Qcb+sy/3g91ubKWlpen111/Xp59+qj179uiff/5xmX/06NFcKw6AZ5FnwB7IMmAf5BmwD/IMeIfbd0UcPny4xo4dq3/96186ceKEnnjiCd15550KCAhQUlKSB0oE4CnkGbAHsgzYB3kG7IM8A97hdmPrk08+0fjx4/Xkk08qKChIXbt21YQJE/T8889r7dq1nqgRgIeQZ8AeyDJgH+QZsA/yDHiH242tgwcPqlq1apKkqKgonThxQpLUtm1bLViwIHerA+BR5BmwB7IM2Ad5BuyDPAPe4XZjq3jx4jpw4IAkqVy5clq8eLEkKTk5WaGhoblbHQCPIs+APZBlwD7IM2Af5BnwDrcbW506ddLSpUslSY899piee+45lS9fXj179tR9992X6wUC8BzyDNgDWQbsgzwD9kGeAe9w+66Io0ePdv777rvvVvHixbV69WqVK1dO7du3z9XiAHgWeQbsgSwD9kGeAfsgz4B3uN3YutxNN92km266KTdqAeBj5BmwB7IM2Ad5BuyDPAOecU2NrWnTpun999/Xzp07tWbNGiUkJOiNN95Q6dKl1aFDh9yuEZLOdNgtSYrwcR15wdAutX1dgleRZ/9G9pFTZNl3yClyG3n2b2Qe7iDPsDt/2H92+xpb7733np544gm1bt1ax48fV1pamiQpLi5Ob7zxRm7XB8CDyDNgD2QZsA/yDNgHeQa8w+3G1ltvvaXx48frmWeeUWBgoHN63bp19dtvv+VqcQA8izwD9kCWAfsgz4B9kGfAO9w+FXHnzp2qVatWpumhoaE6ffp0rhSFrEUsqCp13u3rMmxv1Mz1On8hTUk96vm6FI8jz9ZA9nE1ZNm3Ir5MkIKiySlyBXn2f2QeOUWekRdk7D9L8tk+tNtHbJUuXVobNmzINH3hwoWqUqVKbtQEwEvIM2APZBmwD/IM2Ad5BrzD7SO2nnrqKfXv31/nzp2TMUY//vijZsyYoVGjRmnChAmeqBGAh5BnwB7IMmAf5BmwD/IMeIfbja0+ffooNTVVgwcP1pkzZ9StWzcVK1ZM48aNU5cuXTxRIwAPIc+APZBlwD7IM2Af5Bnwjhydijhv3jxduHDB+fuDDz6o3bt369ChQzp48KD27t2r+++/32NFAsg95BmwB7IM2Ad5BuyDPAPel6PGVqdOnXT8+HFJUmBgoA4dOiRJKliwoAoVKuSx4gDkPvIM2ANZBuyDPAP2QZ4B78tRYys+Pl5r166VJBlj5HA4PFoUAM8hz4A9kGXAPsgzYB/kGfC+HF1jq2/fvurQoYMcDoccDocKFy6c7di0tLRcKw5A7iPPgD2QZcA+yDNgH+QZ8L4cNbaSkpLUpUsX/fXXX2rfvr0mT56suLg4D5cGwBPIM2APZBmwD/IM2Ad5Brwvx3dFrFSpkipVqqRhw4apc+fOioiI8GRdADyIPAP2QJYB+yDPgH2QZ8C7HMYY4+siUlJSFBsbqwMH9ikmJsbX5fi1iIhonTlz0tdl2JY31m9KSoqKFCmuEydO2PLzTp49g+z7J/KMS5FT67J7liXy7Alk3j/ZPc9k2XPItPs8vc5ymuccXTweAAAAAAAA8Dc5PhURvhexoKrUebevy7CtUTPXa8R9ib4uA8iE7AP+LeLLBCkompwCeQjbZgB5TdK0ZJffQ4MD/Wb/mSO2AAAAAAAAYEk0tgAAAAAAAGBJudbY+r//+z+98MILufV0AHyIPAP2QJYB+yDPgH2QZyB35Vpj6+DBgxo+fHhuPR0AHyLPgD2QZcA+yDNgH+QZyF05vnj8xo0brzh/69at110MAO8gz4A9kGXAPsgzYB/kGfCuHDe2atasKYfDIWNMpnkZ0x0OR64WB8AzyDNgD2QZsA/yDNgHeQa8K8eNrQIFCujll19W8+bNs5z/+++/q127drlWGADPIc+APZBlwD7IM2Af5Bnwrhw3turUqaP9+/crISEhy/nHjx/PsiMNwP+QZ8AeyDJgH+QZsA/yDHhXjhtbDz/8sE6fPp3t/JIlS2ry5Mm5UhQAzyLPgD2QZcA+yDNgH+QZ8C6H8YNWcUpKimJjY3XgwD7FxMT4uhy/FhERrTNnTvq6DNvyxvpNSUlRkSLFdeLECVt+3smzZ5B9/0SecSlyal12z7JEnj2BzPsnu+eZLHsOmXafp9dZTvMc4LEKAAAAAAAAAA9yq7F19uxZrVq1Sps3b84079y5c5o6dWquFYbMIhZU9XUJecKomeuVNC3Z12V4HHkG7IEs+we20cgN5Nk6yDyuhjwjr8jYf770x9ty3Nj6888/VblyZTVp0kTVqlVT06ZNdeDAAef8EydOqE+fPh4pEkDuIs+APZBlwD7IM2Af5Bnwrhw3toYMGaJq1arp0KFD2rp1q2JiYtS4cWPt2bPHk/UB8ADyDNgDWQbsgzwD9kGeAe/KcWNr9erVGjlypAoWLKhy5cpp3rx5uuOOO3TLLbdox44dnqwRQC4jz4A9kGXAPsgzYB/kGfCuoJwOPHv2rIKCXIe/8847CggIUGJioqZPn57rxQHwDPIM2ANZBuyDPAP2QZ4B78pxY6tSpUr66aefVLlyZZfpb731lowxat++fa4XB8AzyDNgD2QZsA/yDNgHeQa8K8enInbq1EkzZszIct7bb7+trl27yhiTa4UB8BzyDNgDWQbsgzwD9kGeAe9yGD9IVEpKimJjY3XgwD7FxMT4uhy/FbGgqtR5t86cOenrUmwrIiJaz01aqfMX0pTUo55HXiMlJUVFihTXiRMnbPl5J8+eERERTfb9EHlGBrbR1mb3LEvkObeRef9l9zyTZc/h7233Xbr/fKnc2pfOaZ5zfMQWAAAAAAAA4E9obAEAAAAAAMCScnzxePjemTabFOHrIvKAoV1q+7oEAIDFsI0G8hYyDwAX+cP+M0dsAQAAAAAAwJI4YstCMi5SCc8aNXN9povfucNTF50HAPgvttEAACAvym7/2Zv7xdfU2Nq6daveeustbdmyRQ6HQ5UqVdK///1vVaxYMbfrA+Bh5BmwB7IM2Ad5BuyDPAOe5/apiLNnz1bVqlX1888/q0aNGqpevbrWr1+vqlWr6rPPPvNEjQA8hDwD9kCWAfsgz4B9kGfAO9w+Ymvw4MEaOnSoXnjhBZfpw4YN05AhQ9S5c+dcKw6AZ5FnwB7IMmAf5BmwD/IMeIfbR2wdPHhQPXv2zDT93nvv1cGDB3OlKADeQZ4BeyDLgH2QZ8A+yDPgHW43tpo2barvv/8+0/RVq1bplltuyZWiAHgHeQbsgSwD9kGeAfsgz4B3uH0qYvv27TVkyBD9/PPPuummmyRJa9eu1Weffabhw4dr3rx5LmMB+C/yDNgDWQbsgzwD9kGeAe9wGGOMOw8ICMjZQV4Oh0NpaZlv+ZiVlJQUxcbG6sCBfYqJiXGnnDwl41biZ86c9HUpthUREa3nJq3M8nalOXW125qmpKSoSJHiOnHihM8/7+TZOiIiosm+H/KXPHsiyxJ5dgfbaGvzlyxL5NlK2Db7J7vnmSx7Dpl235X2n6+2X5wTOc2z20dspaenX1dhAPwHeQbsgSwD9kGeAfsgz4B3uH2NLQAAAAAAAMAfuH3EliStXLlSY8aM0ZYtW+RwOFS5cmU99dRTXADPw8602aQIXxeRBwztUtvXJXgVeQbsgSz7Ftto5CbyDNgHeYbd+cP+s9tHbH388ce67bbbFBERoUcffVQDBgxQeHi4mjdvrunTp3uiRgAeQp4BeyDLgH2QZ8A+yDPgHW5fPL5y5cp66KGH9Pjjj7tMHzt2rMaPH68tW7a4XQQXwMsZLkybu5KmJbv8HhocqBH3JXp8/frTBS3Js3VwMUv/5C959kSWJfLsDrbR1uYvWZbIs5WwbfZPds8zWfYcMu2+q9187XovIJ/TPLt9xNaOHTvUrl27TNPbt2+vnTt3uvt0AHyIPAP2QJYB+yDPgH2QZ8A73G5slShRQkuXLs00fenSpSpRokSuFAXAO8gzYA9kGbAP8gzYB3kGvCPHF4+/7777NG7cOA0aNEiPPvqoNmzYoEaNGsnhcGjVqlWaMmWKxo0b58laAeQS8gzYA1kG7IM8A/ZBngHvynFj66OPPtLo0aPVr18/FS5cWK+99po+/fRTSRfPHZ41a5Y6dOjgsUIB5B7yDNgDWQbsgzwD9kGeAe/KcWPr0mvMd+rUSZ06dfJIQQA8jzwD9kCWAfsgz4B9kGfAu9y6xpbD4fBUHQC8jDwD9kCWAfsgz4B9kGfAe3J8xJYkVahQ4aoBPXr06HUVBMA7yDNgD2QZsA/yDNgHeQa8x63G1vDhwxUbG+upWgB4EXkG7IEsA/ZBngH7IM+A97jV2OrSpYsKFSrkqVoAeBF5BuyBLAP2QZ4B+yDPgPfkuLHFOcK+d6bNJkX4uggbSepRz9cl+Ax5BuyBLPsPttG4XuQZsA/yjLxkaJfavi4h5xePv/TODgCsjTwD9kCWAfsgz4B9kGfAu3J8xFZ6eron6wB8KmlaskKDAzXivkRfl+IV5BmwB7IM2Ad5BuyDPMOKkqYluzXen/afc3zEFgAAAAAAAOBPaGwBAAAAAADAkmhsAQAAAAAAwJJobAEAAAAAAMCSaGwBAAAAAADAkmhsAQAAAAAAwJJobAEAAAAAAMCSaGwBAAAAAADAkmhsAQAAAAAAwJKCfF0A4A+SetTzdQkAAAAAAPiElfeJOWILAAAAAAAAlsQRW8BlRs1cr/MX0iRZu2sNAAAAAIAnXbr/nFO5vZ/NEVsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALCkIF8XAPiboV1q+7oEAAAAAAD8nj/sP3PEFgAAAAAAACyJI7aAy4yauV7nL6Rlmp7Uo54PqgEAAAAAwD9lt/+cE7m1j80RWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALAkGlsAAAAAAACwJBpbAAAAAAAAsKQgXxcA+JuhXWr7ugQAAAAAAPyeP+w/c8QWAAAAAAAALIkjtgBJSdOSFRocqBH3Jfq6FACAhUUsqKozbTb5ugwAAACvGDVzvc5fSLumxyb1qJcrNXDEFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALCnI1wUA/iCpRz1flwAAsIEzbTb5ugQAAACvGdqltq9L4IgtAAAAAAAAWBNHbAGXGTVzvc5fSHP7cRz1BQCIWFCVo7YAAAC8iCO2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSTS2AAAAAAAAYEk0tgAAAAAAAGBJNLYAAAAAAABgSUG+LgDwN0O71PZ1CQAAizrTZpOvSwAAAMhTOGILAAAAAAAAlkRjCwAAAAAAAJbEqYgWFLGgqpR6Umc67PZ1KbY0auZ6nb+Q5jItqUc9H1UD/E9G9iWRf8BPXZrT3EbuAf9zPZkn0wCQOzhiCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWFOTrAuC+M202+boEWxvapbavSwCyRPYB/0dOgbyFzAOA73HEFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsicYWAAAAAAAALInGFgAAAAAAACyJxhYAAAAAAAAsKcjXBUiSMUaSdPLkSR9X4v9SU43OnGE9eYo31m/G5zzjc2835NkzyL5/Is+4FDm1LrtnWSLPnkDm/ZPd80yWPYdMu8/T6yynefaLxlZGsRUqVPZxJYD3nDx5UrGxsb4uI9eRZ+RFR44cIc+ADdg1yxJ5Rt5j1zyTZeRFV9t3dhg/aGWnp6dr//79io6OlsPh8HU5fislJUUlSpTQ3r17FRMT4+tybMdb69cYo5MnT6po0aIKCLDf2cDkOfeRff914sQJlSxZUseOHVNcXJyvy8l15DnnyKm12T3LEnnObWTef9k9z2TZM8i0+7yxznK67+wXR2wFBASoePHivi7DMmJiYgibB3lj/drxf48ykGfPIfv+y45Naok8Xwtyam12zbJEnj2FzPsvu+aZLHsWmXafp9dZTvad7Zl2AAAAAAAA2B6NLQAAAAAAAFgSjS0LCQ0N1bBhwxQaGurrUmyJ9Qt/xWfTf/HeIAOfBWvj/YO7+Mz4L94bXAs+N+7zp3XmFxePBwAAAAAAANzFEVsAAAAAAACwJBpbAAAAAAAAsCQaWwAAAAAAALAkGlt+pHfv3urYsaOvy7CFpk2bauDAgZKkUqVK6Y033vBpPcCVkH3A/5FTIG8h8wDyGivvQwf5ugDA05KTkxUZGenrMgAAAAAA8HtW24emsQXbi4+P93UJAAAAAABYgtX2oTkV0Qdmz56tatWqKTw8XAUKFNBtt92m06dPO+ePGTNGRYoUUYECBdS/f39duHDBOe/jjz9W3bp1FR0drcKFC6tbt246dOiQc/6KFSvkcDi0YMEC1ahRQ2FhYWrQoIF+++03ry6jP7n8MEqHw6EPPvhAbdu2VUREhCpXrqw1a9bor7/+UtOmTRUZGamGDRtq+/btLs/z1VdfqU6dOgoLC1OZMmU0fPhwpaamenlpYGVk3zoWLVqkm2++WXFxcSpQoIDatm3r8p2wb98+denSRfnz51dkZKTq1q2rdevWaevWrXI4HPrjjz9cnm/s2LEqVaqUjDHeXhS4iZzaD3nGlZB5ayHPcBefmWtjtX1oGlteduDAAXXt2lX33XeftmzZohUrVujOO+90BmP58uXavn27li9fro8++khTpkzRlClTnI//559/NGLECP3666+aO3eudu7cqd69e2d6naeeekpjxoxRcnKyChUqpPbt27tsiPO6ESNGqGfPntqwYYMqVaqkbt266eGHH9bQoUP1008/SZIGDBjgHP/NN9/o3nvv1aOPPqrNmzfrgw8+0JQpU/TSSy/5ahFgMWTfWk6fPq0nnnhCycnJWrp0qQICAtSpUyelp6fr1KlTSkxM1P79+zVv3jz9+uuvGjx4sNLT01WxYkXVqVNHn3zyicvzTZ8+Xd26dZPD4fDREiEnyKk9kWdkh8xbD3mGu/jM5B6/3oc28Kqff/7ZSDK7du3KNK9Xr14mISHBpKamOqd17tzZ3HPPPdk+348//mgkmZMnTxpjjFm+fLmRZGbOnOkcc+TIERMeHm5mzZqVi0vi3xITE81jjz1mjDEmISHBvP766855ksyzzz7r/H3NmjVGkpk4caJz2owZM0xYWJjz91tuucWMHDnS5TWmTZtmihQp4pkFgO2QfWs7dOiQkWR+++0388EHH5jo6Ghz5MiRLMeOHTvWlClTxvn71q1bjSTz+++/e6tcXCNymjeQZ2Qg89ZHnuEuPjPZs/I+NEdseVmNGjXUvHlzVatWTZ07d9b48eN17Ngx5/wbb7xRgYGBzt+LFCnickjzL7/8og4dOighIUHR0dFq2rSpJGnPnj0ur9OwYUPnv/Pnz6+KFStqy5YtHloq66levbrz3zfccIMkqVq1ai7Tzp07p5SUFEnSzz//rBdeeEFRUVHOnwcffFAHDhzQmTNnvFs8LInsW8v27dvVrVs3lSlTRjExMSpdurSki+t7w4YNqlWrlvLnz5/lY7t06aLdu3dr7dq1kqRPPvlENWvWVJUqVbxWP64NObUn8ozskHnrIc9wF5+Z3OPP+9A0trwsMDBQS5Ys0cKFC1WlShW99dZbqlixonbu3ClJCg4OdhnvcDiUnp4u6eJhlLfffruioqL08ccfKzk5WV988YWki4dCX01ePFwyO5eu54z1ktW0jHWfnp6u4cOHa8OGDc6f3377Tdu2bVNYWJgXK4dVkX1radeunY4cOaLx48dr3bp1WrdunaSL6zs8PPyKjy1SpIiaNWum6dOnS5JmzJihe++91+M14/qRU3siz8gOmbce8gx38ZnJPf68D01jywccDocaN26s4cOH65dfflFISIhzQ3glf/zxh/7++2+NHj1at9xyiypVquTyv0aXyugqS9KxY8f0559/qlKlSrm2DHlN7dq1tXXrVpUrVy7TT0AAMULOkH1rOHLkiLZs2aJnn31WzZs3V+XKlV3+B7969erasGGDjh49mu1zdO/eXbNmzdKaNWu0fft2denSxRulIxeQU3shz7gaMm8d5Bnu4jPjW97ch2aP3MvWrVunkSNH6qefftKePXv0+eef6/Dhw6pcufJVH1uyZEmFhITorbfe0o4dOzRv3jyNGDEiy7EvvPCCli5dqk2bNql3794qWLCgOnbsmMtLk3c8//zzmjp1qpKSkvT7779ry5YtmjVrlp599llflwaLIPvWkS9fPhUoUEAffvih/vrrLy1btkxPPPGEc37Xrl1VuHBhdezYUT/88IN27NihOXPmaM2aNc4xd955p1JSUtSvXz81a9ZMxYoV88WiwE3k1H7IM66EzFsLeYa7+Mz4ljf3oWlseVlMTIy+++47tW7dWhUqVNCzzz6r1157TXfcccdVHxsfH68pU6bos88+U5UqVTR69GiNGTMmy7GjR4/WY489pjp16ujAgQOaN2+eQkJCcntx8oyWLVtq/vz5WrJkierVq6ebbrpJY8eOVUJCgq9Lg0WQfesICAjQzJkz9fPPP6tq1ap6/PHH9eqrrzrnh4SEaPHixSpUqJBat26tatWqafTo0S7XYYmJiVG7du3066+/qnv37r5YDFwDcmo/5BlXQuathTzDXXxmfMub+9CO/3+Fe9jEihUr1KxZMx07dkxxcXG+LgeAl5B9wP+RUyBvIfMA4B0csQUAAAAAAABLorEFAAAAAAAAS+JURAAAAAAAAFgSR2wBAAAAAADAkmhsAQAAAAAAwJJobAEAAAAAAMCSaGwBAAAAAADAkmhs2VxSUpJq1qzp/L13797q2LGjV14LQO4iz4B9kGfAHsgyYB/k2bpobOWygwcP6t///rfKlCmj0NBQlShRQu3atdPSpUtz7TWaNm2qgQMH5mjsk08+mauvncHhcGju3LleeS3AV8gzeYZ9kGfyDHsgy2QZ9kGeyXNuCfJ1AXaya9cuNW7cWHFxcXrllVdUvXp1XbhwQd9884369++vP/74w2u1GGOUlpamqKgoRUVFeeU1vflagKeRZ/IM+yDP5Bn2QJbJMuyDPJPnXGWQa+644w5TrFgxc+rUqUzzjh07ZowxZvfu3aZ9+/YmMjLSREdHm86dO5uDBw86xw0bNszUqFHDTJ061SQkJJiYmBhzzz33mJSUFGOMMb169TKSXH527txpli9fbiSZRYsWmTp16pjg4GCzbNky5/Nl6NWrl+nQoYNJSkoy8fHxJjo62jz00EPm/PnzzjEJCQnm9ddfd6m/Ro0aZtiwYc75l75+QkKCS+0Z0tLSzPDhw02xYsVMSEiIqVGjhlm4cKFz/s6dO40kM2fOHNO0aVMTHh5uqlevblavXu0cs2vXLtO2bVsTFxdnIiIiTJUqVcyCBQvceVuAa0KeyTPsgzyTZ9gDWSbLsA/yTJ5zE6ci5pKjR49q0aJF6t+/vyIjIzPNj4uLkzFGHTt21NGjR7Vy5UotWbJE27dv1z333OMydvv27Zo7d67mz5+v+fPna+XKlRo9erQkady4cWrYsKEefPBBHThwQAcOHFCJEiWcjx08eLBGjRqlLVu2qHr16lnWunTpUm3ZskXLly/XjBkz9MUXX2j48OE5Xtbk5GRJ0uTJk3XgwAHn75cbN26cXnvtNY0ZM0YbN25Uy5Yt1b59e23bts1l3DPPPKMnn3xSGzZsUIUKFdS1a1elpqZKkvr376/z58/ru+++02+//aaXX36ZzjY8jjxnRp5hVeQ5M/IMKyLLmZFlWBV5zow8XyefttVsZN26dUaS+fzzz7Mds3jxYhMYGGj27NnjnPb7778bSebHH380xlzs3EZERDi7zMYY89RTT5kGDRo4f09MTDSPPfaYy3NndJ3nzp3rMj2rrnP+/PnN6dOnndPee+89ExUVZdLS0owxV+86G2OMJPPFF19c8bWKFi1qXnrpJZcx9erVM4888ogx5n9d5wkTJmRaH1u2bDHGGFOtWjWTlJRkAG8iz+QZ9kGeyTPsgSyTZdgHeSbPuY0jtnKJMUbSxQvDZWfLli0qUaKES5e4SpUqiouL05YtW5zTSpUqpejoaOfvRYoU0aFDh3JUR926da86pkaNGoqIiHD+3rBhQ506dUp79+7N0WvkREpKivbv36/GjRu7TG/cuLHLskpy6Y4XKVJEkpzL++ijj+rFF19U48aNNWzYMG3cuDHXagSyQ55dkWdYGXl2RZ5hVWTZFVmGlZFnV+T5+tHYyiXly5eXw+HI9MG7lDEmy/BePj04ONhlvsPhUHp6eo7qyOpQzpzKqCEgIMD5ZZPhwoUL1/WcGbJaB5cub8a8jOV94IEHtGPHDvXo0UO//fab6tatq7feeuuaagFyijxf+TkzkGdYAXm+8nNmIM/wd2T5ys+ZgSzDCsjzlZ8zA3nOORpbuSR//vxq2bKl3nnnHZ0+fTrT/OPHj6tKlSras2ePS3d38+bNOnHihCpXrpzj1woJCVFaWto11/rrr7/q7Nmzzt/Xrl2rqKgoFS9eXJIUHx+vAwcOOOenpKRo586dLs8RHBx8xRpiYmJUtGhRrVq1ymX66tWr3VpWSSpRooT69u2rzz//XIMGDdL48ePdejzgLvLsijzDysizK/IMqyLLrsgyrIw8uyLP14/GVi569913lZaWpvr162vOnDnatm2btmzZojfffFMNGzbUbbfdpurVq6t79+5av369fvzxR/Xs2VOJiYk5OgwyQ6lSpbRu3Trt2rVLf//9d4470hn++ecf3X///dq8ebMWLlyoYcOGacCAAQoIuPhxuPXWWzVt2jR9//332rRpk3r16qXAwMBMNSxdulQHDx7UsWPHsnydp556Si+//LJmzZqlrVu36umnn9aGDRv02GOP5bjWgQMH6ptvvtHOnTu1fv16LVu2zO1wA9eCPLsiz7Ay8uyKPMOqyLIrsgwrI8+uyPP1CfJ1AXZSunRprV+/Xi+99JIGDRqkAwcOKD4+XnXq1NF7770nh8OhuXPn6t///reaNGmigIAAtWrVyu3DA5988kn16tVLVapU0dmzZzN1hK+mefPmKl++vJo0aaLz58+rS5cuSkpKcs4fOnSoduzYobZt2yo2NlYjRozI9BqvvfaannjiCY0fP17FihXTrl27Mr3Oo48+qpSUFA0aNEiHDh1SlSpVNG/ePJUvXz7Htaalpal///7at2+fYmJi1KpVK73++utuLS9wLcizK/IMKyPPrsgzrIosuyLLsDLy7Io8Xx+HufyEUAAAAAAAAMACOBURAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACWRGMLAAAAAAAAlkRjCwAAAAAAAJZEYwsAAAAAAACW9P8AmPr8vnbGUhgAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1500x400 with 5 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "index = [1, 2, 3, 4, 5]\n",
+    "cns.consistency_plot(selection=index, max_features=21)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "cumulative": {
+          "enabled": true
+         },
+         "histnorm": "percent",
+         "hovertemplate": "Top %{x:.0f} features explain at least 90%<br>of the model for %{y:.1f}% of the instances",
+         "hovertext": "none",
+         "marker": {
+          "color": "rgba(255, 166, 17, 0.9)"
+         },
+         "name": "",
+         "type": "histogram",
+         "x": [
+          9,
+          11,
+          5,
+          12,
+          12,
+          9,
+          13,
+          10,
+          6,
+          7,
+          9,
+          8,
+          11,
+          8,
+          5,
+          3,
+          12,
+          5,
+          7,
+          9,
+          3,
+          3,
+          3,
+          9,
+          8,
+          10,
+          6,
+          10,
+          11,
+          9,
+          12,
+          13,
+          8,
+          12,
+          10,
+          7,
+          12,
+          10,
+          7,
+          6,
+          10,
+          11,
+          9,
+          15,
+          9,
+          3,
+          5,
+          9,
+          11,
+          11,
+          8,
+          10,
+          7,
+          10,
+          3,
+          3,
+          10,
+          6,
+          8,
+          8,
+          3,
+          9,
+          10,
+          6,
+          3,
+          10,
+          3,
+          9,
+          13,
+          6,
+          10,
+          8,
+          8,
+          3,
+          8,
+          10,
+          5,
+          6,
+          9,
+          10,
+          7,
+          10,
+          6,
+          9,
+          8,
+          9,
+          11,
+          7,
+          6,
+          12,
+          7,
+          3,
+          7,
+          3,
+          10,
+          8,
+          7,
+          9,
+          9,
+          5,
+          8,
+          7,
+          3,
+          12,
+          8,
+          8,
+          3,
+          7,
+          12,
+          7,
+          14,
+          8,
+          10,
+          7,
+          7
+         ],
+         "xaxis": "x",
+         "yaxis": "y"
+        },
+        {
+         "cumulative": {
+          "direction": "decreasing",
+          "enabled": true
+         },
+         "histnorm": "percent",
+         "hovertemplate": "Top 5 features explain at least %{x:.0f}%<br>of the model for %{y:.1f}% of the instances",
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "",
+         "type": "histogram",
+         "x": [
+          61.19251870722153,
+          59.87629877325817,
+          94.8261203956573,
+          82.01155768772654,
+          61.41084966922906,
+          63.69331958542608,
+          0,
+          67.17610362932867,
+          55.45404309539386,
+          80.97261227880593,
+          63.47211074144479,
+          65.23900346794144,
+          0,
+          82.11229581300489,
+          97.08459427313399,
+          69.23179237762369,
+          78.81208156259004,
+          94.80986812060506,
+          77.65551955707951,
+          63.468442222720434,
+          89.18961172036433,
+          69.23992154575132,
+          56.04685824816728,
+          44.52568320415509,
+          67.17556575278891,
+          79.50648641832174,
+          71.54596396453582,
+          67.94143110872595,
+          59.07593308298704,
+          66.87994081642384,
+          0,
+          0,
+          63.18963116166425,
+          0,
+          66.02543786162265,
+          75.78033394423827,
+          0,
+          65.77336786941466,
+          75.54927271715854,
+          88.98352637412276,
+          0,
+          65.08716749560435,
+          48.77877145851599,
+          0,
+          57.095542229991295,
+          54.16506774899021,
+          97.20765954187564,
+          60.39410603428781,
+          40.77987450284738,
+          0,
+          65.34068847818162,
+          79.01061189370857,
+          67.52880718506714,
+          79.19508690948885,
+          53.946428406032695,
+          56.1143293348855,
+          72.69242034909573,
+          82.04420580269888,
+          53.66935701331692,
+          69.74822253284935,
+          66.35927026447277,
+          62.82917024396353,
+          66.15292946811931,
+          47.399244295127474,
+          62.094773957321166,
+          73.51152719799634,
+          53.869297230960896,
+          63.665202759502115,
+          33.494518088513736,
+          65.78208340665883,
+          17.786468185560267,
+          65.43137833230301,
+          65.240413193363,
+          53.865783700264245,
+          70.45059062110445,
+          0,
+          91.66065099257654,
+          82.03625481912434,
+          63.466116067766706,
+          0,
+          71.1073251189025,
+          67.77821808824021,
+          57.77212505758644,
+          63.55965953250018,
+          69.71177222359847,
+          63.477771090594715,
+          0,
+          60.438303754662904,
+          83.91407839250431,
+          0,
+          80.97252982947624,
+          93.57588780268176,
+          36.47393570395692,
+          60.40630488347749,
+          69.662705729165,
+          62.93792744552835,
+          50.60634795908516,
+          49.38062633109021,
+          63.41889125023328,
+          92.92012989574445,
+          58.181471853146505,
+          76.97365950808033,
+          68.1337567073272,
+          61.41857291588124,
+          67.17757283867823,
+          73.4740866611304,
+          69.16482848763725,
+          71.13647638164773,
+          64.7462962244302,
+          80.97174694294473,
+          22.50049208791447,
+          65.23986869772243,
+          65.98090506112646,
+          71.1148749819655,
+          76.86060899667532
+         ],
+         "xaxis": "x2",
+         "yaxis": "y2"
+        }
+       ],
+       "layout": {
+        "annotations": [
+         {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial",
+           "size": 14
+          },
+          "showarrow": false,
+          "text": "Number of features required<br>to explain 90% of the model's output",
+          "x": 0.2,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1,
+          "yanchor": "bottom",
+          "yref": "paper"
+         },
+         {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial",
+           "size": 14
+          },
+          "showarrow": false,
+          "text": "Percentage of the model output<br>explained by the 5 most important<br>features per instance",
+          "x": 0.8,
+          "xanchor": "center",
+          "xref": "paper",
+          "y": 1,
+          "yanchor": "bottom",
+          "yref": "paper"
+         }
+        ],
+        "hovermode": "closest",
+        "margin": {
+         "t": 150
+        },
+        "showlegend": false,
+        "template": {
+         "data": {
+          "scatter": [
+           {
+            "type": "scatter"
+           }
+          ]
+         }
+        },
+        "title": {
+         "font": {
+          "color": "rgb(50, 50, 50)",
+          "family": "Arial",
+          "size": 24
+         },
+         "pad": {
+          "b": 50
+         },
+         "text": "Compacity of explanations:<span style='font-size: 16px;'><br />How many variables are enough to produce accurate explanations?</span>",
+         "x": 0.5,
+         "xanchor": "center",
+         "y": 0.8,
+         "yanchor": "bottom"
+        },
+        "xaxis": {
+         "anchor": "y",
+         "domain": [
+          0,
+          0.4
+         ],
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Number of selected features"
+         }
+        },
+        "xaxis2": {
+         "anchor": "y2",
+         "domain": [
+          0.6000000000000001,
+          1
+         ],
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Percentage of model output<br>explained (%)"
+         }
+        },
+        "yaxis": {
+         "anchor": "x",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Cumulative distribution over<br>dataset's instances (%)"
+         }
+        },
+        "yaxis2": {
+         "anchor": "x2",
+         "domain": [
+          0,
+          1
+         ],
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Cumulative distribution over<br>dataset's instances (%)"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# xpl.plot.compacity_plot(selection=index, approx=.85, nb_features=3)\n",
+    "xpl.plot.compacity_plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "hovertemplate": "%{hovertext}<extra></extra>",
+         "hovertext": [
+          "<b>Feature: %dl_volume</b><br />Importance: 0.00939909131358997<br />Variability: 0.18130880538724892",
+          "<b>Feature: %tcp_protocol</b><br />Importance: 0.2416063292346793<br />Variability: 0.11994505953468278",
+          "<b>Feature: %udp_protocol</b><br />Importance: 0.015069838357398127<br />Variability: 0.13208490159573183",
+          "<b>Feature: %ul_volume</b><br />Importance: 0.013847884539231725<br />Variability: 0.592637691913",
+          "<b>Feature: avg_dl_volume</b><br />Importance: 0.0487503786254441<br />Variability: 0.3411225371157414",
+          "<b>Feature: avg_ul_volume</b><br />Importance: 0.25915679392380764<br />Variability: 0.1290606829873321",
+          "<b>Feature: dl_data_volume</b><br />Importance: 0.00798426860018547<br />Variability: 0.4305604521252976",
+          "<b>Feature: dl_packet</b><br />Importance: 0.005896776118200444<br />Variability: 0.4498148175191367",
+          "<b>Feature: kB/s</b><br />Importance: 0.002895188542019483<br />Variability: 0.8418494343046908",
+          "<b>Feature: max_dl_volume</b><br />Importance: 0.03070800505657479<br />Variability: 0.18032380819945812",
+          "<b>Feature: max_ul_volume</b><br />Importance: 0.007986023168982514<br />Variability: 0.25878505846270905",
+          "<b>Feature: min_dl_volume</b><br />Importance: 0.012422102579702625<br />Variability: 0.35819572494251234",
+          "<b>Feature: min_ul_volume</b><br />Importance: 0.002129233744137999<br />Variability: 0.379982599394447",
+          "<b>Feature: nb_downlink_packet</b><br />Importance: 0.0028796048028591056<br />Variability: 0.5885282827913803",
+          "<b>Feature: nb_packet/s</b><br />Importance: 1.5982949349188883e-06<br />Variability: 0.8971636104893811",
+          "<b>Feature: nb_uplink_packet</b><br />Importance: 0.0038726000331021195<br />Variability: 0.808168181942712",
+          "<b>Feature: session_time</b><br />Importance: 0.0228451070216818<br />Variability: 0.876803985639012",
+          "<b>Feature: std_dl_volume</b><br />Importance: 0.29460936669922133<br />Variability: 0.11524083078579556",
+          "<b>Feature: std_ul_volume</b><br />Importance: 0.01359125075446915<br />Variability: 0.5203561085347085",
+          "<b>Feature: ul_data_volume</b><br />Importance: 0.0012414130723385464<br />Variability: 0.7396812302866231",
+          "<b>Feature: ul_packet</b><br />Importance: 0.003107145517439257<br />Variability: 0.4525451365946841"
+         ],
+         "marker": {
+          "color": [
+           0.00939909131358997,
+           0.2416063292346793,
+           0.015069838357398127,
+           0.013847884539231725,
+           0.0487503786254441,
+           0.25915679392380764,
+           0.00798426860018547,
+           0.005896776118200444,
+           0.002895188542019483,
+           0.03070800505657479,
+           0.007986023168982514,
+           0.012422102579702625,
+           0.002129233744137999,
+           0.0028796048028591056,
+           0.0000015982949349188883,
+           0.0038726000331021195,
+           0.0228451070216818,
+           0.29460936669922133,
+           0.01359125075446915,
+           0.0012414130723385464,
+           0.003107145517439257
+          ],
+          "colorscale": [
+           [
+            0,
+            "rgb(52, 55, 54)"
+           ],
+           [
+            0.007221925819292564,
+            "rgb(74, 99, 138)"
+           ],
+           [
+            0.00982183960306752,
+            "rgb(116, 153, 214)"
+           ],
+           [
+            0.013139510064972479,
+            "rgb(162, 188, 213)"
+           ],
+           [
+            0.027095926045969148,
+            "rgb(212, 234, 242)"
+           ],
+           [
+            0.03189832050103646,
+            "rgb(235, 216, 134)"
+           ],
+           [
+            0.04612795016622008,
+            "rgb(255, 204, 83)"
+           ],
+           [
+            0.051146784567422734,
+            "rgb(244, 192, 0)"
+           ],
+           [
+            0.10422809597981092,
+            "rgb(255, 166, 17)"
+           ],
+           [
+            0.8200894777770874,
+            "rgb(255, 123, 38)"
+           ],
+           [
+            1,
+            "rgb(255, 77, 7)"
+           ]
+          ],
+          "line": {
+           "color": "white",
+           "width": 0.8
+          },
+          "opacity": 0.8,
+          "size": 10
+         },
+         "mode": "markers",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          0.18130880538724892,
+          0.11994505953468278,
+          0.13208490159573183,
+          0.592637691913,
+          0.3411225371157414,
+          0.1290606829873321,
+          0.4305604521252976,
+          0.4498148175191367,
+          0.8418494343046908,
+          0.18032380819945812,
+          0.25878505846270905,
+          0.35819572494251234,
+          0.379982599394447,
+          0.5885282827913803,
+          0.8971636104893811,
+          0.808168181942712,
+          0.876803985639012,
+          0.11524083078579556,
+          0.5203561085347085,
+          0.7396812302866231,
+          0.4525451365946841
+         ],
+         "y": [
+          0.00939909131358997,
+          0.2416063292346793,
+          0.015069838357398127,
+          0.013847884539231725,
+          0.0487503786254441,
+          0.25915679392380764,
+          0.00798426860018547,
+          0.005896776118200444,
+          0.002895188542019483,
+          0.03070800505657479,
+          0.007986023168982514,
+          0.012422102579702625,
+          0.002129233744137999,
+          0.0028796048028591056,
+          0.0000015982949349188883,
+          0.0038726000331021195,
+          0.0228451070216818,
+          0.29460936669922133,
+          0.01359125075446915,
+          0.0012414130723385464,
+          0.003107145517439257
+         ]
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "rgba(117, 152, 189, 0.9)",
+          "dash": "dot"
+         },
+         "mode": "lines",
+         "name": "<-- Stable",
+         "type": "scatter",
+         "x": [
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15
+         ],
+         "y": [
+          0,
+          0.29460936669922133
+         ]
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "rgba(255, 166, 17, 0.9)",
+          "dash": "dot"
+         },
+         "mode": "lines",
+         "name": "--> Unstable",
+         "type": "scatter",
+         "x": [
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3
+         ],
+         "y": [
+          0,
+          0.29460936669922133
+         ]
+        }
+       ],
+       "layout": {
+        "coloraxis": {
+         "showscale": false
+        },
+        "hovermode": "closest",
+        "template": {
+         "data": {
+          "scatter": [
+           {
+            "type": "scatter"
+           }
+          ]
+         }
+        },
+        "title": {
+         "font": {
+          "color": "rgb(50, 50, 50)",
+          "family": "Arial",
+          "size": 24
+         },
+         "pad": {
+          "b": 50
+         },
+         "text": "Importance & Local Stability of explanations:<span style='font-size: 16px;'><br />How similar are explanations for closeby neighbours?</span>",
+         "x": 0.5,
+         "xanchor": "center",
+         "yanchor": "bottom"
+        },
+        "xaxis": {
+         "automargin": true,
+         "range": [
+          0.08524083078579556,
+          0.9271636104893811
+         ],
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Variability of the Normalized Local Contribution Values<span style='font-size: 12px;'><br />(standard deviation / mean)</span>"
+         }
+        },
+        "yaxis": {
+         "automargin": true,
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Importance<span style='font-size: 12px;'><br />(Average contributions)</span>"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "xpl.plot.stability_plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": "rgb(162, 188, 213)"
+         },
+         "name": "max_dl_volume",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.17441364316468896,
+          0.20883275291386352
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgb(162, 188, 213)"
+         },
+         "name": "avg_dl_volume",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          1.0403743626946835,
+          0.9644832226270998
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgb(244, 192, 0)"
+         },
+         "name": "%tcp_protocol",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.2089954426026338,
+          0.21274588921559878
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgb(255, 166, 17)"
+         },
+         "name": "avg_ul_volume",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.15039078060464664,
+          0.15148596975174633
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgb(255, 77, 7)"
+         },
+         "name": "std_dl_volume",
+         "showlegend": false,
+         "type": "box",
+         "x": [
+          0.8664344361591372,
+          0.8656465553919838
+         ]
+        },
+        {
+         "hoverinfo": "none",
+         "marker": {
+          "color": [
+           0.031754916829833696,
+           0.3095559362732442
+          ],
+          "colorbar": {
+           "len": 300,
+           "lenmode": "pixels",
+           "thickness": 20,
+           "title": {
+            "text": "Importance<br />(Average contributions)"
+           },
+           "y": 1,
+           "yanchor": "top",
+           "ypad": 60
+          },
+          "colorscale": [
+           [
+            0,
+            "rgb(52, 55, 54)"
+           ],
+           [
+            0.026249689618813403,
+            "rgb(74, 99, 138)"
+           ],
+           [
+            0.052499379237626806,
+            "rgb(116, 153, 214)"
+           ],
+           [
+            0.21122546039129592,
+            "rgb(162, 188, 213)"
+           ],
+           [
+            0.5024279330798204,
+            "rgb(212, 234, 242)"
+           ],
+           [
+            0.7936304057683449,
+            "rgb(235, 216, 134)"
+           ],
+           [
+            0.8115358961075013,
+            "rgb(255, 204, 83)"
+           ],
+           [
+            0.829441386446658,
+            "rgb(244, 192, 0)"
+           ],
+           [
+            0.870715305292989,
+            "rgb(255, 166, 17)"
+           ],
+           [
+            0.9353576526464944,
+            "rgb(255, 123, 38)"
+           ],
+           [
+            1,
+            "rgb(255, 77, 7)"
+           ]
+          ],
+          "showscale": true,
+          "size": 1
+         },
+         "mode": "markers",
+         "showlegend": false,
+         "type": "scatter",
+         "x": [
+          null
+         ],
+         "y": [
+          null
+         ]
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "rgba(117, 152, 189, 0.9)",
+          "dash": "dot"
+         },
+         "mode": "lines",
+         "name": "<-- Stable",
+         "type": "scatter",
+         "x": [
+          0.15,
+          0.15,
+          0.15,
+          0.15,
+          0.15
+         ],
+         "y": [
+          "%tcp_protocol",
+          "avg_dl_volume",
+          "avg_ul_volume",
+          "max_dl_volume",
+          "std_dl_volume"
+         ]
+        },
+        {
+         "hoverinfo": "none",
+         "line": {
+          "color": "rgba(255, 166, 17, 0.9)",
+          "dash": "dot"
+         },
+         "mode": "lines",
+         "name": "--> Unstable",
+         "type": "scatter",
+         "x": [
+          0.3,
+          0.3,
+          0.3,
+          0.3,
+          0.3
+         ],
+         "y": [
+          "%tcp_protocol",
+          "avg_dl_volume",
+          "avg_ul_volume",
+          "max_dl_volume",
+          "std_dl_volume"
+         ]
+        }
+       ],
+       "layout": {
+        "coloraxis": {
+         "showscale": false
+        },
+        "height": 500,
+        "hovermode": "closest",
+        "template": {
+         "data": {
+          "scatter": [
+           {
+            "type": "scatter"
+           }
+          ]
+         }
+        },
+        "title": {
+         "font": {
+          "color": "rgb(50, 50, 50)",
+          "family": "Arial",
+          "size": 24
+         },
+         "pad": {
+          "b": 50
+         },
+         "text": "Importance & Local Stability of explanations:<span style='font-size: 16px;'><br />How similar are explanations for closeby neighbours?</span>",
+         "x": 0.5,
+         "xanchor": "center",
+         "yanchor": "bottom"
+        },
+        "xaxis": {
+         "automargin": true,
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Normalized local contribution value variability"
+         }
+        },
+        "yaxis": {
+         "automargin": true,
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": ""
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "xpl.plot.stability_plot(selection=[1,24], max_features=5, distribution=\"boxplot\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "10th closest neighbor",
+         "opacity": 0.2,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.010723086959941501,
+          0.011020933697665988,
+          -0.011202014386934392,
+          0.012348811149018373,
+          -0.012360250144135639,
+          0.016900610715829417,
+          -0.14877337079067582,
+          -0.18476279424924613,
+          -0.20606932289485505,
+          -0.34717968307464353
+         ],
+         "y": [
+          "nb_uplink_packet",
+          "std_ul_volume",
+          "avg_dl_volume",
+          "dl_data_volume",
+          "%udp_protocol",
+          "ul_data_volume",
+          "max_dl_volume",
+          "std_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "9th closest neighbor",
+         "opacity": 0.28,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.010646857635415957,
+          0.011257419776704858,
+          -0.011411521454403956,
+          0.012550121465513387,
+          -0.012608529212982746,
+          -0.022091604076723916,
+          -0.1517492711186961,
+          -0.20066210847781246,
+          -0.2068672158861165,
+          -0.3181285963040638
+         ],
+         "y": [
+          "nb_uplink_packet",
+          "std_ul_volume",
+          "avg_dl_volume",
+          "dl_data_volume",
+          "%udp_protocol",
+          "ul_data_volume",
+          "max_dl_volume",
+          "std_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "8th closest neighbor",
+         "opacity": 0.36,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.010638676449844595,
+          0.011850145243403106,
+          -0.011354691206077216,
+          0.023201684896583506,
+          -0.012599178263967068,
+          -0.022125025985997488,
+          -0.15086579902679695,
+          -0.1863071368111012,
+          -0.2068410328377909,
+          -0.31561230960628717
+         ],
+         "y": [
+          "nb_uplink_packet",
+          "std_ul_volume",
+          "avg_dl_volume",
+          "dl_data_volume",
+          "%udp_protocol",
+          "ul_data_volume",
+          "max_dl_volume",
+          "std_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "7th closest neighbor",
+         "opacity": 0.44000000000000006,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.010604094653740438,
+          0.010882696910785866,
+          -0.011115332290086169,
+          0.01218118995782999,
+          -0.01221895060285485,
+          0.01670349764788323,
+          -0.1538699789183949,
+          -0.18269113277347196,
+          -0.20426651992536787,
+          -0.3470500797247711
+         ],
+         "y": [
+          "nb_uplink_packet",
+          "std_ul_volume",
+          "avg_dl_volume",
+          "dl_data_volume",
+          "%udp_protocol",
+          "ul_data_volume",
+          "max_dl_volume",
+          "std_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "6th closest neighbor",
+         "opacity": 0.52,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.010882399162880616,
+          0.011146040411345662,
+          0.04565378058552233,
+          0.02337487941541908,
+          -0.012547773329423828,
+          0.01711705532446811,
+          -0.0969931111714162,
+          -0.1875994091073574,
+          -0.19644994290010628,
+          -0.3522995343103441
+         ],
+         "y": [
+          "nb_uplink_packet",
+          "std_ul_volume",
+          "avg_dl_volume",
+          "dl_data_volume",
+          "%udp_protocol",
+          "ul_data_volume",
+          "max_dl_volume",
+          "std_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "5th closest neighbor",
+         "opacity": 0.6000000000000001,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.011013695447399283,
+          0.0112642321123729,
+          -0.013299396825033,
+          0.02325674284150803,
+          -0.0127169689570896,
+          0.017351376129168514,
+          -0.10617443044214128,
+          -0.19618770180821313,
+          -0.2057435361990232,
+          -0.361631389828561
+         ],
+         "y": [
+          "nb_uplink_packet",
+          "std_ul_volume",
+          "avg_dl_volume",
+          "dl_data_volume",
+          "%udp_protocol",
+          "ul_data_volume",
+          "max_dl_volume",
+          "std_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "4th closest neighbor",
+         "opacity": 0.6800000000000002,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.010421825536102543,
+          0.011075130851435666,
+          -0.01112758715542006,
+          0.012661092574966445,
+          -0.012352447200617275,
+          0.01682704380585348,
+          -0.14788281551822596,
+          -0.18437862529713797,
+          -0.20274212828894123,
+          -0.34981875901961174
+         ],
+         "y": [
+          "nb_uplink_packet",
+          "std_ul_volume",
+          "avg_dl_volume",
+          "dl_data_volume",
+          "%udp_protocol",
+          "ul_data_volume",
+          "max_dl_volume",
+          "std_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "3rd closest neighbor",
+         "opacity": 0.76,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.010539584674011318,
+          0.010823199432807821,
+          0.035003102813632656,
+          0.012134919801849189,
+          -0.012150432193449875,
+          0.01660752165008995,
+          -0.14615633147661586,
+          -0.18160134937432162,
+          -0.19523891570079643,
+          -0.3413431953653148
+         ],
+         "y": [
+          "nb_uplink_packet",
+          "std_ul_volume",
+          "avg_dl_volume",
+          "dl_data_volume",
+          "%udp_protocol",
+          "ul_data_volume",
+          "max_dl_volume",
+          "std_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "2nd closest neighbor",
+         "opacity": 0.8400000000000001,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.010571773461876788,
+          0.011245047980411175,
+          -0.010899442134408669,
+          0.009120889612060533,
+          -0.01299835084323083,
+          0.01660247546165081,
+          -0.1425968956899397,
+          -0.18154493511921868,
+          -0.1973300701140701,
+          -0.34372043013369313
+         ],
+         "y": [
+          "nb_uplink_packet",
+          "std_ul_volume",
+          "avg_dl_volume",
+          "dl_data_volume",
+          "%udp_protocol",
+          "ul_data_volume",
+          "max_dl_volume",
+          "std_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(117, 152, 189, 0.9)"
+         },
+         "name": "closest neighbor",
+         "opacity": 0.9199999999999999,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.010431456699663763,
+          0.011066396854162523,
+          -0.011140215512475028,
+          0.012230322405717618,
+          -0.012360365941513064,
+          0.016840943591382242,
+          -0.1480139247942664,
+          -0.1845722351723029,
+          -0.20291585399275366,
+          -0.3502940177590902
+         ],
+         "y": [
+          "nb_uplink_packet",
+          "std_ul_volume",
+          "avg_dl_volume",
+          "dl_data_volume",
+          "%udp_protocol",
+          "ul_data_volume",
+          "max_dl_volume",
+          "std_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol"
+         ]
+        },
+        {
+         "marker": {
+          "color": "rgba(255, 166, 17, 0.9)"
+         },
+         "name": "instance",
+         "opacity": 1,
+         "orientation": "h",
+         "type": "bar",
+         "x": [
+          -0.010698371564443566,
+          0.010966042465820069,
+          -0.011101429856649468,
+          0.012306541056278224,
+          -0.012319976495559406,
+          0.016837915045828836,
+          -0.1475003297952727,
+          -0.1841933341979573,
+          -0.2057139447683082,
+          -0.3498124537412848
+         ],
+         "y": [
+          "nb_uplink_packet",
+          "std_ul_volume",
+          "avg_dl_volume",
+          "dl_data_volume",
+          "%udp_protocol",
+          "ul_data_volume",
+          "max_dl_volume",
+          "std_dl_volume",
+          "avg_ul_volume",
+          "%tcp_protocol"
+         ]
+        }
+       ],
+       "layout": {
+        "barmode": "group",
+        "height": 1210,
+        "hovermode": "closest",
+        "legend": {
+         "traceorder": "reversed"
+        },
+        "template": {
+         "data": {
+          "scatter": [
+           {
+            "type": "scatter"
+           }
+          ]
+         }
+        },
+        "title": {
+         "font": {
+          "color": "rgb(50, 50, 50)",
+          "family": "Arial",
+          "size": 24
+         },
+         "pad": {
+          "b": 50
+         },
+         "text": "Comparing local explanations in a neighborhood - Id: <b>5</b><span style='font-size: 16px;'><br />How similar are explanations for closeby neighbours?</span>",
+         "x": 0.5,
+         "xanchor": "center",
+         "yanchor": "bottom"
+        },
+        "xaxis": {
+         "automargin": true,
+         "side": "bottom",
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": "Normalized contribution values"
+         }
+        },
+        "yaxis": {
+         "automargin": true,
+         "title": {
+          "font": {
+           "color": "rgb(50, 50, 50)",
+           "family": "Arial Black",
+           "size": 16
+          },
+          "text": ""
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "xpl.plot.local_neighbors_plot(index=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import shap\n",
+    "\n",
+    "# treeSHAP = shap.TreeExplainer(clf).shap_values(X_train, check_additivity=False)[1]\n",
+    "# samplingSHAP = shap.SamplingExplainer(clf.predict_proba, shap.kmeans(X_train, 200)).shap_values(X_train, check_additivity=False)[1]\n",
+    "# kernelSHAP = shap.KernelExplainer(clf.predict_proba, shap.kmeans(X_train, 200)).shap_values(X_train, check_additivity=False)[1]\n",
+    "\n",
+    "# treeSHAP = pd.DataFrame(treeSHAP, columns=X_train.columns)\n",
+    "# samplingSHAP = pd.DataFrame(samplingSHAP, columns=X_train.columns)\n",
+    "# kernelSHAP = pd.DataFrame(kernelSHAP, columns=X_train.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xpl.generate_report(\n",
+    "    output_file='report.html',\n",
+    "    project_info_file='shapash_project_info.yml',\n",
+    "    x_train=X_train,\n",
+    "    y_train=y_train_orig,\n",
+    "    y_test=y_test_orig,\n",
+    "    title_story=\"User Network Activities Classification\",\n",
+    "    title_description=\"This document is a data science report of the user network activities classification.\",\n",
+    "    metrics=[\n",
+    "        {\n",
+    "            'path': 'sklearn.metrics.mean_squared_error',\n",
+    "            'name': 'Mean squared error',  # Optional : name that will be displayed next to the metric\n",
+    "        },\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mi_xai",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
In this update we separately create notebooks to implement accountability metrics and resilience metrics. Accountability metrics are implemented with shapash for XGB and LGB models. Resilience metrics are developed in a separate notebook for Neural networks, XGB and LGB models. Explanations for attack and benign dataset are also compared here as well. 